### PR TITLE
Improve sponge performance

### DIFF
--- a/src/common/keccak-generic_keccakf-byte_lanes.adb
+++ b/src/common/keccak-generic_keccakf-byte_lanes.adb
@@ -128,8 +128,6 @@ is
       --  Process whole lanes
       Outer_Loop :
       for Y2 in Y_Coord loop
-         pragma Loop_Variant (Increases => Offset,
-                              Decreases => Remaining_Bytes);
          pragma Loop_Invariant (Offset mod (W / 8) = 0
                                 and Offset + Remaining_Bytes = Data'Length);
 
@@ -233,8 +231,6 @@ is
       --  Process whole lanes
       Outer_Loop :
       for Y2 in Y_Coord loop
-         pragma Loop_Variant (Increases => Offset,
-                              Decreases => Remaining_Bytes);
          pragma Loop_Invariant (Offset mod (W / 8) = 0
                                 and Offset + Remaining_Bytes = Data'Length);
 

--- a/src/common/keccak-generic_parallel_sponge.adb
+++ b/src/common/keccak-generic_parallel_sponge.adb
@@ -175,6 +175,10 @@ is
             Bit_Len     => Ctx.Rate * 8);
 
          Permute_All (Ctx.Permutation_State);
+
+      else
+         --  Help prove contract case.
+         pragma Assert ((Data'Length / Num_Parallel_Instances) mod (Rate_Of (Ctx) / 8) = 0);
       end if;
 
    end Absorb_Bytes_Separate;

--- a/src/common/keccak-generic_sponge.ads
+++ b/src/common/keccak-generic_sponge.ads
@@ -231,6 +231,9 @@ is
      Depends => ((Ctx, Digest) => (Ctx, Digest)),
      Post => (State_Of (Ctx) = Squeezing
               and Rate_Of (Ctx) = Rate_Of (Ctx'Old));
+   pragma Annotate (GNATprove, False_Positive,
+                    """Digest"" might not be initialized",
+                    "Digest is fully initialized by the end of the subprogram");
    --  Squeeze (output) bits from the sponge.
    --
    --  Squeeze can be called multiple times to extract an arbitrary amount of
@@ -288,6 +291,9 @@ private
       --  the rate, then the next block of output is generated and Bytes_Squeezed
       --  is reset to 0.
       Bytes_Squeezed  : Byte_Absorption_Number;
+
+      --  True if the data in the 'Block' buffer contain valid output data.
+      Out_Bytes_Ready : Boolean;
 
       --  The rate parameter. This value is represented in bytes, not bits
       --  so that it is easier to manage in proof.


### PR DESCRIPTION
This gives a 0.5 cycles per byte performance improvement (on a Ryzen7 1700x) when generating output bytes from the serial sponge (Keccak.Generic_Sponge).

The changes made are:
 * Remove pre-zeroing of the output buffer as a workaround for a flow control warning, and instead use an explicit suppresson of the (false positive) warning. There's no need to zero the output buffer when it's going to be fully overwritten anyway.
 * Copy directly to the output buffer in 'Squeeze' instead of going via an intermediate buffer. This avoids unnecessary copying.
 * Refactor 'Extract_Bytes' to allow for loop unrolling.