### PR TITLE
Implement MarsupilamiFourteen.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ as specified in [1,4,5]:
   * TupleHash128 and TupleHash256
 * Parallel Hashes:
   * KangarooTwelve
+  * MarsupilamiFourteen (256-bit security variant of KangarooTwelve)
   * ParallelHash128 and ParallelHash256
 
 Note that the difference between a hash function an a XOF function is that a

--- a/src/common/keccak-generic_kangarootwelve.ads
+++ b/src/common/keccak-generic_kangarootwelve.ads
@@ -47,6 +47,11 @@ with Keccak.Types;
 --  @group KangarooTwelve
 generic
 
+   CV_Size_Bytes : Positive;
+   --  The size of each chaining value (CV) in bytes.
+   --  This is set to 256 bits (32 bytes) for KangarooTwelve
+   --  and 512 bits (64 bytes) for MarsupilamiFourteen.
+
    with package XOF_Serial is new Keccak.Generic_XOF (<>);
    --  This XOF must be configured with NO SUFFIX BITS.
    --  The Generic_KangarooTwelve implementation takes care of the appropriate
@@ -169,10 +174,6 @@ is
    --  to KangarooTwelve. This decreases as input bytes are processed.
 
 private
-
-   CV_Size_Bytes    : constant := 256 / 8;
-   --  The size of each chaining value (CV) in bytes.
-   --  This is set to 256 bits (32 bytes) in the documentation.
 
    use type XOF_Serial.States;
 

--- a/src/common/keccak-keccak_1600-rounds_14.ads
+++ b/src/common/keccak-keccak_1600-rounds_14.ads
@@ -1,0 +1,62 @@
+-------------------------------------------------------------------------------
+--  Copyright (c) 2019, Daniel King
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--      * Redistributions of source code must retain the above copyright
+--        notice, this list of conditions and the following disclaimer.
+--      * Redistributions in binary form must reproduce the above copyright
+--        notice, this list of conditions and the following disclaimer in the
+--        documentation and/or other materials provided with the distribution.
+--      * The name of the copyright holder may not be used to endorse or promote
+--        Products derived from this software without specific prior written
+--        permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+--  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+--  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+--  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+--  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+--  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+--  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+with Keccak.Generic_Duplex;
+with Keccak.Generic_Sponge;
+
+pragma Elaborate_All (Keccak.Generic_Duplex);
+pragma Elaborate_All (Keccak.Generic_Sponge);
+
+--  @summary
+--  Instantiation of Keccak-p[1600,14], with a Sponge and Duplex built on top of it.
+package Keccak.Keccak_1600.Rounds_14
+with SPARK_Mode => On
+is
+
+   procedure Permute is new KeccakF_1600_Permutation.Permute
+     (First_Round => 10,
+      Num_Rounds  => 14);
+
+   package Sponge is new Keccak.Generic_Sponge
+     (State_Size          => KeccakF_1600.B,
+      State_Type          => KeccakF_1600.Lane_Complemented_State,
+      Init_State          => KeccakF_1600.Init,
+      F                   => Permute,
+      XOR_Bits_Into_State => KeccakF_1600_Lanes.XOR_Bits_Into_State,
+      Extract_Data        => KeccakF_1600_Lanes.Extract_Bytes,
+      Pad                 => Keccak.Padding.Pad101_Multi_Blocks);
+
+   package Duplex is new Keccak.Generic_Duplex
+     (State_Size          => KeccakF_1600.B,
+      State_Type          => KeccakF_1600.Lane_Complemented_State,
+      Init_State          => KeccakF_1600.Init,
+      F                   => Permute,
+      XOR_Bits_Into_State => KeccakF_1600_Lanes.XOR_Bits_Into_State,
+      Extract_Bits        => KeccakF_1600_Lanes.Extract_Bits,
+      Pad                 => Keccak.Padding.Pad101_Single_Block,
+      Min_Padding_Bits    => Keccak.Padding.Pad101_Min_Bits);
+
+end Keccak.Keccak_1600.Rounds_14;

--- a/src/common/marsupilamifourteen.ads
+++ b/src/common/marsupilamifourteen.ads
@@ -24,9 +24,9 @@
 --  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 --  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------------------------------------------------------------------------
-with Keccak.Keccak_1600.Rounds_12;
+with Keccak.Keccak_1600.Rounds_14;
 with Keccak.Generic_KangarooTwelve;
-with Keccak.Parallel_Keccak_1600.Rounds_12;
+with Keccak.Parallel_Keccak_1600.Rounds_14;
 with Keccak.Generic_Parallel_Sponge;
 with Keccak.Generic_Parallel_XOF;
 with Keccak.Generic_Sponge;
@@ -35,10 +35,19 @@ with Keccak.Padding;
 with Interfaces;
 
 --  @summary
---  Defines the KangarooTwelve instance.
+--  Defines the MarsupilamiFourteen instance.
 --
---  @group KangarooTwelve
-package KangarooTwelve
+--  @description
+--  MarsupilamiFourteen is a variant of KangarooTwelve which provides 256-bit
+--  security (compared to 128-bit for KangarooTwelve). MarsupilamiFourteen is
+--  identical to KangarooTwelve except for the following differences:
+--
+--  * MarsupilamiFourteen uses a 512-bit capacity (256-bit for KangarooTwelve)
+--  * MarsupilamiFourteen uses a 14-round Keccak permutation (14 rounds for KangarooTwelve)
+--  * MarsupilamiFourteen uses a 512-bit chaining value (256-bit for KangarooTwelve)
+--
+--  @group MarsupilamiFourteen
+package MarsupilamiFourteen
 with SPARK_Mode => On
 is
 
@@ -48,41 +57,41 @@ is
    --  @private
    package Implementation is
 
-      K12_Capacity : constant := 256;
-      --  Capacity in bits (security parameter) for KangarooTwelve.
+      K12_Capacity : constant := 512;
+      --  Capacity in bits (security parameter) for MarsupilamiFourteen.
 
       --  Now we can build a XOF on each parallel sponge
       package XOF_S1 is new Keccak.Generic_XOF
-      (XOF_Sponge  => Keccak.Keccak_1600.Rounds_12.Sponge,
+      (XOF_Sponge  => Keccak.Keccak_1600.Rounds_14.Sponge,
          Capacity    => K12_Capacity,
          Suffix      => 0, --  Add no suffix here, since suffix is dynamic (01 or 11)
          Suffix_Size => 0);
 
       package XOF_P2 is new Keccak.Generic_Parallel_XOF
-      (Sponge      => Keccak.Parallel_Keccak_1600.Rounds_12.Parallel_Sponge_P2,
+      (Sponge      => Keccak.Parallel_Keccak_1600.Rounds_14.Parallel_Sponge_P2,
          Capacity    => K12_Capacity,
          Suffix      => 2#011#,
          Suffix_Size => 3);
 
       package XOF_P4 is new Keccak.Generic_Parallel_XOF
-      (Sponge      => Keccak.Parallel_Keccak_1600.Rounds_12.Parallel_Sponge_P4,
+      (Sponge      => Keccak.Parallel_Keccak_1600.Rounds_14.Parallel_Sponge_P4,
          Capacity    => K12_Capacity,
          Suffix      => 2#011#,
          Suffix_Size => 3);
 
       package XOF_P8 is new Keccak.Generic_Parallel_XOF
-      (Sponge      => Keccak.Parallel_Keccak_1600.Rounds_12.Parallel_Sponge_P8,
+      (Sponge      => Keccak.Parallel_Keccak_1600.Rounds_14.Parallel_Sponge_P8,
          Capacity    => K12_Capacity,
          Suffix      => 2#011#,
          Suffix_Size => 3);
 
    end Implementation;
 
-   package K12 is new Keccak.Generic_KangarooTwelve
-     (CV_Size_Bytes  => 256 / 8,
+   package M14 is new Keccak.Generic_KangarooTwelve
+     (CV_Size_Bytes  => 512 / 8,
       XOF_Serial     => Implementation.XOF_S1,
       XOF_Parallel_2 => Implementation.XOF_P2,
       XOF_Parallel_4 => Implementation.XOF_P4,
       XOF_Parallel_8 => Implementation.XOF_P8);
 
-end KangarooTwelve;
+end MarsupilamiFourteen;

--- a/src/generic/keccak-parallel_keccak_1600-rounds_14.ads
+++ b/src/generic/keccak-parallel_keccak_1600-rounds_14.ads
@@ -1,0 +1,82 @@
+-------------------------------------------------------------------------------
+--  Copyright (c) 2019, Daniel King
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--      * Redistributions of source code must retain the above copyright
+--        notice, this list of conditions and the following disclaimer.
+--      * Redistributions in binary form must reproduce the above copyright
+--        notice, this list of conditions and the following disclaimer in the
+--        documentation and/or other materials provided with the distribution.
+--      * The name of the copyright holder may not be used to endorse or promote
+--        Products derived from this software without specific prior written
+--        permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+--  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+--  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+--  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+--  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+--  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+--  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+with Keccak.Keccak_1600.Rounds_14;
+with Keccak.Generic_Parallel_Sponge;
+with Keccak.Padding;
+
+pragma Elaborate_All (Keccak.Generic_Parallel_Sponge);
+
+package Keccak.Parallel_Keccak_1600.Rounds_14
+with SPARK_Mode => On
+is
+
+   procedure Permute_All_P2 is new KeccakF_1600_P2.Permute_All
+     (Keccak.Keccak_1600.Rounds_14.Permute);
+
+   procedure Permute_All_P4 is new KeccakF_1600_P4.Permute_All
+     (Keccak.Keccak_1600.Rounds_14.Permute);
+
+   procedure Permute_All_P8 is new KeccakF_1600_P8.Permute_All
+     (Keccak.Keccak_1600.Rounds_14.Permute);
+
+   package Parallel_Sponge_P2 is new Keccak.Generic_Parallel_Sponge
+     (State_Size                   => 1600,
+      State_Type                   => KeccakF_1600_P2.Parallel_State,
+      Parallelism                  => 2,
+      Init                         => KeccakF_1600_P2.Init,
+      Permute_All                  => Permute_All_P2,
+      XOR_Bits_Into_State_Separate => KeccakF_1600_P2.XOR_Bits_Into_State_Separate,
+      XOR_Bits_Into_State_All      => KeccakF_1600_P2.XOR_Bits_Into_State_All,
+      Extract_Bytes                => KeccakF_1600_P2.Extract_Bytes,
+      Pad                          => Keccak.Padding.Pad101_Single_Block,
+      Min_Padding_Bits             => Keccak.Padding.Pad101_Min_Bits);
+
+   package Parallel_Sponge_P4 is new Keccak.Generic_Parallel_Sponge
+     (State_Size                   => 1600,
+      State_Type                   => KeccakF_1600_P4.Parallel_State,
+      Parallelism                  => 4,
+      Init                         => KeccakF_1600_P4.Init,
+      Permute_All                  => Permute_All_P4,
+      XOR_Bits_Into_State_Separate => KeccakF_1600_P4.XOR_Bits_Into_State_Separate,
+      XOR_Bits_Into_State_All      => KeccakF_1600_P4.XOR_Bits_Into_State_All,
+      Extract_Bytes                => KeccakF_1600_P4.Extract_Bytes,
+      Pad                          => Keccak.Padding.Pad101_Single_Block,
+      Min_Padding_Bits             => Keccak.Padding.Pad101_Min_Bits);
+
+   package Parallel_Sponge_P8 is new Keccak.Generic_Parallel_Sponge
+     (State_Size                   => 1600,
+      State_Type                   => KeccakF_1600_P8.Parallel_State,
+      Parallelism                  => 8,
+      Init                         => KeccakF_1600_P8.Init,
+      Permute_All                  => Permute_All_P8,
+      XOR_Bits_Into_State_Separate => KeccakF_1600_P8.XOR_Bits_Into_State_Separate,
+      XOR_Bits_Into_State_All      => KeccakF_1600_P8.XOR_Bits_Into_State_All,
+      Extract_Bytes                => KeccakF_1600_P8.Extract_Bytes,
+      Pad                          => Keccak.Padding.Pad101_Single_Block,
+      Min_Padding_Bits             => Keccak.Padding.Pad101_Min_Bits);
+
+end Keccak.Parallel_Keccak_1600.Rounds_14;

--- a/src/x86_64/AVX2/keccak-parallel_keccak_1600-rounds_14.ads
+++ b/src/x86_64/AVX2/keccak-parallel_keccak_1600-rounds_14.ads
@@ -1,0 +1,84 @@
+-------------------------------------------------------------------------------
+--  Copyright (c) 2019, Daniel King
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--      * Redistributions of source code must retain the above copyright
+--        notice, this list of conditions and the following disclaimer.
+--      * Redistributions in binary form must reproduce the above copyright
+--        notice, this list of conditions and the following disclaimer in the
+--        documentation and/or other materials provided with the distribution.
+--      * The name of the copyright holder may not be used to endorse or promote
+--        Products derived from this software without specific prior written
+--        permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+--  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+--  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+--  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+--  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+--  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+--  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+with Keccak.Keccak_1600.Rounds_14;
+with Keccak.Generic_Parallel_Sponge;
+with Keccak.Padding;
+
+pragma Elaborate_All (Keccak.Generic_Parallel_Sponge);
+
+package Keccak.Parallel_Keccak_1600.Rounds_14
+with SPARK_Mode => On
+is
+
+   procedure Permute_All_P2 is new KeccakF_1600_P2.Permute_All
+     (First_Round => 10,
+      Num_Rounds  => 14);
+
+   procedure Permute_All_P4 is new KeccakF_1600_P4.Permute_All
+     (First_Round => 10,
+      Num_Rounds  => 14);
+
+   procedure Permute_All_P8 is new KeccakF_1600_P8.Permute_All
+     (Permute_All_P4);
+
+   package Parallel_Sponge_P2 is new Keccak.Generic_Parallel_Sponge
+     (State_Size                   => 1600,
+      State_Type                   => KeccakF_1600_P2.Parallel_State,
+      Parallelism                  => 2,
+      Init                         => KeccakF_1600_P2.Init,
+      Permute_All                  => Permute_All_P2,
+      XOR_Bits_Into_State_Separate => KeccakF_1600_P2.XOR_Bits_Into_State_Separate,
+      XOR_Bits_Into_State_All      => KeccakF_1600_P2.XOR_Bits_Into_State_All,
+      Extract_Bytes                => KeccakF_1600_P2.Extract_Bytes,
+      Pad                          => Keccak.Padding.Pad101_Single_Block,
+      Min_Padding_Bits             => Keccak.Padding.Pad101_Min_Bits);
+
+   package Parallel_Sponge_P4 is new Keccak.Generic_Parallel_Sponge
+     (State_Size                   => 1600,
+      State_Type                   => KeccakF_1600_P4.Parallel_State,
+      Parallelism                  => 4,
+      Init                         => KeccakF_1600_P4.Init,
+      Permute_All                  => Permute_All_P4,
+      XOR_Bits_Into_State_Separate => KeccakF_1600_P4.XOR_Bits_Into_State_Separate,
+      XOR_Bits_Into_State_All      => KeccakF_1600_P4.XOR_Bits_Into_State_All,
+      Extract_Bytes                => KeccakF_1600_P4.Extract_Bytes,
+      Pad                          => Keccak.Padding.Pad101_Single_Block,
+      Min_Padding_Bits             => Keccak.Padding.Pad101_Min_Bits);
+
+   package Parallel_Sponge_P8 is new Keccak.Generic_Parallel_Sponge
+     (State_Size                   => 1600,
+      State_Type                   => KeccakF_1600_P8.Parallel_State,
+      Parallelism                  => 8,
+      Init                         => KeccakF_1600_P8.Init,
+      Permute_All                  => Permute_All_P8,
+      XOR_Bits_Into_State_Separate => KeccakF_1600_P8.XOR_Bits_Into_State_Separate,
+      XOR_Bits_Into_State_All      => KeccakF_1600_P8.XOR_Bits_Into_State_All,
+      Extract_Bytes                => KeccakF_1600_P8.Extract_Bytes,
+      Pad                          => Keccak.Padding.Pad101_Single_Block,
+      Min_Padding_Bits             => Keccak.Padding.Pad101_Min_Bits);
+
+end Keccak.Parallel_Keccak_1600.Rounds_14;

--- a/src/x86_64/SSE2/keccak-parallel_keccak_1600-rounds_14.ads
+++ b/src/x86_64/SSE2/keccak-parallel_keccak_1600-rounds_14.ads
@@ -1,0 +1,83 @@
+-------------------------------------------------------------------------------
+--  Copyright (c) 2019, Daniel King
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--      * Redistributions of source code must retain the above copyright
+--        notice, this list of conditions and the following disclaimer.
+--      * Redistributions in binary form must reproduce the above copyright
+--        notice, this list of conditions and the following disclaimer in the
+--        documentation and/or other materials provided with the distribution.
+--      * The name of the copyright holder may not be used to endorse or promote
+--        Products derived from this software without specific prior written
+--        permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+--  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+--  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+--  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+--  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+--  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+--  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+with Keccak.Keccak_1600.Rounds_12;
+with Keccak.Generic_Parallel_Sponge;
+with Keccak.Padding;
+
+pragma Elaborate_All (Keccak.Generic_Parallel_Sponge);
+
+package Keccak.Parallel_Keccak_1600.Rounds_14
+with SPARK_Mode => On
+is
+
+   procedure Permute_All_P2 is new KeccakF_1600_P2.Permute_All
+     (First_Round => 10,
+      Num_Rounds  => 14);
+
+   procedure Permute_All_P4 is new KeccakF_1600_P4.Permute_All
+     (Permute_All_P2);
+
+   procedure Permute_All_P8 is new KeccakF_1600_P8.Permute_All
+     (Permute_All_P2);
+
+   package Parallel_Sponge_P2 is new Keccak.Generic_Parallel_Sponge
+     (State_Size                   => 1600,
+      State_Type                   => KeccakF_1600_P2.Parallel_State,
+      Parallelism                  => 2,
+      Init                         => KeccakF_1600_P2.Init,
+      Permute_All                  => Permute_All_P2,
+      XOR_Bits_Into_State_Separate => KeccakF_1600_P2.XOR_Bits_Into_State_Separate,
+      XOR_Bits_Into_State_All      => KeccakF_1600_P2.XOR_Bits_Into_State_All,
+      Extract_Bytes                => KeccakF_1600_P2.Extract_Bytes,
+      Pad                          => Keccak.Padding.Pad101_Single_Block,
+      Min_Padding_Bits             => Keccak.Padding.Pad101_Min_Bits);
+
+   package Parallel_Sponge_P4 is new Keccak.Generic_Parallel_Sponge
+     (State_Size                   => 1600,
+      State_Type                   => KeccakF_1600_P4.Parallel_State,
+      Parallelism                  => 4,
+      Init                         => KeccakF_1600_P4.Init,
+      Permute_All                  => Permute_All_P4,
+      XOR_Bits_Into_State_Separate => KeccakF_1600_P4.XOR_Bits_Into_State_Separate,
+      XOR_Bits_Into_State_All      => KeccakF_1600_P4.XOR_Bits_Into_State_All,
+      Extract_Bytes                => KeccakF_1600_P4.Extract_Bytes,
+      Pad                          => Keccak.Padding.Pad101_Single_Block,
+      Min_Padding_Bits             => Keccak.Padding.Pad101_Min_Bits);
+
+   package Parallel_Sponge_P8 is new Keccak.Generic_Parallel_Sponge
+     (State_Size                   => 1600,
+      State_Type                   => KeccakF_1600_P8.Parallel_State,
+      Parallelism                  => 8,
+      Init                         => KeccakF_1600_P8.Init,
+      Permute_All                  => Permute_All_P8,
+      XOR_Bits_Into_State_Separate => KeccakF_1600_P8.XOR_Bits_Into_State_Separate,
+      XOR_Bits_Into_State_All      => KeccakF_1600_P8.XOR_Bits_Into_State_All,
+      Extract_Bytes                => KeccakF_1600_P8.Extract_Bytes,
+      Pad                          => Keccak.Padding.Pad101_Single_Block,
+      Min_Padding_Bits             => Keccak.Padding.Pad101_Min_Bits);
+
+end Keccak.Parallel_Keccak_1600.Rounds_14;

--- a/tests/benchmark/src/common/benchmark.adb
+++ b/tests/benchmark/src/common/benchmark.adb
@@ -32,6 +32,7 @@ with Ada.Integer_Text_IO;           use Ada.Integer_Text_IO;
 with Ada.Long_Float_Text_IO;
 with Interfaces;                    use Interfaces;
 with KangarooTwelve;
+with MarsupilamiFourteen;
 with Keccak.Parallel_Keccak_1600;
 with Keccak.Parallel_Keccak_1600.Rounds_24;
 with Keccak.Parallel_Keccak_1600.Rounds_12;
@@ -67,33 +68,33 @@ procedure Benchmark
 is
    Benchmark_Data_Size : constant := 512 * 1024; -- size of the benchmark data in bytes
    Repeat              : constant := 200;  -- number of benchmark iterations
-   
+
    -- A 1 MiB data chunk to use as an input to the algorithms.
    type Byte_Array_Access is access Keccak.Types.Byte_Array;
    Data_Chunk : Byte_Array_Access := new Keccak.Types.Byte_Array (1 .. Benchmark_Data_Size);
-   
+
    package Cycles_Count_IO is new Ada.Text_IO.Modular_IO (Cycles_Count);
-   
-   
+
+
    procedure Print_Cycles_Per_Byte (Data_Size : in Natural;
                                     Cycles    : in Cycles_Count)
    is
       CPB : Long_Float;
-      
+
    begin
       CPB := Long_Float (Cycles) / Long_Float (Data_Size);
-      
+
       Ada.Long_Float_Text_IO.Put
         (Item => CPB,
          Fore => 0,
          Aft  => 1,
          Exp  => 0);
-      
+
       Ada.Text_IO.Put (" cycles/byte");
       Ada.Text_IO.New_Line;
    end Print_Cycles_Per_Byte;
-   
-   
+
+
    procedure Print_Cycles (Cycles : in Cycles_Count)
    is
    begin
@@ -101,7 +102,7 @@ is
       Ada.Text_IO.Put (" cycles");
       Ada.Text_IO.New_Line;
    end Print_Cycles;
-   
+
    ----------------------------------------------------------------------------
    -- Hash_Benchmark
    --
@@ -112,41 +113,41 @@ is
        Name : String;
        with package Hash_Package is new Keccak.Generic_Hash(<>);
    procedure Hash_Benchmark;
-   
+
    procedure Hash_Benchmark
    is
       Ctx   : Hash_Package.Context;
       Digest : Hash_Package.Digest_Type;
-      
+
       Start_Time : Timing.Time;
       Cycles     : Cycles_Count;
       Min_Cycles : Cycles_Count := Cycles_Count'Last;
-      
+
    begin
       Ada.Text_IO.Put (Name & ": ");
-      
+
       Timing.Calibrate;
-      
+
       for I in Positive range 1 .. Repeat loop
          Start_Measurement (Start_Time);
-      
+
          Hash_Package.Init(Ctx);
-         
+
          Hash_Package.Update(Ctx, Data_Chunk.all, Data_Chunk.all'Length*8);
-         
+
          Hash_Package.Final(Ctx, Digest);
-         
+
          Cycles := End_Measurement (Start_Time);
-         
+
          if Cycles < Min_Cycles then
             Min_Cycles := Cycles;
          end if;
       end loop;
-      
+
       Print_Cycles_Per_Byte (Data_Chunk.all'Length, Min_Cycles);
    end Hash_Benchmark;
-   
-   
+
+
    ----------------------------------------------------------------------------
    -- XOF_Benchmark
    --
@@ -157,59 +158,59 @@ is
        Name : String;
        with package XOF_Package is new Keccak.Generic_XOF(<>);
    procedure XOF_Benchmark;
-   
+
    procedure XOF_Benchmark
    is
       Ctx    : XOF_Package.Context;
-      
+
       Start_Time : Timing.Time;
       Cycles     : Cycles_Count;
       Min_Cycles : Cycles_Count := Cycles_Count'Last;
-      
+
    begin
       Ada.Text_IO.Put(Name & " (Absorbing): ");
-      
+
       Timing.Calibrate;
-      
+
       -- Benchmark Absorbing
       for I in Positive range 1 .. Repeat loop
          Start_Measurement (Start_Time);
-      
+
          XOF_Package.Init(Ctx);
-         
+
          XOF_Package.Update(Ctx, Data_Chunk.all, Data_Chunk.all'Length*8);
-         
+
          Cycles := End_Measurement (Start_Time);
-         
+
          if Cycles < Min_Cycles then
             Min_Cycles := Cycles;
          end if;
       end loop;
-      
+
       Print_Cycles_Per_Byte (Data_Chunk.all'Length, Min_Cycles);
-      
+
       Min_Cycles := Cycles_Count'Last;
-      
+
       Ada.Text_IO.Put(Name & " (Squeezing): ");
-      
+
       Timing.Calibrate;
-      
+
       -- Benchmark squeezing
       for I in Positive range 1 .. Repeat loop
          Start_Measurement (Start_Time);
-      
+
          XOF_Package.Extract(Ctx, Data_Chunk.all);
-         
+
          Cycles := End_Measurement (Start_Time);
-         
+
          if Cycles < Min_Cycles then
             Min_Cycles := Cycles;
          end if;
       end loop;
-      
+
       Print_Cycles_Per_Byte (Data_Chunk.all'Length, Min_Cycles);
    end XOF_Benchmark;
-   
+
    ----------------------------------------------------------------------------
    -- Duplex_Benchmark
    --
@@ -220,44 +221,44 @@ is
       Capacity : Positive;
       with package Duplex is new Keccak.Generic_Duplex(<>);
    procedure Duplex_Benchmark;
-   
+
    procedure Duplex_Benchmark
    is
       Ctx : Duplex.Context;
-      
+
       Out_Data : Keccak.Types.Byte_Array(1 .. 1600/8);
-      
+
       Start_Time : Timing.Time;
       Cycles     : Cycles_Count;
       Min_Cycles : Cycles_Count := Cycles_Count'Last;
-      
+
    begin
       Ada.Text_IO.Put(Name & ": ");
-         
+
       Duplex.Init(Ctx, Capacity);
-      
+
       Timing.Calibrate;
-      
+
       for I in Positive range 1 .. Repeat loop
          Start_Measurement (Start_Time);
-         
+
          Duplex.Duplex(Ctx,
                        Data_Chunk.all(1 .. Duplex.Rate_Of(Ctx)/8),
                        Duplex.Rate_Of(Ctx) - Duplex.Min_Padding_Bits,
                        Out_Data(1 .. Duplex.Rate_Of(Ctx)/8),
                        Duplex.Rate_Of(Ctx) - Duplex.Min_Padding_Bits);
-         
+
          Cycles := End_Measurement (Start_Time);
-         
+
          if Cycles < Min_Cycles then
             Min_Cycles := Cycles;
-         end if;       
+         end if;
       end loop;
-      
+
       Print_Cycles (Min_Cycles);
-   
+
    end Duplex_Benchmark;
-   
+
    ----------------------------------------------------------------------------
    -- KeccakF_Benchmark
    --
@@ -269,171 +270,171 @@ is
       with procedure Init (A : out State_Type);
       with procedure Permute(A : in out State_Type);
    procedure KeccakF_Benchmark;
-   
+
    procedure KeccakF_Benchmark
    is
       package Duration_IO is new Ada.Text_IO.Fixed_IO(Duration);
       package Integer_IO is new Ada.Text_IO.Integer_IO(Integer);
-            
+
       State : State_Type;
-      
+
       Start_Time : Timing.Time;
       Cycles     : Cycles_Count;
       Min_Cycles : Cycles_Count := Cycles_Count'Last;
-      
+
       Num_Iterations : Natural := Repeat * 100;
-      
+
    begin
       Ada.Text_IO.Put(Name & ": ");
-      
+
       Init(State);
-      
+
       Timing.Calibrate;
-      
+
       for I in Positive range 1 .. Num_Iterations loop
          Start_Measurement (Start_Time);
-         
+
          Permute(State);
-         
+
          Cycles := End_Measurement (Start_Time);
-         
+
          if Cycles < Min_Cycles then
             Min_Cycles := Cycles;
          end if;
       end loop;
-      
+
       Print_Cycles (Min_Cycles);
-      
+
    end KeccakF_Benchmark;
-   
+
    ----------------------------------------------------------------------------
    -- K12_Benchmark
    --
-   -- Generic procedure to run a benchmark for a KangarooTwelve 
+   -- Generic procedure to run a benchmark for a KangarooTwelve
    ----------------------------------------------------------------------------
    generic
       Name : String;
       with package K12 is new Keccak.Generic_KangarooTwelve(<>);
    procedure K12_Benchmark;
-   
+
    procedure K12_Benchmark
    is
       Ctx    : K12.Context;
-      
+
       Start_Time : Timing.Time;
       Cycles     : Cycles_Count;
       Min_Cycles : Cycles_Count := Cycles_Count'Last;
-      
+
    begin
       Ada.Text_IO.Put(Name & " (Absorbing): ");
-      
+
       Timing.Calibrate;
-      
+
       -- Benchmark Absorbing
       for I in Positive range 1 .. Repeat loop
          Start_Measurement (Start_Time);
-      
+
          K12.Init(Ctx);
-         
+
          K12.Update(Ctx, Data_Chunk.all);
-      
+
          K12.Finish (Ctx, "");
-         
+
          Cycles := End_Measurement (Start_Time);
-         
+
          if Cycles < Min_Cycles then
             Min_Cycles := Cycles;
          end if;
       end loop;
-      
+
       Print_Cycles_Per_Byte (Data_Chunk.all'Length, Min_Cycles);
-      
+
       Min_Cycles := Cycles_Count'Last;
       Ada.Text_IO.Put(Name & " (Squeezing): ");
-      
+
       Timing.Calibrate;
-      
+
       -- Benchmark squeezing
       for I in Positive range 1 .. Repeat loop
          Start_Measurement (Start_Time);
-      
+
          K12.Extract(Ctx, Data_Chunk.all);
-         
+
          Cycles := End_Measurement (Start_Time);
-         
+
          if Cycles < Min_Cycles then
             Min_Cycles := Cycles;
          end if;
       end loop;
-      
+
       Print_Cycles_Per_Byte (Data_Chunk.all'Length, Min_Cycles);
    end K12_Benchmark;
-   
+
    ----------------------------------------------------------------------------
    -- ParallelHash_Benchmark
    --
-   -- Generic procedure to run a benchmark for a ParallelHash 
+   -- Generic procedure to run a benchmark for a ParallelHash
    ----------------------------------------------------------------------------
    generic
       Name : String;
       with package ParallelHash is new Keccak.Generic_Parallel_Hash(<>);
    procedure ParallelHash_Benchmark;
-   
+
    procedure ParallelHash_Benchmark
    is
       Ctx    : ParallelHash.Context;
-      
+
       Start_Time : Timing.Time;
       Cycles     : Cycles_Count;
       Min_Cycles : Cycles_Count := Cycles_Count'Last;
-      
+
    begin
       Ada.Text_IO.Put(Name & " (Absorbing): ");
-      
+
       Timing.Calibrate;
-      
+
       -- Benchmark Absorbing
       for I in Positive range 1 .. Repeat loop
          Start_Measurement (Start_Time);
-      
+
          ParallelHash.Init(Ctx, 8192, "");
-         
+
          ParallelHash.Update(Ctx, Data_Chunk.all);
-      
+
          Cycles := End_Measurement (Start_Time);
-         
+
          if Cycles < Min_Cycles then
             Min_Cycles := Cycles;
          end if;
       end loop;
-      
+
       Print_Cycles_Per_Byte (Data_Chunk.all'Length, Min_Cycles);
-      
+
       Min_Cycles := Cycles_Count'Last;
       Ada.Text_IO.Put(Name & " (Squeezing): ");
-      
+
       Timing.Calibrate;
-      
+
       -- Benchmark squeezing
       for I in Positive range 1 .. Repeat loop
          Start_Measurement (Start_Time);
-      
+
          ParallelHash.Extract(Ctx, Data_Chunk.all);
-         
+
          Cycles := End_Measurement (Start_Time);
-         
+
          if Cycles < Min_Cycles then
             Min_Cycles := Cycles;
          end if;
       end loop;
-      
+
       Print_Cycles_Per_Byte (Data_Chunk.all'Length, Min_Cycles);
    end ParallelHash_Benchmark;
-   
+
    ----------------------------------------------------------------------------
    -- Benchmark procedure instantiations.
    ----------------------------------------------------------------------------
-   
+
    procedure Benchmark_SHA_224 is new Hash_Benchmark
       ("SHA3-224", SHA3.SHA3_224);
    procedure Benchmark_SHA_256 is new Hash_Benchmark
@@ -442,7 +443,7 @@ is
       ("SHA3-384", SHA3.SHA3_384);
    procedure Benchmark_SHA_512 is new Hash_Benchmark
       ("SHA3-512", SHA3.SHA3_512);
-   
+
    procedure Benchmark_Keccak_224 is new Hash_Benchmark
       ("Keccak-224", SHA3.Keccak_224);
    procedure Benchmark_Keccak_256 is new Hash_Benchmark
@@ -451,17 +452,17 @@ is
       ("Keccak-384", SHA3.Keccak_384);
    procedure Benchmark_Keccak_512 is new Hash_Benchmark
       ("Keccak-512", SHA3.Keccak_512);
-   
+
    procedure Benchmark_SHAKE128 is new XOF_Benchmark
       ("SHAKE128", SHAKE.SHAKE128);
    procedure Benchmark_SHAKE256 is new XOF_Benchmark
       ("SHAKE256", SHAKE.SHAKE256);
-   
+
    procedure Benchmark_RawSHAKE128 is new XOF_Benchmark
       ("RawSHAKE128", RawSHAKE.RawSHAKE128);
    procedure Benchmark_RawSHAKE256 is new XOF_Benchmark
       ("RawSHAKE256", RawSHAKE.RawSHAKE256);
-   
+
    procedure Benchmark_Duplex_r1152c448 is new Duplex_Benchmark
       ("Duplex r1152c448", 448, Keccak.Keccak_1600.Rounds_24.Duplex);
    procedure Benchmark_Duplex_r1088c512 is new Duplex_Benchmark
@@ -470,82 +471,86 @@ is
       ("Duplex r832c768", 768, Keccak.Keccak_1600.Rounds_24.Duplex);
    procedure Benchmark_Duplex_r576c1024 is new Duplex_Benchmark
      ("Duplex r576c1024", 1024, Keccak.Keccak_1600.Rounds_24.Duplex);
-   
+
    procedure Benchmark_KeccakF_25 is new KeccakF_Benchmark
-     ("Keccak-p[25,12]", 
-      Keccak.Keccak_25.KeccakF_25.Lane_Complemented_State, 
-      Keccak.Keccak_25.KeccakF_25.Init, 
+     ("Keccak-p[25,12]",
+      Keccak.Keccak_25.KeccakF_25.Lane_Complemented_State,
+      Keccak.Keccak_25.KeccakF_25.Init,
       Keccak.Keccak_25.Rounds_12.Permute);
    procedure Benchmark_KeccakF_50 is new KeccakF_Benchmark
-     ("Keccak-p[50,14]", 
-      Keccak.Keccak_50.KeccakF_50.Lane_Complemented_State, 
-      Keccak.Keccak_50.KeccakF_50.Init, 
+     ("Keccak-p[50,14]",
+      Keccak.Keccak_50.KeccakF_50.Lane_Complemented_State,
+      Keccak.Keccak_50.KeccakF_50.Init,
       Keccak.Keccak_50.Rounds_14.Permute);
    procedure Benchmark_KeccakF_100 is new KeccakF_Benchmark
-     ("Keccak-p[100,16]", 
-      Keccak.Keccak_100.KeccakF_100.Lane_Complemented_State, 
-      Keccak.Keccak_100.KeccakF_100.Init, 
+     ("Keccak-p[100,16]",
+      Keccak.Keccak_100.KeccakF_100.Lane_Complemented_State,
+      Keccak.Keccak_100.KeccakF_100.Init,
       Keccak.Keccak_100.Rounds_16.Permute);
    procedure Benchmark_KeccakF_200 is new KeccakF_Benchmark
-     ("Keccak-p[200,18]", 
-      Keccak.Keccak_200.KeccakF_200.Lane_Complemented_State, 
-      Keccak.Keccak_200.KeccakF_200.Init,  
+     ("Keccak-p[200,18]",
+      Keccak.Keccak_200.KeccakF_200.Lane_Complemented_State,
+      Keccak.Keccak_200.KeccakF_200.Init,
       Keccak.Keccak_200.Rounds_18.Permute);
    procedure Benchmark_KeccakF_400 is new KeccakF_Benchmark
-     ("Keccak-p[400,20]", 
-      Keccak.Keccak_400.KeccakF_400.Lane_Complemented_State, 
-      Keccak.Keccak_400.KeccakF_400.Init, 
+     ("Keccak-p[400,20]",
+      Keccak.Keccak_400.KeccakF_400.Lane_Complemented_State,
+      Keccak.Keccak_400.KeccakF_400.Init,
       Keccak.Keccak_400.Rounds_20.Permute);
    procedure Benchmark_KeccakF_800 is new KeccakF_Benchmark
      ("Keccak-p[800,22]",
-      Keccak.Keccak_800.KeccakF_800.Lane_Complemented_State, 
-      Keccak.Keccak_800.KeccakF_800.Init, 
+      Keccak.Keccak_800.KeccakF_800.Lane_Complemented_State,
+      Keccak.Keccak_800.KeccakF_800.Init,
       Keccak.Keccak_800.Rounds_22.Permute);
    procedure Benchmark_KeccakF_1600_R24 is new KeccakF_Benchmark
-     ("Keccak-p[1600,24]", 
+     ("Keccak-p[1600,24]",
       Keccak.Keccak_1600.KeccakF_1600.Lane_Complemented_State,
-      Keccak.Keccak_1600.KeccakF_1600.Init, 
+      Keccak.Keccak_1600.KeccakF_1600.Init,
       Keccak.Keccak_1600.Rounds_24.Permute);
    procedure Benchmark_KeccakF_1600_P2_R24 is new KeccakF_Benchmark
-     ("Keccak-p[1600,24]×2", 
+     ("Keccak-p[1600,24]×2",
       Keccak.Parallel_Keccak_1600.Parallel_State_P2,
-      Keccak.Parallel_Keccak_1600.Init_P2, 
+      Keccak.Parallel_Keccak_1600.Init_P2,
       Keccak.Parallel_Keccak_1600.Rounds_24.Permute_All_P2);
    procedure Benchmark_KeccakF_1600_P4_R24 is new KeccakF_Benchmark
-     ("Keccak-p[1600,24]×4", 
+     ("Keccak-p[1600,24]×4",
       Keccak.Parallel_Keccak_1600.Parallel_State_P4,
-      Keccak.Parallel_Keccak_1600.Init_P4, 
+      Keccak.Parallel_Keccak_1600.Init_P4,
       Keccak.Parallel_Keccak_1600.Rounds_24.Permute_All_P4);
    procedure Benchmark_KeccakF_1600_P8_R24 is new KeccakF_Benchmark
-     ("Keccak-p[1600,24]×8", 
+     ("Keccak-p[1600,24]×8",
       Keccak.Parallel_Keccak_1600.Parallel_State_P8,
-      Keccak.Parallel_Keccak_1600.Init_P8, 
+      Keccak.Parallel_Keccak_1600.Init_P8,
       Keccak.Parallel_Keccak_1600.Rounds_24.Permute_All_P8);
    procedure Benchmark_KeccakF_1600_R12 is new KeccakF_Benchmark
-     ("Keccak-p[1600,12]", 
+     ("Keccak-p[1600,12]",
       Keccak.Keccak_1600.KeccakF_1600.Lane_Complemented_State,
-      Keccak.Keccak_1600.KeccakF_1600.Init, 
+      Keccak.Keccak_1600.KeccakF_1600.Init,
       Keccak.Keccak_1600.Rounds_12.Permute);
    procedure Benchmark_KeccakF_1600_P2_R12 is new KeccakF_Benchmark
-     ("Keccak-p[1600,12]×2", 
+     ("Keccak-p[1600,12]×2",
       Keccak.Parallel_Keccak_1600.Parallel_State_P2,
-      Keccak.Parallel_Keccak_1600.Init_P2, 
+      Keccak.Parallel_Keccak_1600.Init_P2,
       Keccak.Parallel_Keccak_1600.Rounds_12.Permute_All_P2);
    procedure Benchmark_KeccakF_1600_P4_R12 is new KeccakF_Benchmark
-     ("Keccak-p[1600,12]×4", 
+     ("Keccak-p[1600,12]×4",
       Keccak.Parallel_Keccak_1600.Parallel_State_P4,
-      Keccak.Parallel_Keccak_1600.Init_P4, 
+      Keccak.Parallel_Keccak_1600.Init_P4,
       Keccak.Parallel_Keccak_1600.Rounds_12.Permute_All_P4);
    procedure Benchmark_KeccakF_1600_P8_R12 is new KeccakF_Benchmark
-     ("Keccak-p[1600,12]×8", 
+     ("Keccak-p[1600,12]×8",
       Keccak.Parallel_Keccak_1600.Parallel_State_P8,
-      Keccak.Parallel_Keccak_1600.Init_P8, 
+      Keccak.Parallel_Keccak_1600.Init_P8,
       Keccak.Parallel_Keccak_1600.Rounds_12.Permute_All_P8);
-   
+
    procedure Benchmark_K12 is new K12_Benchmark
      ("KangarooTwelve",
       KangarooTwelve.K12);
-      
+
+   procedure Benchmark_M14 is new K12_Benchmark
+     ("MarsupilamiFourteen",
+      MarsupilamiFourteen.M14);
+
    procedure Benchmark_ParallelHash128 is new ParallelHash_Benchmark
      ("ParallelHash128",
       Parallel_Hash.ParallelHash128);
@@ -555,7 +560,7 @@ is
 
 begin
    Data_Chunk.all := (others => 16#A7#);
-   
+
    Put ("Message size: ");
    Ada.Integer_Text_IO.Put (Data_Chunk.all'Length, Width => 0);
    Put (" bytes");
@@ -565,8 +570,9 @@ begin
    Put (" measurements for each test");
    New_Line;
    New_Line;
-   
+
    Benchmark_K12;
+   Benchmark_M14;
    Benchmark_ParallelHash128;
    Benchmark_ParallelHash256;
    Benchmark_SHA_224;


### PR DESCRIPTION
This implements the MarsupilamiFourteen variant of KangarooTwelve as described by the Keccak authors in Section 5 of https://keccak.team/files/KangarooTwelve.pdf

This algorithm has a higher security margin than KangarooTwelve, but increases the capacity and chaining value size from 256-bits to 512-bits, and increases the number of Keccak rounds from 12 to 14. 