### PR TITLE
Implement Ketje v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj
 lib
 bin
 doc
+gnatinspect.db

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ libkeccak implements the following generic constructions:
 * The Keccak-p permutation for state sizes of 25, 50, 100, 200, 400, 800, and 1600 bits (see [1] and [2]).
 * The Sponge construction
 * The Duplex construction
+* The MonkeyDuplex construction
+* The MonkeyWrap construction
 * Hash functions based on the Sponge construction
 * eXtendable Output Functions (XOF) based on the Sponge construction
 * cSHAKE, KMAC, TupleHash, and ParallelHash as specified in NIST SP 800-185 [4]
 * KangarooTwelve as specified by the Keccak team [5]
 
 libkeccak also provides concrete implementations of the above constructions,
-as specified in [1,4,5]:
+as specified in [1,4,5,6]:
 
 * Hash functions:
   * SHA-3 (224, 256, 384, and 512 bits)
@@ -34,6 +36,8 @@ as specified in [1,4,5]:
   * KangarooTwelve
   * MarsupilamiFourteen (256-bit security variant of KangarooTwelve)
   * ParallelHash128 and ParallelHash256
+* Authenticated encryption:
+  * Ketje (Jr, Sr, Minor, and Major variants)
 
 Note that the difference between a hash function an a XOF function is that a
 hash function has a fixed output length (for example, 256 bits), whereas the
@@ -201,3 +205,5 @@ http://sponge.noekeon.org/CSF-0.1.pdf
 http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-185.pdf
 * [5] KangarooTwelve: fast hashing based on Keccak-p
 http://keccak.noekeon.org/kangarootwelve.html
+* [6] CAESAR submission: Ketje v2
+https://keccak.team/files/Ketjev2-doc2.0.pdf

--- a/build/libkeccak.gpr
+++ b/build/libkeccak.gpr
@@ -49,7 +49,7 @@ project Libkeccak is
    end Builder;
 
    package Prove is
-      for Switches use ("-j8", "--level=3", "--prover=cvc4,z3,altergo", "--proof=progressive", "--timeout=60");
+      for Switches use ("-j0", "--level=3");
    end Prove;
 
    package Compiler is

--- a/src/common/keccak-generic_keccakf-byte_lanes-twisted.adb
+++ b/src/common/keccak-generic_keccakf-byte_lanes-twisted.adb
@@ -162,7 +162,8 @@ package body Keccak.Generic_KeccakF.Byte_Lanes.Twisted is
       YT : constant Y_Coord := Y_Coord (X);
 
    begin
-      A (XT, YT) := A (XT, YT) xor Shift_Left (Lane_Type (Value), Offset mod (Lane_Size_Bits / 8));
+      A (XT, YT) := A (XT, YT) xor Shift_Left (Lane_Type (Value),
+                                               (Offset mod (Lane_Size_Bits / 8)) * 8);
    end XOR_Byte_Into_State_Twisted;
 
    ---------------------------

--- a/src/common/keccak-generic_keccakf-byte_lanes-twisted.ads
+++ b/src/common/keccak-generic_keccakf-byte_lanes-twisted.ads
@@ -1,0 +1,108 @@
+-------------------------------------------------------------------------------
+--  Copyright (c) 2019, Daniel King
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--      * Redistributions of source code must retain the above copyright
+--        notice, this list of conditions and the following disclaimer.
+--      * Redistributions in binary form must reproduce the above copyright
+--        notice, this list of conditions and the following disclaimer in the
+--        documentation and/or other materials provided with the distribution.
+--      * The name of the copyright holder may not be used to endorse or promote
+--        Products derived from this software without specific prior written
+--        permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+--  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+--  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+--  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+--  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+--  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+--  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+--  @summary
+--  Variants for twisted Keccak-p permutations.
+--
+--  @group Keccak-f
+generic
+package Keccak.Generic_KeccakF.Byte_Lanes.Twisted is
+
+   procedure XOR_Bits_Into_State_Twisted (A       : in out State;
+                                          Data    : in     Keccak.Types.Byte_Array;
+                                          Bit_Len : in     Natural)
+     with Global => null,
+     Depends => (A =>+ (Data, Bit_Len)),
+     Pre => (Bit_Len <= State_Size_Bits
+             and then (Bit_Len + 7) / 8 <= Data'Length);
+   --  Version of XOR_Bits_Into_State for Twisted Keccak-p
+
+   procedure XOR_Bits_Into_State_Twisted (A       : in out Lane_Complemented_State;
+                                          Data    : in     Keccak.Types.Byte_Array;
+                                          Bit_Len : in     Natural)
+     with Inline,
+     Global => null,
+     Depends => (A =>+ (Data, Bit_Len)),
+     Pre => (Bit_Len <= State_Size_Bits
+             and then (Bit_Len + 7) / 8 <= Data'Length);
+   --  Version of XOR_Bits_Into_State for Twisted Keccak-p
+
+   procedure XOR_Byte_Into_State_Twisted (A       : in out State;
+                                          Offset  : in     Natural;
+                                          Value   : in     Keccak.Types.Byte)
+     with Global => null,
+     Depends => (A =>+ (Offset, Value)),
+     Pre => Offset < (State_Size_Bits + 7) / 8;
+
+   procedure XOR_Byte_Into_State_Twisted (A       : in out Lane_Complemented_State;
+                                          Offset  : in     Natural;
+                                          Value   : in     Keccak.Types.Byte)
+     with Global => null,
+     Depends => (A =>+ (Offset, Value)),
+     Pre => Offset < (State_Size_Bits + 7) / 8;
+
+   procedure Extract_Bytes_Twisted (A    : in     State;
+                                    Data :    out Keccak.Types.Byte_Array)
+     with Global => null,
+     Depends => (Data =>+ A),
+     Pre => Data'Length <= ((State_Size_Bits + 7) / 8);
+   pragma Annotate
+     (GNATprove, False_Positive,
+      """Data"" might not be initialized",
+      "GNATprove issues a false positive due to the use of loops to initialize Data");
+   --  Twisted version of Extract_Bytes
+
+   procedure Extract_Bytes_Twisted (A    : in     Lane_Complemented_State;
+                                    Data :    out Keccak.Types.Byte_Array)
+     with Global => null,
+     Depends => (Data =>+ A),
+     Pre => Data'Length <= ((State_Size_Bits + 7) / 8);
+   pragma Annotate
+     (GNATprove, False_Positive,
+      """Data"" might not be initialized",
+      "GNATprove issues a false positive due to the use of loops to initialize Data");
+   --  Twisted version of Extract_Bytes
+
+   procedure Extract_Bits_Twisted (A       : in     State;
+                                   Data    :    out Keccak.Types.Byte_Array;
+                                   Bit_Len : in     Natural)
+     with Global => null,
+     Depends => (Data =>+ (A, Bit_Len)),
+     Pre => (Bit_Len <= State_Size_Bits
+             and then Data'Length = (Bit_Len + 7) / 8);
+   --  Twisted version of Extract_Bits
+
+   procedure Extract_Bits_Twisted (A       : in     Lane_Complemented_State;
+                                   Data    :    out Keccak.Types.Byte_Array;
+                                   Bit_Len : in     Natural)
+     with Global => null,
+     Depends => (Data =>+ (A, Bit_Len)),
+     Pre => (Bit_Len <= State_Size_Bits
+             and then Data'Length = (Bit_Len + 7) / 8);
+   --  Twisted version of Extract_Bits
+
+end Keccak.Generic_KeccakF.Byte_Lanes.Twisted;

--- a/src/common/keccak-generic_keccakf-byte_lanes.adb
+++ b/src/common/keccak-generic_keccakf-byte_lanes.adb
@@ -107,6 +107,35 @@ is
          Bit_Len => Bit_Len);
    end XOR_Bits_Into_State;
 
+   ---------------------------
+   --  XOR_Byte_Into_State  --
+   ---------------------------
+
+   procedure XOR_Byte_Into_State (A       : in out State;
+                                  Offset  : in     Natural;
+                                  Value   : in     Keccak.Types.Byte)
+   is
+      Lane_Size_Bytes : constant Positive := Lane_Size_Bits / 8;
+
+      X : X_Coord := X_Coord ((Offset / Lane_Size_Bytes) mod 5);
+      Y : Y_Coord := Y_Coord (Offset / (Lane_Size_Bytes * 5));
+
+   begin
+      A (X, Y) := A (X, Y) xor Shift_Left (Lane_Type (Value), Offset mod (Lane_Size_Bits / 8));
+   end XOR_Byte_Into_State;
+
+   ---------------------------
+   --  XOR_Byte_Into_State  --
+   ---------------------------
+
+   procedure XOR_Byte_Into_State (A       : in out Lane_Complemented_State;
+                                  Offset  : in     Natural;
+                                  Value   : in     Keccak.Types.Byte)
+   is
+   begin
+      XOR_Byte_Into_State (State (A), Offset, Value);
+   end XOR_Byte_Into_State;
+
    ---------------------
    --  Extract_Bytes  --
    ---------------------

--- a/src/common/keccak-generic_keccakf-byte_lanes.ads
+++ b/src/common/keccak-generic_keccakf-byte_lanes.ads
@@ -97,6 +97,25 @@ is
    --     value cannot be larger than the bit-length of the 'Data' array, and
    --     cannot be larger than the Keccak-f state size.
 
+   procedure XOR_Bits_Into_State_Twisted (A       : in out State;
+                                          Data    : in     Keccak.Types.Byte_Array;
+                                          Bit_Len : in     Natural)
+     with Global => null,
+     Depends => (A =>+ (Data, Bit_Len)),
+     Pre => (Bit_Len <= State_Size_Bits
+             and then (Bit_Len + 7) / 8 <= Data'Length);
+   --  Version of XOR_Bits_Into_State for Twisted Keccak-p
+
+   procedure XOR_Bits_Into_State_Twisted (A       : in out Lane_Complemented_State;
+                                          Data    : in     Keccak.Types.Byte_Array;
+                                          Bit_Len : in     Natural)
+     with Inline,
+     Global => null,
+     Depends => (A =>+ (Data, Bit_Len)),
+     Pre => (Bit_Len <= State_Size_Bits
+             and then (Bit_Len + 7) / 8 <= Data'Length);
+   --  Version of XOR_Bits_Into_State for Twisted Keccak-p
+
    procedure XOR_Byte_Into_State (A       : in out State;
                                   Offset  : in     Natural;
                                   Value   : in     Keccak.Types.Byte)
@@ -107,6 +126,20 @@ is
    procedure XOR_Byte_Into_State (A       : in out Lane_Complemented_State;
                                   Offset  : in     Natural;
                                   Value   : in     Keccak.Types.Byte)
+     with Global => null,
+     Depends => (A =>+ (Offset, Value)),
+     Pre => Offset < (State_Size_Bits + 7) / 8;
+
+   procedure XOR_Byte_Into_State_Twisted (A       : in out State;
+                                          Offset  : in     Natural;
+                                          Value   : in     Keccak.Types.Byte)
+     with Global => null,
+     Depends => (A =>+ (Offset, Value)),
+     Pre => Offset < (State_Size_Bits + 7) / 8;
+
+   procedure XOR_Byte_Into_State_Twisted (A       : in out Lane_Complemented_State;
+                                          Offset  : in     Natural;
+                                          Value   : in     Keccak.Types.Byte)
      with Global => null,
      Depends => (A =>+ (Offset, Value)),
      Pre => Offset < (State_Size_Bits + 7) / 8;

--- a/src/common/keccak-generic_keccakf-byte_lanes.ads
+++ b/src/common/keccak-generic_keccakf-byte_lanes.ads
@@ -97,25 +97,6 @@ is
    --     value cannot be larger than the bit-length of the 'Data' array, and
    --     cannot be larger than the Keccak-f state size.
 
-   procedure XOR_Bits_Into_State_Twisted (A       : in out State;
-                                          Data    : in     Keccak.Types.Byte_Array;
-                                          Bit_Len : in     Natural)
-     with Global => null,
-     Depends => (A =>+ (Data, Bit_Len)),
-     Pre => (Bit_Len <= State_Size_Bits
-             and then (Bit_Len + 7) / 8 <= Data'Length);
-   --  Version of XOR_Bits_Into_State for Twisted Keccak-p
-
-   procedure XOR_Bits_Into_State_Twisted (A       : in out Lane_Complemented_State;
-                                          Data    : in     Keccak.Types.Byte_Array;
-                                          Bit_Len : in     Natural)
-     with Inline,
-     Global => null,
-     Depends => (A =>+ (Data, Bit_Len)),
-     Pre => (Bit_Len <= State_Size_Bits
-             and then (Bit_Len + 7) / 8 <= Data'Length);
-   --  Version of XOR_Bits_Into_State for Twisted Keccak-p
-
    procedure XOR_Byte_Into_State (A       : in out State;
                                   Offset  : in     Natural;
                                   Value   : in     Keccak.Types.Byte)
@@ -126,20 +107,6 @@ is
    procedure XOR_Byte_Into_State (A       : in out Lane_Complemented_State;
                                   Offset  : in     Natural;
                                   Value   : in     Keccak.Types.Byte)
-     with Global => null,
-     Depends => (A =>+ (Offset, Value)),
-     Pre => Offset < (State_Size_Bits + 7) / 8;
-
-   procedure XOR_Byte_Into_State_Twisted (A       : in out State;
-                                          Offset  : in     Natural;
-                                          Value   : in     Keccak.Types.Byte)
-     with Global => null,
-     Depends => (A =>+ (Offset, Value)),
-     Pre => Offset < (State_Size_Bits + 7) / 8;
-
-   procedure XOR_Byte_Into_State_Twisted (A       : in out Lane_Complemented_State;
-                                          Offset  : in     Natural;
-                                          Value   : in     Keccak.Types.Byte)
      with Global => null,
      Depends => (A =>+ (Offset, Value)),
      Pre => Offset < (State_Size_Bits + 7) / 8;

--- a/src/common/keccak-generic_keccakf-byte_lanes.ads
+++ b/src/common/keccak-generic_keccakf-byte_lanes.ads
@@ -43,9 +43,8 @@ is
                                   Bit_Len : in     Natural)
      with Global => null,
      Depends => (A =>+ (Data, Bit_Len)),
-     Pre => (Data'Length <= Natural'Last / 8
-             and then Bit_Len <= Data'Length * 8
-             and then Bit_Len <= State_Size_Bits);
+     Pre => (Bit_Len <= State_Size_Bits
+             and then (Bit_Len + 7) / 8 <= Data'Length);
    --  XOR bits into the Keccak-f state.
    --
    --  The data is XOR'ed into the first Bit_Len bits of the state.
@@ -74,9 +73,8 @@ is
      with Inline,
      Global => null,
      Depends => (A =>+ (Data, Bit_Len)),
-     Pre => (Data'Length <= Natural'Last / 8
-             and then Bit_Len <= Data'Length * 8
-             and then Bit_Len <= State_Size_Bits);
+     Pre => (Bit_Len <= State_Size_Bits
+             and then (Bit_Len + 7) / 8 <= Data'Length);
    --  XOR bits into the lane complemented version of the Keccak-f state.
    --
    --  The data is XOR'ed into the first Bit_Len bits of the state.
@@ -98,6 +96,20 @@ is
    --  @param Bit_Len The number of bits to XOR into the Keccak-f state. This
    --     value cannot be larger than the bit-length of the 'Data' array, and
    --     cannot be larger than the Keccak-f state size.
+
+   procedure XOR_Byte_Into_State (A       : in out State;
+                                  Offset  : in     Natural;
+                                  Value   : in     Keccak.Types.Byte)
+     with Global => null,
+     Depends => (A =>+ (Offset, Value)),
+     Pre => Offset < (State_Size_Bits + 7) / 8;
+
+   procedure XOR_Byte_Into_State (A       : in out Lane_Complemented_State;
+                                  Offset  : in     Natural;
+                                  Value   : in     Keccak.Types.Byte)
+     with Global => null,
+     Depends => (A =>+ (Offset, Value)),
+     Pre => Offset < (State_Size_Bits + 7) / 8;
 
    procedure Extract_Bytes (A    : in     State;
                             Data :    out Keccak.Types.Byte_Array)

--- a/src/common/keccak-generic_keccakf-lane_complementing_permutation.adb
+++ b/src/common/keccak-generic_keccakf-lane_complementing_permutation.adb
@@ -31,7 +31,10 @@ is
 
    procedure Permute (S : in out Lane_Complemented_State)
    is
-      First_Round : constant Round_Index := 23 - Round_Index (Num_Rounds - 1);
+      Max_Rounds : constant Positive := 12 + (Lane_Size_Log * 2);
+
+      First_Round : constant Round_Index := Round_Index (Max_Rounds - 1)
+                                          - Round_Index (Num_Rounds - 1);
 
       type Round_Constants is array (Round_Index) of Interfaces.Unsigned_64;
 

--- a/src/common/keccak-generic_keccakf-lane_complementing_permutation.adb
+++ b/src/common/keccak-generic_keccakf-lane_complementing_permutation.adb
@@ -495,25 +495,29 @@ is
 
       Prepare_Theta;
 
+      pragma Warnings
+        (GNATprove, Off,
+         "statement has no effect, in instantiation at",
+         Reason => "Loop is not executed in instantiations with Num_Rounds = 1");
+
       for RI in 0 .. (Num_Rounds / 2) - 1 loop
+
          pragma Warnings
            (GNATprove, Off,
-            "unused assignment to ""A",
-            Reason => "Axx variables are also re-used as temporaries");
+            "unused assignment to",
+            Reason => "Axx and Exx variables are also re-used as temporaries");
+
+         pragma Warnings
+           (GNATprove, Off,
+            "this statement is never reached",
+            Reason => "This loop is not executed when instantiated with Num_Rounds => 1");
 
          Theta_Rho_Pi_Chi_Iota_Prepare_Theta_AtoE (First_Round + Round_Index (RI * 2));
+         Theta_Rho_Pi_Chi_Iota_Prepare_Theta_EtoA (First_Round + Round_Index ((RI * 2) + 1));
 
-         pragma Warnings (GNATprove, On);
-
-         pragma Warnings
-           (GNATprove, Off,
-            "unused assignment to ""E",
-            Reason => "Exx variables are also re-used as temporaries");
-
-         Theta_Rho_Pi_Chi_Iota_Prepare_Theta_EtoA (First_Round + Round_Index (RI * 2) + 1);
-
-         pragma Warnings (GNATprove, On);
       end loop;
+
+      pragma Warnings (GNATprove, On);
 
       if Num_Rounds mod 2 /= 0 then
          --  Number of rounds is an odd number, so we need to do the final step.

--- a/src/common/keccak-generic_keccakf-lane_complementing_permutation.adb
+++ b/src/common/keccak-generic_keccakf-lane_complementing_permutation.adb
@@ -31,6 +31,8 @@ is
 
    procedure Permute (S : in out Lane_Complemented_State)
    is
+      First_Round : constant Round_Index := 23 - Round_Index (Num_Rounds - 1);
+
       type Round_Constants is array (Round_Index) of Interfaces.Unsigned_64;
 
       RC : constant Round_Constants :=

--- a/src/common/keccak-generic_keccakf-lane_complementing_permutation.ads
+++ b/src/common/keccak-generic_keccakf-lane_complementing_permutation.ads
@@ -47,7 +47,6 @@ is
       --  Number of rounds.
       --
       --  By default, the definition from The Keccak Reference is used.
-      First_Round : Round_Index := 0;
       Num_Rounds  : Round_Count := 12 + (2 * Lane_Size_Log);
    procedure Permute (S : in out Lane_Complemented_State)
      with Global => null;

--- a/src/common/keccak-generic_keccakf-optimized_permutation.adb
+++ b/src/common/keccak-generic_keccakf-optimized_permutation.adb
@@ -35,7 +35,10 @@ is
    is
       type Round_Constants is array (Round_Index) of Interfaces.Unsigned_64;
 
-      First_Round : constant Round_Index := 23 - Round_Index (Num_Rounds - 1);
+      Max_Rounds : constant Positive := 12 + (Lane_Size_Log * 2);
+
+      First_Round : constant Round_Index := Round_Index (Max_Rounds - 1)
+                                          - Round_Index (Num_Rounds - 1);
 
       RC : constant Round_Constants :=
         (

--- a/src/common/keccak-generic_keccakf-optimized_permutation.adb
+++ b/src/common/keccak-generic_keccakf-optimized_permutation.adb
@@ -35,6 +35,8 @@ is
    is
       type Round_Constants is array (Round_Index) of Interfaces.Unsigned_64;
 
+      First_Round : constant Round_Index := 23 - Round_Index (Num_Rounds - 1);
+
       RC : constant Round_Constants :=
         (
          16#0000_0000_0000_0001#,

--- a/src/common/keccak-generic_keccakf-optimized_permutation.ads
+++ b/src/common/keccak-generic_keccakf-optimized_permutation.ads
@@ -41,7 +41,6 @@ is
       --  Number of rounds.
       --
       --  By default, the definition from The Keccak Reference is used.
-      First_Round : Round_Index := 0;
       Num_Rounds  : Round_Count := 12 + (2 * Lane_Size_Log);
    procedure Permute (S : in out State)
      with Global => null;

--- a/src/common/keccak-generic_keccakf-reference_permutation.adb
+++ b/src/common/keccak-generic_keccakf-reference_permutation.adb
@@ -268,7 +268,10 @@ is
 
    procedure Permute (A : in out State)
    is
-      First_Round : constant Round_Index := 23 - Round_Index (Num_Rounds - 1);
+      Max_Rounds : constant Positive := 12 + (Lane_Size_Log * 2);
+
+      First_Round : constant Round_Index := Round_Index (Max_Rounds - 1)
+                                          - Round_Index (Num_Rounds - 1);
 
       Temp : State;
 

--- a/src/common/keccak-generic_keccakf-reference_permutation.adb
+++ b/src/common/keccak-generic_keccakf-reference_permutation.adb
@@ -268,6 +268,8 @@ is
 
    procedure Permute (A : in out State)
    is
+      First_Round : constant Round_Index := 23 - Round_Index (Num_Rounds - 1);
+
       Temp : State;
 
    begin

--- a/src/common/keccak-generic_keccakf-reference_permutation.ads
+++ b/src/common/keccak-generic_keccakf-reference_permutation.ads
@@ -46,7 +46,6 @@ is
       --  Number of rounds.
       --
       --  By default, the definition from The Keccak Reference is used.
-      First_Round : Round_Index := 0;
       Num_Rounds  : Round_Count := 12 + (2 * Lane_Size_Log);
    procedure Permute (A : in out State)
      with Global => null,

--- a/src/common/keccak-generic_monkeyduplex.adb
+++ b/src/common/keccak-generic_monkeyduplex.adb
@@ -47,10 +47,14 @@ package body Keccak.Generic_MonkeyDuplex is
 
       XOR_Padding_Into_State (A         => Ctx.State,
                               First_Bit => Bit_Len,
-                              Last_Bit  => Rate_Of (Ctx) - 1);
+                              Last_Bit  => State_Size_Bits - 1);
 
       Permute_Start (Ctx.State);
    end Start;
+
+   -------------
+   --  Start  --
+   -------------
 
    function Start (Rate     : in     Rate_Bits_Number;
                    Data     : in     Keccak.Types.Byte_Array;

--- a/src/common/keccak-generic_monkeyduplex.adb
+++ b/src/common/keccak-generic_monkeyduplex.adb
@@ -151,7 +151,7 @@ package body Keccak.Generic_MonkeyDuplex is
       end if;
 
       XOR_Padding_Into_State (A         => Ctx.State,
-                              First_Bit => In_Data_Bit_Length,
+                              First_Bit => In_Data_Bit_Length + Suffix_Bit_Length,
                               Last_Bit  => Rate_Of (Ctx) - 1);
 
       Permute_Stride (Ctx.State);

--- a/src/common/keccak-generic_monkeyduplex.adb
+++ b/src/common/keccak-generic_monkeyduplex.adb
@@ -1,0 +1,160 @@
+-------------------------------------------------------------------------------
+--  Copyright (c) 2019, Daniel King
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--      * Redistributions of source code must retain the above copyright
+--        notice, this list of conditions and the following disclaimer.
+--      * Redistributions in binary form must reproduce the above copyright
+--        notice, this list of conditions and the following disclaimer in the
+--        documentation and/or other materials provided with the distribution.
+--      * The name of the copyright holder may not be used to endorse or promote
+--        Products derived from this software without specific prior written
+--        permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+--  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+--  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+--  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+--  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+--  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+--  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+with Interfaces; use Interfaces;
+
+package body Keccak.Generic_MonkeyDuplex is
+
+   -------------
+   --  Start  --
+   -------------
+
+   procedure Start (Ctx      :    out Context;
+                    Rate     : in     Rate_Bits_Number;
+                    Data     : in     Keccak.Types.Byte_Array;
+                    Bit_Len  : in     Natural) is
+   begin
+      Ctx.Rate := Rate;
+      Init_State (Ctx.State);
+
+      XOR_Bits_Into_State (A       => Ctx.State,
+                           Data    => Data,
+                           Bit_Len => Bit_Len);
+
+      XOR_Padding_Into_State (A         => Ctx.State,
+                              First_Bit => Bit_Len,
+                              Last_Bit  => Rate_Of (Ctx) - 1);
+
+      Permute_Start (Ctx.State);
+   end Start;
+
+   function Start (Rate     : in     Rate_Bits_Number;
+                   Data     : in     Keccak.Types.Byte_Array;
+                   Bit_Len  : in     Natural) return Context is
+   begin
+      return Ctx : Context do
+         Start (Ctx, Rate, Data, Bit_Len);
+      end return;
+   end Start;
+
+   ------------
+   --  Step  --
+   ------------
+
+   procedure Step (Ctx                 : in out Context;
+                   In_Data             : in     Keccak.Types.Byte_Array;
+                   In_Data_Bit_Length  : in     Natural;
+                   Suffix              : in     Keccak.Types.Byte;
+                   Suffix_Bit_Length   : in     Natural;
+                   Out_Data            :    out Keccak.Types.Byte_Array;
+                   Out_Data_Bit_Length : in     Natural) is
+   begin
+      Step_Mute (Ctx                => Ctx,
+                 In_Data            => In_Data,
+                 In_Data_Bit_Length => In_Data_Bit_Length,
+                 Suffix             => Suffix,
+                 Suffix_Bit_Length  => Suffix_Bit_Length);
+
+      Extract_Bits (A       => Ctx.State,
+                    Data    => Out_Data,
+                    Bit_Len => Out_Data_Bit_Length);
+   end Step;
+
+   -----------------
+   --  Step_Mute  --
+   -----------------
+
+   procedure Step_Mute (Ctx                 : in out Context;
+                        In_Data             : in     Keccak.Types.Byte_Array;
+                        In_Data_Bit_Length  : in     Natural;
+                        Suffix              : in     Keccak.Types.Byte;
+                        Suffix_Bit_Length   : in     Natural) is
+
+      First_Suffix_Byte : constant Natural := In_Data_Bit_Length / 8;
+      Last_Suffix_Byte  : constant Natural := (In_Data_Bit_Length + Suffix_Bit_Length - 1) / 8;
+
+   begin
+      XOR_Bits_Into_State (Ctx.State, In_Data, In_Data_Bit_Length);
+
+      XOR_Byte_Into_State (A      => Ctx.State,
+                           Offset => First_Suffix_Byte,
+                           Value  => Shift_Left (Suffix, In_Data_Bit_Length mod 8));
+
+      if Last_Suffix_Byte /= First_Suffix_Byte then
+         XOR_Byte_Into_State (A      => Ctx.State,
+                              Offset => Last_Suffix_Byte,
+                              Value  => Shift_Right (Suffix, 8 - In_Data_Bit_Length mod 8));
+      end if;
+
+      XOR_Padding_Into_State (A         => Ctx.State,
+                              First_Bit => In_Data_Bit_Length + Suffix_Bit_Length,
+                              Last_Bit  => Rate_Of (Ctx) - 1);
+
+      Permute_Step (Ctx.State);
+
+   end Step_Mute;
+
+   --------------
+   --  Stride  --
+   --------------
+
+   procedure Stride (Ctx                 : in out Context;
+                     In_Data             : in     Keccak.Types.Byte_Array;
+                     In_Data_Bit_Length  : in     Natural;
+                     Suffix              : in     Keccak.Types.Byte;
+                     Suffix_Bit_Length   : in     Natural;
+                     Out_Data            :    out Keccak.Types.Byte_Array;
+                     Out_Data_Bit_Length : in     Natural) is
+
+      First_Suffix_Byte : constant Natural := In_Data_Bit_Length / 8;
+      Last_Suffix_Byte  : constant Natural := (In_Data_Bit_Length + Suffix_Bit_Length - 1) / 8;
+
+   begin
+      XOR_Bits_Into_State (Ctx.State, In_Data, In_Data_Bit_Length);
+
+      XOR_Byte_Into_State (A      => Ctx.State,
+                           Offset => First_Suffix_Byte,
+                           Value  => Shift_Left (Suffix, In_Data_Bit_Length mod 8));
+
+      if Last_Suffix_Byte /= First_Suffix_Byte then
+         XOR_Byte_Into_State (A      => Ctx.State,
+                              Offset => Last_Suffix_Byte,
+                              Value  => Shift_Right (Suffix, 8 - In_Data_Bit_Length mod 8));
+      end if;
+
+      XOR_Padding_Into_State (A         => Ctx.State,
+                              First_Bit => In_Data_Bit_Length,
+                              Last_Bit  => Rate_Of (Ctx) - 1);
+
+      Permute_Stride (Ctx.State);
+
+      Extract_Bits (A       => Ctx.State,
+                    Data    => Out_Data,
+                    Bit_Len => Out_Data_Bit_Length);
+   end Stride;
+
+end Keccak.Generic_MonkeyDuplex;

--- a/src/common/keccak-generic_monkeyduplex.adb
+++ b/src/common/keccak-generic_monkeyduplex.adb
@@ -111,7 +111,7 @@ package body Keccak.Generic_MonkeyDuplex is
       if Last_Suffix_Byte /= First_Suffix_Byte then
          XOR_Byte_Into_State (A      => Ctx.State,
                               Offset => Last_Suffix_Byte,
-                              Value  => Shift_Right (Suffix, 8 - In_Data_Bit_Length mod 8));
+                              Value  => Shift_Right (Suffix, 8 - (In_Data_Bit_Length mod 8)));
       end if;
 
       XOR_Padding_Into_State (A         => Ctx.State,
@@ -147,7 +147,7 @@ package body Keccak.Generic_MonkeyDuplex is
       if Last_Suffix_Byte /= First_Suffix_Byte then
          XOR_Byte_Into_State (A      => Ctx.State,
                               Offset => Last_Suffix_Byte,
-                              Value  => Shift_Right (Suffix, 8 - In_Data_Bit_Length mod 8));
+                              Value  => Shift_Right (Suffix, 8 - (In_Data_Bit_Length mod 8)));
       end if;
 
       XOR_Padding_Into_State (A         => Ctx.State,

--- a/src/common/keccak-generic_monkeyduplex.ads
+++ b/src/common/keccak-generic_monkeyduplex.ads
@@ -70,7 +70,7 @@ package Keccak.Generic_MonkeyDuplex is
                     Bit_Len  : in     Natural)
      with Global => null,
      Pre => (Rate > Min_Padding_Bits
-             and then Bit_Len <= Rate - Min_Padding_Bits
+             and then Bit_Len <= State_Size_Bits - Min_Padding_Bits
              and then Data'Length >= (Bit_Len + 7) / 8),
      Post => Rate_Of (Ctx) = Rate;
 
@@ -79,7 +79,7 @@ package Keccak.Generic_MonkeyDuplex is
                    Bit_Len  : in     Natural) return Context
      with Global => null,
      Pre => (Rate > Min_Padding_Bits
-             and then Bit_Len <= Rate - Min_Padding_Bits
+             and then Bit_Len <= State_Size_Bits - Min_Padding_Bits
              and then Data'Length >= (Bit_Len + 7) / 8),
      Post => Rate_Of (Start'Result) = Rate;
 

--- a/src/common/keccak-generic_monkeyduplex.ads
+++ b/src/common/keccak-generic_monkeyduplex.ads
@@ -1,0 +1,174 @@
+-------------------------------------------------------------------------------
+--  Copyright (c) 2019, Daniel King
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--      * Redistributions of source code must retain the above copyright
+--        notice, this list of conditions and the following disclaimer.
+--      * Redistributions in binary form must reproduce the above copyright
+--        notice, this list of conditions and the following disclaimer in the
+--        documentation and/or other materials provided with the distribution.
+--      * The name of the copyright holder may not be used to endorse or promote
+--        Products derived from this software without specific prior written
+--        permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+--  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+--  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+--  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+--  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+--  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+--  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+with Keccak.Types;
+
+generic
+   --  Size of the Duplex state in bits (e.g. 1600 for Keccak[1600])
+   State_Size_Bits : Positive;
+
+   type State_Type is private;
+
+   with procedure Init_State (A : out State_Type);
+
+   with procedure Permute_Start (A : in out State_Type);
+   with procedure Permute_Step (A : in out State_Type);
+   with procedure Permute_Stride (A : in out State_Type);
+
+   --  Procedure to XOR bits into the generic state.
+   with procedure XOR_Bits_Into_State (A       : in out State_Type;
+                                       Data    : in     Keccak.Types.Byte_Array;
+                                       Bit_Len : in     Natural);
+
+   with procedure XOR_Byte_Into_State (A      : in out State_Type;
+                                       Offset : in Natural;
+                                       Value  : in Keccak.Types.Byte);
+
+   with procedure Extract_Bits (A       : in     State_Type;
+                                Data    :    out Keccak.Types.Byte_Array;
+                                Bit_Len : in     Natural);
+
+   with procedure XOR_Padding_Into_State (A         : in out State_Type;
+                                          First_Bit : in     Natural;
+                                          Last_Bit  : in     Natural);
+
+   Min_Padding_Bits : Natural;
+
+package Keccak.Generic_MonkeyDuplex is
+
+   subtype Rate_Bits_Number is Positive range 1 .. State_Size_Bits - Min_Padding_Bits - 1;
+
+   type Context is private;
+
+   procedure Start (Ctx      :    out Context;
+                    Rate     : in     Rate_Bits_Number;
+                    Data     : in     Keccak.Types.Byte_Array;
+                    Bit_Len  : in     Natural)
+     with Global => null,
+     Pre => (Rate > Min_Padding_Bits
+             and then Bit_Len <= Rate - Min_Padding_Bits
+             and then Data'Length >= (Bit_Len + 7) / 8),
+     Post => Rate_Of (Ctx) = Rate;
+
+   function Start (Rate     : in     Rate_Bits_Number;
+                   Data     : in     Keccak.Types.Byte_Array;
+                   Bit_Len  : in     Natural) return Context
+     with Global => null,
+     Pre => (Rate > Min_Padding_Bits
+             and then Bit_Len <= Rate - Min_Padding_Bits
+             and then Data'Length >= (Bit_Len + 7) / 8),
+     Post => Rate_Of (Start'Result) = Rate;
+
+   procedure Step (Ctx                 : in out Context;
+                   In_Data             : in     Keccak.Types.Byte_Array;
+                   In_Data_Bit_Length  : in     Natural;
+                   Suffix              : in     Keccak.Types.Byte;
+                   Suffix_Bit_Length   : in     Natural;
+                   Out_Data            :    out Keccak.Types.Byte_Array;
+                   Out_Data_Bit_Length : in     Natural)
+     with Global => null,
+     Depends => (Ctx      => (Ctx,
+                              In_Data,
+                              In_Data_Bit_Length,
+                              Suffix,
+                              Suffix_Bit_Length),
+                 Out_Data => (Ctx,
+                              In_Data,
+                              In_Data_Bit_Length,
+                              Suffix,
+                              Suffix_Bit_Length,
+                              Out_Data,
+                              Out_Data_Bit_Length)),
+     Pre => (In_Data_Bit_Length <= Rate_Of (Ctx) - Min_Padding_Bits
+             and then Suffix_Bit_Length <= 8
+             and then In_Data_Bit_Length + Suffix_Bit_Length <= Rate_Of (Ctx) - Min_Padding_Bits
+             and then In_Data'Length >= (In_Data_Bit_Length + 7) / 8
+             and then Out_Data_Bit_Length <= Rate_Of (Ctx)
+             and then Out_Data'Length = (Out_Data_Bit_Length + 7) / 8),
+     Post => (Rate_Of (Ctx) = Rate_Of (Ctx'Old));
+
+   procedure Step_Mute (Ctx                 : in out Context;
+                        In_Data             : in     Keccak.Types.Byte_Array;
+                        In_Data_Bit_Length  : in     Natural;
+                        Suffix              : in     Keccak.Types.Byte;
+                        Suffix_Bit_Length   : in     Natural)
+     with Global => null,
+     Depends => (Ctx      => (Ctx,
+                              In_Data,
+                              In_Data_Bit_Length,
+                              Suffix,
+                              Suffix_Bit_Length)),
+     Pre => (In_Data_Bit_Length <= Rate_Of (Ctx) - Min_Padding_Bits
+             and then Suffix_Bit_Length <= 8
+             and then In_Data_Bit_Length + Suffix_Bit_Length <= Rate_Of (Ctx) - Min_Padding_Bits
+             and then In_Data'Length >= (In_Data_Bit_Length + 7) / 8),
+     Post => (Rate_Of (Ctx) = Rate_Of (Ctx'Old));
+
+   procedure Stride (Ctx                 : in out Context;
+                     In_Data             : in     Keccak.Types.Byte_Array;
+                     In_Data_Bit_Length  : in     Natural;
+                     Suffix              : in     Keccak.Types.Byte;
+                     Suffix_Bit_Length   : in     Natural;
+                     Out_Data            :    out Keccak.Types.Byte_Array;
+                     Out_Data_Bit_Length : in     Natural)
+     with Global => null,
+     Depends => (Ctx      => (Ctx,
+                              In_Data,
+                              In_Data_Bit_Length,
+                              Suffix,
+                              Suffix_Bit_Length),
+                 Out_Data => (Ctx,
+                              In_Data,
+                              In_Data_Bit_Length,
+                              Suffix,
+                              Suffix_Bit_Length,
+                              Out_Data,
+                              Out_Data_Bit_Length)),
+     Pre => (In_Data_Bit_Length <= Rate_Of (Ctx) - Min_Padding_Bits
+             and then Suffix_Bit_Length <= 8
+             and then In_Data_Bit_Length + Suffix_Bit_Length <= Rate_Of (Ctx) - Min_Padding_Bits
+             and then In_Data'Length >= (In_Data_Bit_Length + 7) / 8
+             and then Out_Data_Bit_Length <= Rate_Of (Ctx)
+             and then Out_Data'Length = (Out_Data_Bit_Length + 7) / 8),
+     Post => (Rate_Of (Ctx) = Rate_Of (Ctx'Old));
+
+   function Rate_Of (Ctx : in Context) return Rate_Bits_Number
+     with Inline,
+     Global => null;
+
+private
+
+   type Context is record
+      State : State_Type;
+      Rate  : Rate_Bits_Number;
+   end record
+     with Predicate => Rate > Min_Padding_Bits;
+
+   function Rate_Of (Ctx : in Context) return Rate_Bits_Number is
+     (Ctx.Rate);
+
+end Keccak.Generic_MonkeyDuplex;

--- a/src/common/keccak-generic_monkeyduplex.ads
+++ b/src/common/keccak-generic_monkeyduplex.ads
@@ -60,7 +60,7 @@ generic
 
 package Keccak.Generic_MonkeyDuplex is
 
-   subtype Rate_Bits_Number is Positive range 1 .. State_Size_Bits - Min_Padding_Bits - 1;
+   subtype Rate_Bits_Number is Positive range Min_Padding_Bits + 1 .. State_Size_Bits - 1;
 
    type Context is private;
 
@@ -69,8 +69,7 @@ package Keccak.Generic_MonkeyDuplex is
                     Data     : in     Keccak.Types.Byte_Array;
                     Bit_Len  : in     Natural)
      with Global => null,
-     Pre => (Rate > Min_Padding_Bits
-             and then Bit_Len <= State_Size_Bits - Min_Padding_Bits
+     Pre => (Bit_Len <= State_Size_Bits - Min_Padding_Bits
              and then Data'Length >= (Bit_Len + 7) / 8),
      Post => Rate_Of (Ctx) = Rate;
 
@@ -78,8 +77,7 @@ package Keccak.Generic_MonkeyDuplex is
                    Data     : in     Keccak.Types.Byte_Array;
                    Bit_Len  : in     Natural) return Context
      with Global => null,
-     Pre => (Rate > Min_Padding_Bits
-             and then Bit_Len <= State_Size_Bits - Min_Padding_Bits
+     Pre => (Bit_Len <= State_Size_Bits - Min_Padding_Bits
              and then Data'Length >= (Bit_Len + 7) / 8),
      Post => Rate_Of (Start'Result) = Rate;
 

--- a/src/common/keccak-generic_monkeywrap.adb
+++ b/src/common/keccak-generic_monkeywrap.adb
@@ -97,8 +97,8 @@ package body Keccak.Generic_MonkeyWrap is
             Ctx.In_Data (Ctx.In_Data_Length .. Ctx.In_Data_Length + (Remaining_In_Chunk - 1)) :=
               Data (Data'First .. Data'First + (Remaining_In_Chunk - 1));
 
-            Offset             := Offset           + Remaining_In_Chunk;
-            Remaining          := Remaining        - Remaining_In_Chunk;
+            Offset             := Offset             + Remaining_In_Chunk;
+            Remaining          := Remaining          - Remaining_In_Chunk;
             Ctx.In_Data_Length := Ctx.In_Data_Length + Remaining_In_Chunk;
 
             pragma Assert (Ctx.In_Data_Length = Block_Size_Bytes);
@@ -115,6 +115,7 @@ package body Keccak.Generic_MonkeyWrap is
 
          else
             Ctx.In_Data (Ctx.In_Data_Length .. Ctx.In_Data_Length + Remaining - 1) := Data;
+            Ctx.In_Data_Length := Ctx.In_Data_Length + Remaining;
 
             Offset    := Remaining;
             Remaining := 0;

--- a/src/common/keccak-generic_monkeywrap.adb
+++ b/src/common/keccak-generic_monkeywrap.adb
@@ -1,0 +1,559 @@
+-------------------------------------------------------------------------------
+--  Copyright (c) 2019, Daniel King
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--      * Redistributions of source code must retain the above copyright
+--        notice, this list of conditions and the following disclaimer.
+--      * Redistributions in binary form must reproduce the above copyright
+--        notice, this list of conditions and the following disclaimer in the
+--        documentation and/or other materials provided with the distribution.
+--      * The name of the copyright holder may not be used to endorse or promote
+--        Products derived from this software without specific prior written
+--        permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+--  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+--  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+--  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+--  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+--  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+--  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+with Interfaces; use Interfaces;
+
+package body Keccak.Generic_MonkeyWrap is
+
+   ------------
+   --  Init  --
+   ------------
+
+   procedure Init (Ctx   :    out Context;
+                   Key   : in     Keccak.Types.Byte_Array;
+                   Nonce : in     Keccak.Types.Byte_Array) is
+
+      Block : Keccak.Types.Byte_Array (1 .. 1 + Key'Length + 2 + Nonce'Length);
+      --  Combines the packed Key & Nonce.
+
+      Rate : MonkeyDuplex.Rate_Bits_Number;
+
+   begin
+      --  keypack(Key, |Key| + 16)
+      Block (1)                                := Key'Length + 2;
+      Block (2 .. Key'Length + 1)              := Key;
+      Block (Key'Length + 2 .. Key'Length + 3) := (16#01#, 16#00#);
+
+      Block (Key'Length + 4 .. Block'Last)     := Nonce;
+
+      Rate := (Block_Size_Bytes * 8) + MonkeyDuplex.Min_Padding_Bits + 2;
+
+      Ctx := (Inner_Ctx       => MonkeyDuplex.Start (Rate     => Rate,
+                                                     Data     => Block,
+                                                     Bit_Len  => Block'Length * 8),
+              Current_State   => Auth_Data,
+              In_Data         => (others => 0),
+              In_Data_Length  => 0,
+              Keystream       => (others => 0),
+              Tag_Accumulator => 0);
+
+      pragma Annotate (GNATprove, False_Positive,
+                       """Block"" might not be initialized",
+                       "Block is initialised in parts, which confuses GNATprove");
+   end Init;
+
+   ------------------------
+   --  Update_Auth_Data  --
+   ------------------------
+
+   procedure Update_Auth_Data (Ctx  : in out Context;
+                               Data : in     Keccak.Types.Byte_Array) is
+
+      Offset    : Natural := 0;
+      Remaining : Natural := Data'Length;
+
+      Pos : Natural;
+
+      Remaining_In_Chunk : Natural;
+
+      Initial_In_Data_Length : constant Block_Byte_Count := Ctx.In_Data_Length with Ghost;
+
+   begin
+      --  Concatenate the data with the previous leftover bytes.
+      if Ctx.In_Data_Length > 0 then
+         Remaining_In_Chunk := Block_Size_Bytes - Ctx.In_Data_Length;
+
+         if Remaining >= Remaining_In_Chunk then
+            Ctx.In_Data (Ctx.In_Data_Length .. Ctx.In_Data_Length + (Remaining_In_Chunk - 1)) :=
+              Data (Data'First .. Data'First + (Remaining_In_Chunk - 1));
+
+            Offset           := Offset           + Remaining_In_Chunk;
+            Remaining        := Remaining        - Remaining_In_Chunk;
+            Ctx.In_Data_Length := Ctx.In_Data_Length + Remaining_In_Chunk;
+
+            pragma Assert (Ctx.In_Data_Length = Block_Size_Bytes);
+
+            if Remaining > 0 then
+               MonkeyDuplex.Step_Mute (Ctx                 => Ctx.Inner_Ctx,
+                                       In_Data             => Ctx.In_Data,
+                                       In_Data_Bit_Length  => Block_Size_Bytes * 8,
+                                       Suffix              => 2#00#,
+                                       Suffix_Bit_Length   => 2);
+
+               Ctx.In_Data_Length := 0;
+            end if;
+
+         else
+            Ctx.In_Data (Ctx.In_Data_Length .. Ctx.In_Data_Length + Remaining - 1) := Data;
+
+            Offset    := Remaining;
+            Remaining := 0;
+         end if;
+      end if;
+
+      pragma Assert (if Remaining = 0 then Ctx.In_Data_Length >= Initial_In_Data_Length);
+
+      --  Process complete blocks, but don't process last block if it is
+      --  a complete block.
+      while Remaining > Block_Size_Bytes loop
+         pragma Loop_Variant (Increases => Offset,
+                              Decreases => Remaining);
+         pragma Loop_Invariant (Ctx.In_Data_Length = 0
+                                and Offset + Remaining = Data'Length);
+
+         Pos := Data'First + Offset;
+
+         MonkeyDuplex.Step_Mute
+           (Ctx                => Ctx.Inner_Ctx,
+            In_Data            => Data (Pos .. Pos + Block_Size_Bytes - 1),
+            In_Data_Bit_Length => Block_Size_Bytes * 8,
+            Suffix             => 2#00#,
+            Suffix_Bit_Length  => 2);
+
+         Offset    := Offset    + Block_Size_Bytes;
+         Remaining := Remaining - Block_Size_Bytes;
+      end loop;
+
+      --  Save the last (partial or full) block.
+      --  Even if this is a full block, we don't process it yet because we
+      --  don't yet know if this is the last block of authenticated data or not
+      --  which determines the suffix value to use.
+      --  (there may be additional calls to Update_Auth_Data).
+      if Remaining > 0 then
+         pragma Assert (Remaining <= Block_Size_Bytes);
+
+         Ctx.In_Data_Length := Remaining;
+         Ctx.In_Data (0 .. Remaining - 1) := Data (Data'First + Offset .. Data'Last);
+      end if;
+
+   end Update_Auth_Data;
+
+   ----------------------
+   --  Update_Encrypt  --
+   ----------------------
+
+   procedure Update_Encrypt (Ctx        : in out Context;
+                             Plaintext  : in     Keccak.Types.Byte_Array;
+                             Ciphertext :    out Keccak.Types.Byte_Array) is
+
+      Offset    : Natural := 0;
+      Remaining : Natural := Plaintext'Length;
+
+      Remaining_Keystream : Natural;
+
+      PT_Pos : Keccak.Types.Index_Number;
+      CT_Pos : Keccak.Types.Index_Number;
+
+   begin
+
+      --  Process last block of AAD, if needed.
+      if Ctx.Current_State = Auth_Data then
+         --  Process final block of auth data to generate first Keystream bits.
+
+         MonkeyDuplex.Step (Ctx                 => Ctx.Inner_Ctx,
+                            In_Data             => Ctx.In_Data,
+                            In_Data_Bit_Length  => Ctx.In_Data_Length * 8,
+                            Suffix              => 2#01#,
+                            Suffix_Bit_Length   => 2,
+                            Out_Data            => Ctx.Keystream (0 .. Block_Size_Bytes - 1),
+                            Out_Data_Bit_Length => Block_Size_Bytes * 8);
+
+         Ctx.In_Data_Length := 0;
+         Ctx.Current_State  := Encrypting;
+      end if;
+
+      pragma Assert (Offset + Remaining = Plaintext'Length);
+
+      --  Concatenate plaintext with leftover plaintext from previous call to Encrypt.
+      if Ctx.In_Data_Length > 0 and Remaining > 0 then
+         Remaining_Keystream := Block_Size_Bytes - Ctx.In_Data_Length;
+
+         if Remaining_Keystream <= Plaintext'Length then
+
+            --  Use all remaining keystream bytes to produce the ciphertext.
+            for I in 0 .. Remaining_Keystream - 1 loop
+               Ciphertext (Ciphertext'First + I) :=
+                 Plaintext (Plaintext'First + I)
+                 xor Ctx.Keystream (I);
+            end loop;
+
+            --  Concatenate the plaintext with the previous leftover plaintext
+
+            PT_Pos := Plaintext'First + Offset;
+
+            Ctx.In_Data (Ctx.In_Data_Length .. Ctx.In_Data_Length + Remaining_Keystream - 1) :=
+              Plaintext (PT_Pos .. PT_Pos + Remaining_Keystream - 1);
+
+            Ctx.In_Data_Length := Ctx.In_Data_Length + Remaining_Keystream;
+            Offset             := Offset             + Remaining_Keystream;
+            Remaining          := Remaining          - Remaining_Keystream;
+
+         else
+
+            for I in 0 .. Remaining - 1 loop
+               Ciphertext (Ciphertext'First + I) :=
+                 Plaintext (Plaintext'First + I)
+                 xor Ctx.Keystream (I);
+            end loop;
+
+            PT_Pos := Plaintext'First + Offset;
+
+            Ctx.In_Data (Ctx.In_Data_Length .. Ctx.In_Data_Length + Remaining - 1) :=
+              Plaintext (PT_Pos .. PT_Pos + Remaining - 1);
+
+            Ctx.In_Data_Length := Ctx.In_Data_Length + Remaining;
+            Offset             := Offset + Remaining;
+            Remaining          := 0;
+
+         end if;
+      end if;
+
+      if Remaining > 0 then
+         pragma Assert (Ctx.In_Data_Length in 0 | Block_Size_Bytes);
+
+         if Ctx.In_Data_Length = Block_Size_Bytes then
+            MonkeyDuplex.Step
+              (Ctx                 => Ctx.Inner_Ctx,
+               In_Data             => Ctx.In_Data (0 .. Block_Size_Bytes - 1),
+               In_Data_Bit_Length  => Block_Size_Bytes * 8,
+               Suffix              => 2#11#,
+               Suffix_Bit_Length   => 2,
+               Out_Data            => Ctx.Keystream (0 .. Block_Size_Bytes - 1),
+               Out_Data_Bit_Length => Block_Size_Bytes * 8);
+
+            Ctx.In_Data_Length := 0;
+         end if;
+
+         --  Process full blocks.
+         while Remaining > Block_Size_Bytes loop
+            pragma Loop_Variant (Increases => Offset,
+                                 Decreases => Remaining);
+            pragma Loop_Invariant (Offset + Remaining = Plaintext'Length
+                                   and Ctx.In_Data_Length = 0);
+
+            PT_Pos := Plaintext'First  + Offset;
+            CT_Pos := Ciphertext'First + Offset;
+
+            for I in 0 .. Block_Size_Bytes - 1 loop
+               Ciphertext (CT_Pos + I) := Plaintext (PT_Pos + I) xor Ctx.Keystream (I);
+            end loop;
+
+            MonkeyDuplex.Step
+              (Ctx                 => Ctx.Inner_Ctx,
+               In_Data             => Plaintext (PT_Pos .. PT_Pos + Block_Size_Bytes),
+               In_Data_Bit_Length  => Block_Size_Bytes * 8,
+               Suffix              => 2#11#,
+               Suffix_Bit_Length   => 2,
+               Out_Data            => Ctx.Keystream (0 .. Block_Size_Bytes - 1),
+               Out_Data_Bit_Length => Block_Size_Bytes * 8);
+
+            Offset    := Offset    + Block_Size_Bytes;
+            Remaining := Remaining - Block_Size_Bytes;
+         end loop;
+
+         --  Process last block.
+         if Remaining > 0 then
+
+            PT_Pos := Plaintext'First  + Offset;
+            CT_Pos := Ciphertext'First + Offset;
+
+            for I in 0 .. Remaining - 1 loop
+               Ciphertext (CT_Pos + I) := Plaintext (PT_Pos + I) xor Ctx.Keystream (I);
+            end loop;
+
+            --  Store last partial/full block of plaintext.
+            --
+            --  Even if we have a full block, we can't process it with MonkeyDuplex
+            --  yet because we don't know if this is the last plaintext block.
+
+            Ctx.In_Data (0 .. Remaining - 1) := Plaintext (PT_Pos .. Plaintext'Last);
+            Ctx.In_Data_Length := Remaining;
+
+         end if;
+      end if;
+
+   end Update_Encrypt;
+
+   ----------------------
+   --  Update_Decrypt  --
+   ----------------------
+
+   procedure Update_Decrypt (Ctx        : in out Context;
+                             Ciphertext : in     Keccak.Types.Byte_Array;
+                             Plaintext  :    out Keccak.Types.Byte_Array) is
+
+      Offset    : Natural := 0;
+      Remaining : Natural := Plaintext'Length;
+
+      Remaining_Keystream : Natural;
+
+      PT_Pos : Keccak.Types.Index_Number;
+      CT_Pos : Keccak.Types.Index_Number;
+
+   begin
+
+      --  Process last block of AAD, if needed.
+      if Ctx.Current_State = Auth_Data then
+         --  Process final block of auth data to generate first Keystream bits.
+
+         MonkeyDuplex.Step (Ctx                 => Ctx.Inner_Ctx,
+                            In_Data             => Ctx.In_Data,
+                            In_Data_Bit_Length  => Ctx.In_Data_Length * 8,
+                            Suffix              => 2#01#,
+                            Suffix_Bit_Length   => 2,
+                            Out_Data            => Ctx.Keystream (0 .. Block_Size_Bytes - 1),
+                            Out_Data_Bit_Length => Block_Size_Bytes * 8);
+
+         Ctx.In_Data_Length := 0;
+         Ctx.Current_State  := Decrypting;
+      end if;
+
+      pragma Assert (Offset + Remaining = Plaintext'Length);
+
+      --  Concatenate plaintext with leftover plaintext from previous call to Encrypt.
+      if Ctx.In_Data_Length > 0 and Remaining > 0 then
+         Remaining_Keystream := Block_Size_Bytes - Ctx.In_Data_Length;
+
+         if Remaining_Keystream <= Plaintext'Length then
+
+            --  Use all remaining keystream bytes to produce the ciphertext.
+            for I in 0 .. Remaining_Keystream - 1 loop
+               Plaintext (Plaintext'First + I) :=
+                 Ciphertext (Ciphertext'First + I)
+                 xor Ctx.Keystream (I);
+            end loop;
+
+            --  Concatenate the plaintext with the previous leftover plaintext
+
+            PT_Pos := Plaintext'First + Offset;
+
+            Ctx.In_Data (Ctx.In_Data_Length .. Ctx.In_Data_Length + Remaining_Keystream - 1) :=
+              Plaintext (PT_Pos .. PT_Pos + Remaining_Keystream - 1);
+
+            pragma Annotate (GNATprove, False_Positive,
+                             """Plaintext"" might not be initialized",
+                             "The plaintext slice used is initialized in the preceding loop");
+
+            Ctx.In_Data_Length := Ctx.In_Data_Length + Remaining_Keystream;
+            Offset             := Offset             + Remaining_Keystream;
+            Remaining          := Remaining          - Remaining_Keystream;
+
+         else
+
+            for I in 0 .. Remaining - 1 loop
+               Plaintext (Plaintext'First + I) :=
+                 Ciphertext (Ciphertext'First + I)
+                 xor Ctx.Keystream (I);
+            end loop;
+
+            PT_Pos := Plaintext'First + Offset;
+
+            Ctx.In_Data (Ctx.In_Data_Length .. Ctx.In_Data_Length + Remaining - 1) :=
+              Plaintext (PT_Pos .. PT_Pos + Remaining - 1);
+
+            pragma Annotate (GNATprove, False_Positive,
+                             """Plaintext"" might not be initialized",
+                             "The plaintext slice used is initialized in the preceding loop");
+
+            Ctx.In_Data_Length := Ctx.In_Data_Length + Remaining;
+            Offset             := Offset + Remaining;
+            Remaining          := 0;
+
+         end if;
+      end if;
+
+      if Remaining > 0 then
+         pragma Assert (Ctx.In_Data_Length in 0 | Block_Size_Bytes);
+
+         if Ctx.In_Data_Length = Block_Size_Bytes then
+            MonkeyDuplex.Step
+              (Ctx                 => Ctx.Inner_Ctx,
+               In_Data             => Ctx.In_Data (0 .. Block_Size_Bytes - 1),
+               In_Data_Bit_Length  => Block_Size_Bytes * 8,
+               Suffix              => 2#11#,
+               Suffix_Bit_Length   => 2,
+               Out_Data            => Ctx.Keystream (0 .. Block_Size_Bytes - 1),
+               Out_Data_Bit_Length => Block_Size_Bytes * 8);
+
+            Ctx.In_Data_Length := 0;
+         end if;
+
+         --  Process full blocks.
+         while Remaining > Block_Size_Bytes loop
+            pragma Loop_Variant (Increases => Offset,
+                                 Decreases => Remaining);
+            pragma Loop_Invariant (Offset + Remaining = Plaintext'Length
+                                   and Ctx.In_Data_Length = 0);
+
+            PT_Pos := Plaintext'First  + Offset;
+            CT_Pos := Ciphertext'First + Offset;
+
+            for I in 0 .. Block_Size_Bytes - 1 loop
+               Plaintext (PT_Pos + I) := Ciphertext (CT_Pos + I) xor Ctx.Keystream (I);
+            end loop;
+
+            MonkeyDuplex.Step
+              (Ctx                 => Ctx.Inner_Ctx,
+               In_Data             => Plaintext (PT_Pos .. PT_Pos + Block_Size_Bytes),
+               In_Data_Bit_Length  => Block_Size_Bytes * 8,
+               Suffix              => 2#11#,
+               Suffix_Bit_Length   => 2,
+               Out_Data            => Ctx.Keystream (0 .. Block_Size_Bytes - 1),
+               Out_Data_Bit_Length => Block_Size_Bytes * 8);
+
+            pragma Annotate (GNATprove, False_Positive,
+                             """Plaintext"" might not be initialized",
+                             "The plaintext slice used is initialized in the preceding loop");
+
+            Offset    := Offset    + Block_Size_Bytes;
+            Remaining := Remaining - Block_Size_Bytes;
+         end loop;
+
+         --  Process last block.
+         if Remaining > 0 then
+
+            PT_Pos := Plaintext'First  + Offset;
+            CT_Pos := Ciphertext'First + Offset;
+
+            for I in 0 .. Remaining - 1 loop
+               Plaintext (PT_Pos + I) := Ciphertext (CT_Pos + I) xor Ctx.Keystream (I);
+            end loop;
+
+            --  Store last partial/full block of plaintext.
+            --
+            --  Even if we have a full block, we can't process it with MonkeyDuplex
+            --  yet because we don't know if this is the last plaintext block.
+
+            Ctx.In_Data (0 .. Remaining - 1) := Plaintext (PT_Pos .. Plaintext'Last);
+
+            pragma Annotate (GNATprove, False_Positive,
+                             """Plaintext"" might not be initialized",
+                             "The plaintext slice used is initialized in the preceding loop");
+
+            Ctx.In_Data_Length := Remaining;
+
+         end if;
+      end if;
+
+   end Update_Decrypt;
+
+   -------------------
+   --  Extract_Tag  --
+   -------------------
+
+   procedure Extract_Tag (Ctx : in out Context;
+                          Tag :    out Keccak.Types.Byte_Array) is
+
+      Offset    : Natural := 0;
+      Remaining : Natural := Tag'Length;
+
+      Pos : Keccak.Types.Index_Number;
+
+      Remaining_Output : Natural;
+
+   begin
+      if Ctx.Current_State in Auth_Data | Encrypting | Decrypting then
+
+         if Ctx.Current_State = Auth_Data then
+            --  Finish auth data stage
+            MonkeyDuplex.Step_Mute
+              (Ctx                 => Ctx.Inner_Ctx,
+               In_Data             => Ctx.In_Data,
+               In_Data_Bit_Length  => Ctx.In_Data_Length * 8,
+               Suffix              => 2#01#,
+               Suffix_Bit_Length   => 2);
+
+            Ctx.In_Data_Length := 0;
+         end if;
+
+         --  Finish encryption stage.
+         MonkeyDuplex.Stride (Ctx                 => Ctx.Inner_Ctx,
+                              In_Data             => Ctx.In_Data,
+                              In_Data_Bit_Length  => Ctx.In_Data_Length * 8,
+                              Suffix              => 2#10#,
+                              Suffix_Bit_Length   => 2,
+                              Out_Data            => Ctx.Keystream (0 .. Block_Size_Bytes - 1),
+                              Out_Data_Bit_Length => Block_Size_Bytes * 8);
+
+         Ctx.In_Data_Length := 0;
+         Ctx.Current_State  := Extracting_Tag;
+      end if;
+
+      Remaining_Output := Block_Size_Bytes - Ctx.In_Data_Length;
+
+      if Remaining > 0 then
+         --  First, take from the previous leftovers.
+         if Remaining < Remaining_Output then
+            Tag := Ctx.Keystream (Ctx.In_Data_Length .. Ctx.In_Data_Length + Remaining - 1);
+            Ctx.In_Data_Length := Ctx.In_Data_Length + Remaining;
+         else
+
+            Pos := Tag'First + Offset;
+            Tag (Pos .. Pos + Remaining_Output - 1) :=
+              Ctx.Keystream (Ctx.In_Data_Length .. Ctx.In_Data_Length + Remaining_Output - 1);
+
+            Ctx.In_Data_Length := Block_Size_Bytes;
+         end if;
+
+         --  Process full blocks
+         while Remaining >= Block_Size_Bytes loop
+            pragma Loop_Variant (Increases => Offset,
+                                 Decreases => Remaining);
+            pragma Loop_Invariant (Offset + Remaining = Tag'Length);
+
+            Pos := Tag'First + Offset;
+
+            MonkeyDuplex.Step (Ctx                 => Ctx.Inner_Ctx,
+                               In_Data             => Ctx.In_Data,
+                               In_Data_Bit_Length  => 0,
+                               Suffix              => 2#0#,
+                               Suffix_Bit_Length   => 1,
+                               Out_Data            => Tag (Pos .. Pos + Block_Size_Bytes - 1),
+                               Out_Data_Bit_Length => Block_Size_Bytes * 8);
+
+            Offset    := Offset + Block_Size_Bytes;
+            Remaining := Remaining - Block_Size_Bytes;
+         end loop;
+
+         --  Generate last partial block
+         if Remaining > 0 then
+            MonkeyDuplex.Step (Ctx                 => Ctx.Inner_Ctx,
+                               In_Data             => Ctx.In_Data,
+                               In_Data_Bit_Length  => 0,
+                               Suffix              => 2#0#,
+                               Suffix_Bit_Length   => 1,
+                               Out_Data            => Ctx.Keystream (0 .. Block_Size_Bytes - 1),
+                               Out_Data_Bit_Length => Block_Size_Bytes * 8);
+
+            Tag (Tag'First + Offset .. Tag'Last) := Ctx.Keystream (0 .. Remaining - 1);
+
+            Ctx.In_Data_Length := Remaining;
+         end if;
+      end if;
+   end Extract_Tag;
+
+end Keccak.Generic_MonkeyWrap;

--- a/src/common/keccak-generic_monkeywrap.adb
+++ b/src/common/keccak-generic_monkeywrap.adb
@@ -556,4 +556,14 @@ package body Keccak.Generic_MonkeyWrap is
       end if;
    end Extract_Tag;
 
+   -------------------
+   --  New_Session  --
+   -------------------
+
+   procedure New_Session (Ctx : in out Context) is
+   begin
+      Ctx.Current_State  := Auth_Data;
+      Ctx.In_Data_Length := 0;
+   end New_Session;
+
 end Keccak.Generic_MonkeyWrap;

--- a/src/common/keccak-generic_monkeywrap.adb
+++ b/src/common/keccak-generic_monkeywrap.adb
@@ -516,6 +516,9 @@ package body Keccak.Generic_MonkeyWrap is
          if Remaining < Remaining_Output then
             Tag := Ctx.Keystream (Ctx.In_Data_Length .. Ctx.In_Data_Length + Remaining - 1);
             Ctx.In_Data_Length := Ctx.In_Data_Length + Remaining;
+
+            Offset    := Remaining;
+            Remaining := 0;
          else
 
             Pos := Tag'First + Offset;
@@ -523,6 +526,9 @@ package body Keccak.Generic_MonkeyWrap is
               Ctx.Keystream (Ctx.In_Data_Length .. Ctx.In_Data_Length + Remaining_Output - 1);
 
             Ctx.In_Data_Length := Block_Size_Bytes;
+
+            Offset    := Offset    + Remaining_Output;
+            Remaining := Remaining - Remaining_Output;
          end if;
 
          --  Process full blocks

--- a/src/common/keccak-generic_monkeywrap.ads
+++ b/src/common/keccak-generic_monkeywrap.ads
@@ -1,0 +1,178 @@
+-------------------------------------------------------------------------------
+--  Copyright (c) 2019, Daniel King
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--      * Redistributions of source code must retain the above copyright
+--        notice, this list of conditions and the following disclaimer.
+--      * Redistributions in binary form must reproduce the above copyright
+--        notice, this list of conditions and the following disclaimer in the
+--        documentation and/or other materials provided with the distribution.
+--      * The name of the copyright holder may not be used to endorse or promote
+--        Products derived from this software without specific prior written
+--        permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+--  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+--  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+--  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+--  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+--  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+--  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+with Keccak.Generic_MonkeyDuplex;
+with Keccak.Types;
+
+--  @summary
+--  Generic implementation of the MonkeyWrap construction.
+generic
+   Block_Size_Bytes : Positive;
+
+   with package MonkeyDuplex is new Keccak.Generic_MonkeyDuplex (<>);
+package Keccak.Generic_MonkeyWrap is
+
+   Max_Rate_Bits : constant Positive :=
+     MonkeyDuplex.State_Size_Bits - MonkeyDuplex.Min_Padding_Bits;
+   --  Maximum possible rate of the underlying MonkeyDuplex.
+   --
+   --  E.g. for Keccak-p[1600] this is 1600 - 2 = 1598
+
+   Max_Block_Size_Bits : constant Positive := Max_Rate_Bits - 2;
+   --  MonkeyWrap specification requires: 0 < p <= b - 4
+   --
+   --  I.e. the block size does not exceed state size - 4 bits
+   --  (2 bits padding, 2 bits domain separation).
+   --
+   --  E.g. for Keccak-p[1600] this is 1600 - 4 = 1596
+
+   pragma Assert (Block_Size_Bytes <= Max_Block_Size_Bits / 8);
+
+   type State is (Auth_Data,
+                  Encrypting,
+                  Extracting_Tag,
+                  Decrypting,
+                  Verifying_Tag);
+
+   type Context is private;
+
+   procedure Init (Ctx   :    out Context;
+                   Key   : in     Keccak.Types.Byte_Array;
+                   Nonce : in     Keccak.Types.Byte_Array)
+     with Global => null,
+     Depends => (Ctx => (Key, Nonce)),
+     Pre => (Key'Length <= (Max_Rate_Bits / 8) - 3
+             and then Nonce'Length <= Max_Rate_Bits / 8
+             and then Key'Length + 3 + Nonce'Length <= Max_Rate_Bits / 8),
+     Post => State_Of (Ctx) = Auth_Data;
+   --  Initialise the MonkeyWrap context.
+   --
+   --  The combined Key + Nonce length cannot exceed the maximum rate of the
+   --  underlying MonkeyDuplex instance. For example, for Keccak-p[1600] the
+   --  maximum Key + Nonce size is 1574 bits.
+
+   procedure Update_Auth_Data (Ctx  : in out Context;
+                               Data : in     Keccak.Types.Byte_Array)
+     with Global => null,
+     Depends => (Ctx =>+ Data),
+     Pre => State_Of (Ctx) = Auth_Data,
+     Post => State_Of (Ctx) = Auth_Data;
+   --  Process additional authenticated data (AAD).
+   --
+   --  This procedure can be called multiple times to process a large amount
+   --  of AAD (streaming input).
+
+   procedure Update_Encrypt (Ctx        : in out Context;
+                             Plaintext  : in     Keccak.Types.Byte_Array;
+                             Ciphertext :    out Keccak.Types.Byte_Array)
+     with Global => null,
+     Depends => (Ctx        =>+ Plaintext,
+                 Ciphertext =>+ (Ctx, Plaintext)),
+     Pre => (Plaintext'Length = Ciphertext'Length
+             and (State_Of (Ctx) in Auth_Data | Encrypting)),
+     Post => State_Of (Ctx) = Encrypting;
+   pragma Annotate (GNATprove, False_Positive,
+                    """Ciphertext"" might not be initialized",
+                    "Ciphertext is fully initialised by end of procedure");
+   --  Encrypt some plaintext and produce ciphertext.
+   --
+   --  This procedure can be called multiple times to process a large amount
+   --  of streaming ciphertext (streaming encryption).
+
+   procedure Update_Decrypt (Ctx        : in out Context;
+                             Ciphertext : in     Keccak.Types.Byte_Array;
+                             Plaintext  :    out Keccak.Types.Byte_Array)
+     with Global => null,
+     Depends => (Ctx       =>+ (Plaintext, Ciphertext),
+                 Plaintext =>+ (Ctx, Ciphertext)),
+     Pre => (Plaintext'Length = Ciphertext'Length
+             and (State_Of (Ctx) in Auth_Data | Decrypting)),
+     Post => State_Of (Ctx) = Decrypting;
+   pragma Annotate (GNATprove, False_Positive,
+                    """Plaintext"" might not be initialized",
+                    "Plaintext is fully initialised by end of procedure");
+
+   procedure Extract_Tag (Ctx : in out Context;
+                          Tag :    out Keccak.Types.Byte_Array)
+     with Global => null,
+     Depends => (Ctx =>+ Tag,
+                 Tag =>+ Ctx),
+     Pre => (State_Of (Ctx) in Auth_Data | Encrypting | Decrypting | Extracting_Tag),
+     Post => State_Of (Ctx) = Extracting_Tag;
+   pragma Annotate (GNATprove, False_Positive,
+                    """Tag"" might not be initialized",
+                    "Tag is fully initialised by end of procedure");
+   --  Produce the authentication tag.
+   --
+   --  This procedure can be called multiple times to produce a tag of
+   --  arbitrary length (streaming output).
+
+   function State_Of (Ctx : in Context) return State
+     with Global => null;
+
+private
+
+   Additional_Bits : constant Positive := MonkeyDuplex.Min_Padding_Bits + 2;
+
+   subtype Block_Byte_Count is Natural range 0 .. Block_Size_Bytes;
+
+   type Context is record
+      Inner_Ctx     : MonkeyDuplex.Context;
+      --  The inner MonkeyDuplex instance.
+
+      Current_State : State;
+      --  The current context state.
+
+      In_Data         : Keccak.Types.Byte_Array (Block_Byte_Count);
+      --  During AAD, this stores the last partial/full block of AAD.
+      --
+      --  During encryption, this stores the last plaintext block.
+
+      In_Data_Length  : Block_Byte_Count;
+      --  During AAD, this is the size of the pending data in 'In_Data'.
+      --
+      --  During Encryption/Decryption, this is the number of pending plaintext
+      --  bytes that are pending to be processed into MonkeyDuplex.
+      --  The number of remaining Keystream bytes is Block_Size - In_Data_Length.
+
+      Keystream : Keccak.Types.Byte_Array (Block_Byte_Count);
+      --  A block of keystream bits.
+      --
+      --  This is only valid during the encryption/decryption phases.
+
+      Tag_Accumulator : Keccak.Types.Byte;
+
+   end record
+     with Predicate =>
+       (In_Data_Length <= Block_Size_Bytes
+        and Block_Size_Bytes = (MonkeyDuplex.Rate_Of (Inner_Ctx) - Additional_Bits) / 8
+        and (MonkeyDuplex.Rate_Of (Inner_Ctx) - Additional_Bits) mod 8 = 0);
+
+   function State_Of (Ctx : in Context) return State is
+     (Ctx.Current_State);
+
+end Keccak.Generic_MonkeyWrap;

--- a/src/common/keccak-generic_monkeywrap.ads
+++ b/src/common/keccak-generic_monkeywrap.ads
@@ -137,9 +137,10 @@ package Keccak.Generic_MonkeyWrap is
      Post => State_Of (Ctx) = Auth_Data;
    --  Begin a new session.
    --
-   --  This can be called at any time to start a new session. The ciphertext
-   --  and tag generated in the next session depends on all previous sessions
-   --  before it.
+   --  This can be called at any time to start a new session, but is normally
+   --  called after generating or verify the tag. The ciphertexts and tags
+   --  generated in all future sessions depends on all previous sessions before
+   --  it.
 
    function State_Of (Ctx : in Context) return State
      with Global => null;

--- a/src/common/keccak-generic_monkeywrap.ads
+++ b/src/common/keccak-generic_monkeywrap.ads
@@ -131,6 +131,19 @@ package Keccak.Generic_MonkeyWrap is
    --  This procedure can be called multiple times to produce a tag of
    --  arbitrary length (streaming output).
 
+   procedure Verify_Tag (Ctx   : in out Context;
+                         Tag   : in     Keccak.Types.Byte_Array;
+                         Valid :    out Boolean)
+     with Global => null,
+     Depends => (Ctx   =>+ Tag,
+                 Valid => (Ctx, Tag)),
+     Pre => (State_Of (Ctx) in Auth_Data | Encrypting | Decrypting | Verifying_Tag),
+     Post => State_Of (Ctx) = Verifying_Tag;
+   --  Verify whether a tag is valid.
+   --
+   --  This procedure can be called multiple times to verify artbirarily long tags.
+   --  At each call, Valid will be set to the result of the encryption so far.
+
    procedure New_Session (Ctx : in out Context)
      with Global => null,
      Depends => (Ctx =>+ null),

--- a/src/common/keccak-generic_monkeywrap.ads
+++ b/src/common/keccak-generic_monkeywrap.ads
@@ -131,6 +131,16 @@ package Keccak.Generic_MonkeyWrap is
    --  This procedure can be called multiple times to produce a tag of
    --  arbitrary length (streaming output).
 
+   procedure New_Session (Ctx : in out Context)
+     with Global => null,
+     Depends => (Ctx =>+ null),
+     Post => State_Of (Ctx) = Auth_Data;
+   --  Begin a new session.
+   --
+   --  This can be called at any time to start a new session. The ciphertext
+   --  and tag generated in the next session depends on all previous sessions
+   --  before it.
+
    function State_Of (Ctx : in Context) return State
      with Global => null;
 

--- a/src/common/keccak-keccak_100-rounds_12.ads
+++ b/src/common/keccak-keccak_100-rounds_12.ads
@@ -42,7 +42,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_100.State_Size_Bits,
-      State_Type          => KeccakF_100.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_100.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_100_Lanes.XOR_Bits_Into_State,
@@ -51,7 +51,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_100.State_Size_Bits,
-      State_Type          => KeccakF_100.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_100.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_100_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_100-rounds_12.ads
+++ b/src/common/keccak-keccak_100-rounds_12.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_100_Permutation.Permute
-     (First_Round => 12,
-      Num_Rounds  => 12);
+     (Num_Rounds  => 12);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_100.State_Size_Bits,

--- a/src/common/keccak-keccak_100-rounds_16.ads
+++ b/src/common/keccak-keccak_100-rounds_16.ads
@@ -42,7 +42,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_100.State_Size_Bits,
-      State_Type          => KeccakF_100.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_100.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_100_Lanes.XOR_Bits_Into_State,
@@ -51,7 +51,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_100.State_Size_Bits,
-      State_Type          => KeccakF_100.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_100.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_100_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_100-rounds_16.ads
+++ b/src/common/keccak-keccak_100-rounds_16.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_100_Permutation.Permute
-     (First_Round => 8,
-      Num_Rounds  => 16);
+     (Num_Rounds  => 16);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_100.State_Size_Bits,

--- a/src/common/keccak-keccak_100.ads
+++ b/src/common/keccak-keccak_100.ads
@@ -48,6 +48,8 @@ is
       Shift_Right   => Keccak.Types.Shift_Right_4,
       Rotate_Left   => Keccak.Types.Rotate_Left_4);
 
+   subtype State is KeccakF_100.Lane_Complemented_State;
+
    package KeccakF_100_Permutation is new KeccakF_100.Lane_Complementing_Permutation;
 
    package KeccakF_100_Lanes is new KeccakF_100.Bit_Lanes;

--- a/src/common/keccak-keccak_1600-rounds_12.ads
+++ b/src/common/keccak-keccak_1600-rounds_12.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_1600_Permutation.Permute
-     (First_Round => 12,
-      Num_Rounds  => 12);
+     (Num_Rounds  => 12);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_1600.State_Size_Bits,

--- a/src/common/keccak-keccak_1600-rounds_12.ads
+++ b/src/common/keccak-keccak_1600-rounds_12.ads
@@ -42,7 +42,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_1600.State_Size_Bits,
-      State_Type          => KeccakF_1600.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_1600.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_1600_Lanes.XOR_Bits_Into_State,
@@ -51,7 +51,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_1600.State_Size_Bits,
-      State_Type          => KeccakF_1600.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_1600.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_1600_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_1600-rounds_14.ads
+++ b/src/common/keccak-keccak_1600-rounds_14.ads
@@ -42,7 +42,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_1600.State_Size_Bits,
-      State_Type          => KeccakF_1600.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_1600.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_1600_Lanes.XOR_Bits_Into_State,
@@ -51,7 +51,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_1600.State_Size_Bits,
-      State_Type          => KeccakF_1600.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_1600.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_1600_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_1600-rounds_14.ads
+++ b/src/common/keccak-keccak_1600-rounds_14.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_1600_Permutation.Permute
-     (First_Round => 10,
-      Num_Rounds  => 14);
+     (Num_Rounds  => 14);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_1600.State_Size_Bits,

--- a/src/common/keccak-keccak_1600-rounds_24.ads
+++ b/src/common/keccak-keccak_1600-rounds_24.ads
@@ -39,8 +39,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_1600_Permutation.Permute
-     (First_Round => 0,
-      Num_Rounds  => 24);
+     (Num_Rounds  => 24);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_1600.State_Size_Bits,

--- a/src/common/keccak-keccak_1600-rounds_24.ads
+++ b/src/common/keccak-keccak_1600-rounds_24.ads
@@ -26,6 +26,8 @@
 -------------------------------------------------------------------------------
 with Keccak.Generic_Duplex;
 with Keccak.Generic_Sponge;
+with Keccak.Generic_MonkeyDuplex;
+with Keccak.Generic_MonkeyWrap;
 
 pragma Elaborate_All (Keccak.Generic_Duplex);
 pragma Elaborate_All (Keccak.Generic_Sponge);
@@ -42,7 +44,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_1600.State_Size_Bits,
-      State_Type          => KeccakF_1600.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_1600.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_1600_Lanes.XOR_Bits_Into_State,
@@ -51,7 +53,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_1600.State_Size_Bits,
-      State_Type          => KeccakF_1600.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_1600.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_1600_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_1600.ads
+++ b/src/common/keccak-keccak_1600.ads
@@ -51,4 +51,9 @@ is
 
    package KeccakF_1600_Lanes is new KeccakF_1600.Byte_Lanes;
 
+   procedure XOR_Pad101_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
+     (State_Size_Bits     => 1600,
+      State_Type          => KeccakF_1600.Lane_Complemented_State,
+      XOR_Byte_Into_State => KeccakF_1600_Lanes.XOR_Byte_Into_State);
+
 end Keccak.Keccak_1600;

--- a/src/common/keccak-keccak_1600.ads
+++ b/src/common/keccak-keccak_1600.ads
@@ -47,13 +47,15 @@ is
       Shift_Right   => Interfaces.Shift_Right,
       Rotate_Left   => Interfaces.Rotate_Left);
 
+   subtype State is KeccakF_1600.Lane_Complemented_State;
+
    package KeccakF_1600_Permutation is new KeccakF_1600.Lane_Complementing_Permutation;
 
    package KeccakF_1600_Lanes is new KeccakF_1600.Byte_Lanes;
 
    procedure XOR_Pad101_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
      (State_Size_Bits     => 1600,
-      State_Type          => KeccakF_1600.Lane_Complemented_State,
+      State_Type          => State,
       XOR_Byte_Into_State => KeccakF_1600_Lanes.XOR_Byte_Into_State);
 
 end Keccak.Keccak_1600;

--- a/src/common/keccak-keccak_200-rounds_12.ads
+++ b/src/common/keccak-keccak_200-rounds_12.ads
@@ -42,7 +42,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_200.State_Size_Bits,
-      State_Type          => KeccakF_200.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_200.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_200_Lanes.XOR_Bits_Into_State,
@@ -51,7 +51,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_200.State_Size_Bits,
-      State_Type          => KeccakF_200.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_200.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_200_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_200-rounds_12.ads
+++ b/src/common/keccak-keccak_200-rounds_12.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_200_Permutation.Permute
-     (First_Round => 12,
-      Num_Rounds  => 12);
+     (Num_Rounds  => 12);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_200.State_Size_Bits,

--- a/src/common/keccak-keccak_200-rounds_18.ads
+++ b/src/common/keccak-keccak_200-rounds_18.ads
@@ -42,7 +42,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_200.State_Size_Bits,
-      State_Type          => KeccakF_200.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_200.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_200_Lanes.XOR_Bits_Into_State,
@@ -51,7 +51,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_200.State_Size_Bits,
-      State_Type          => KeccakF_200.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_200.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_200_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_200-rounds_18.ads
+++ b/src/common/keccak-keccak_200-rounds_18.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_200_Permutation.Permute
-     (First_Round => 6,
-      Num_Rounds  => 18);
+     (Num_Rounds  => 18);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_200.State_Size_Bits,

--- a/src/common/keccak-keccak_200.ads
+++ b/src/common/keccak-keccak_200.ads
@@ -47,13 +47,15 @@ is
       Shift_Right   => Interfaces.Shift_Right,
       Rotate_Left   => Interfaces.Rotate_Left);
 
+   subtype State is KeccakF_200.Lane_Complemented_State;
+
    package KeccakF_200_Permutation is new KeccakF_200.Lane_Complementing_Permutation;
 
    package KeccakF_200_Lanes is new KeccakF_200.Byte_Lanes;
 
    procedure XOR_Pad101_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
      (State_Size_Bits     => 200,
-      State_Type          => KeccakF_200.State,
+      State_Type          => State,
       XOR_Byte_Into_State => KeccakF_200_Lanes.XOR_Byte_Into_State);
 
 end Keccak.Keccak_200;

--- a/src/common/keccak-keccak_200.ads
+++ b/src/common/keccak-keccak_200.ads
@@ -51,4 +51,9 @@ is
 
    package KeccakF_200_Lanes is new KeccakF_200.Byte_Lanes;
 
+   procedure XOR_Pad101_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
+     (State_Size_Bits     => 200,
+      State_Type          => KeccakF_200.State,
+      XOR_Byte_Into_State => KeccakF_200_Lanes.XOR_Byte_Into_State);
+
 end Keccak.Keccak_200;

--- a/src/common/keccak-keccak_25-rounds_12.ads
+++ b/src/common/keccak-keccak_25-rounds_12.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_25_Permutation.Permute
-     (First_Round => 12,
-      Num_Rounds  => 12);
+     (Num_Rounds  => 12);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_25.State_Size_Bits,

--- a/src/common/keccak-keccak_25-rounds_12.ads
+++ b/src/common/keccak-keccak_25-rounds_12.ads
@@ -42,7 +42,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_25.State_Size_Bits,
-      State_Type          => KeccakF_25.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_25.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_25_Lanes.XOR_Bits_Into_State,
@@ -51,7 +51,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_25.State_Size_Bits,
-      State_Type          => KeccakF_25.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_25.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_25_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_25.ads
+++ b/src/common/keccak-keccak_25.ads
@@ -52,6 +52,8 @@ is
       Shift_Right   => Keccak.Types.Shift_Right_1,
       Rotate_Left   => Keccak.Types.Rotate_Left_1);
 
+   subtype State is KeccakF_25.Lane_Complemented_State;
+
    package KeccakF_25_Permutation is new KeccakF_25.Lane_Complementing_Permutation;
 
    package KeccakF_25_Lanes is new KeccakF_25.Bit_Lanes;

--- a/src/common/keccak-keccak_400-rounds_12.ads
+++ b/src/common/keccak-keccak_400-rounds_12.ads
@@ -41,7 +41,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_400.State_Size_Bits,
-      State_Type          => KeccakF_400.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_400.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_400_Lanes.XOR_Bits_Into_State,
@@ -50,7 +50,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_400.State_Size_Bits,
-      State_Type          => KeccakF_400.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_400.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_400_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_400-rounds_12.ads
+++ b/src/common/keccak-keccak_400-rounds_12.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_400_Permutation.Permute
-     (First_Round => 12,
-      Num_Rounds  => 12);
+     (Num_Rounds  => 12);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_400.State_Size_Bits,

--- a/src/common/keccak-keccak_400-rounds_20.ads
+++ b/src/common/keccak-keccak_400-rounds_20.ads
@@ -42,7 +42,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_400.State_Size_Bits,
-      State_Type          => KeccakF_400.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_400.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_400_Lanes.XOR_Bits_Into_State,
@@ -51,7 +51,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_400.State_Size_Bits,
-      State_Type          => KeccakF_400.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_400.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_400_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_400-rounds_20.ads
+++ b/src/common/keccak-keccak_400-rounds_20.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_400_Permutation.Permute
-     (First_Round => 4,
-      Num_Rounds  => 20);
+     (Num_Rounds  => 20);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_400.State_Size_Bits,

--- a/src/common/keccak-keccak_400.ads
+++ b/src/common/keccak-keccak_400.ads
@@ -47,13 +47,15 @@ is
       Shift_Right   => Interfaces.Shift_Right,
       Rotate_Left   => Interfaces.Rotate_Left);
 
+   subtype State is KeccakF_400.Lane_Complemented_State;
+
    package KeccakF_400_Permutation is new KeccakF_400.Lane_Complementing_Permutation;
 
    package KeccakF_400_Lanes is new KeccakF_400.Byte_Lanes;
 
    procedure XOR_Pad101_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
      (State_Size_Bits     => 400,
-      State_Type          => KeccakF_400.State,
+      State_Type          => State,
       XOR_Byte_Into_State => KeccakF_400_Lanes.XOR_Byte_Into_State);
 
 end Keccak.Keccak_400;

--- a/src/common/keccak-keccak_400.ads
+++ b/src/common/keccak-keccak_400.ads
@@ -51,4 +51,9 @@ is
 
    package KeccakF_400_Lanes is new KeccakF_400.Byte_Lanes;
 
+   procedure XOR_Pad101_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
+     (State_Size_Bits     => 400,
+      State_Type          => KeccakF_400.State,
+      XOR_Byte_Into_State => KeccakF_400_Lanes.XOR_Byte_Into_State);
+
 end Keccak.Keccak_400;

--- a/src/common/keccak-keccak_50-rounds_12.ads
+++ b/src/common/keccak-keccak_50-rounds_12.ads
@@ -41,7 +41,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_50.State_Size_Bits,
-      State_Type          => KeccakF_50.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_50.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_50_Lanes.XOR_Bits_Into_State,
@@ -50,7 +50,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_50.State_Size_Bits,
-      State_Type          => KeccakF_50.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_50.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_50_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_50-rounds_12.ads
+++ b/src/common/keccak-keccak_50-rounds_12.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_50_Permutation.Permute
-     (First_Round => 12,
-      Num_Rounds  => 12);
+     (Num_Rounds  => 12);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_50.State_Size_Bits,

--- a/src/common/keccak-keccak_50-rounds_14.ads
+++ b/src/common/keccak-keccak_50-rounds_14.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_50_Permutation.Permute
-     (First_Round => 10,
-      Num_Rounds  => 14);
+     (Num_Rounds  => 14);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_50.State_Size_Bits,

--- a/src/common/keccak-keccak_50-rounds_14.ads
+++ b/src/common/keccak-keccak_50-rounds_14.ads
@@ -42,7 +42,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_50.State_Size_Bits,
-      State_Type          => KeccakF_50.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_50.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_50_Lanes.XOR_Bits_Into_State,
@@ -51,7 +51,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_50.State_Size_Bits,
-      State_Type          => KeccakF_50.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_50.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_50_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_50.ads
+++ b/src/common/keccak-keccak_50.ads
@@ -48,6 +48,8 @@ is
       Shift_Right   => Keccak.Types.Shift_Right_2,
       Rotate_Left   => Keccak.Types.Rotate_Left_2);
 
+   subtype State is KeccakF_50.Lane_Complemented_State;
+
    package KeccakF_50_Permutation is new KeccakF_50.Lane_Complementing_Permutation;
 
    package KeccakF_50_Lanes is new KeccakF_50.Bit_Lanes;

--- a/src/common/keccak-keccak_800-rounds_12.ads
+++ b/src/common/keccak-keccak_800-rounds_12.ads
@@ -41,7 +41,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_800.State_Size_Bits,
-      State_Type          => KeccakF_800.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_800.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_800_Lanes.XOR_Bits_Into_State,
@@ -50,7 +50,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_800.State_Size_Bits,
-      State_Type          => KeccakF_800.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_800.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_800_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_800-rounds_12.ads
+++ b/src/common/keccak-keccak_800-rounds_12.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_800_Permutation.Permute
-     (First_Round => 12,
-      Num_Rounds  => 12);
+     (Num_Rounds  => 12);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_800.State_Size_Bits,

--- a/src/common/keccak-keccak_800-rounds_22.ads
+++ b/src/common/keccak-keccak_800-rounds_22.ads
@@ -42,7 +42,7 @@ is
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_800.State_Size_Bits,
-      State_Type          => KeccakF_800.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_800.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_800_Lanes.XOR_Bits_Into_State,
@@ -51,7 +51,7 @@ is
 
    package Duplex is new Keccak.Generic_Duplex
      (State_Size_Bits     => KeccakF_800.State_Size_Bits,
-      State_Type          => KeccakF_800.Lane_Complemented_State,
+      State_Type          => State,
       Init_State          => KeccakF_800.Init,
       Permute             => Permute,
       XOR_Bits_Into_State => KeccakF_800_Lanes.XOR_Bits_Into_State,

--- a/src/common/keccak-keccak_800-rounds_22.ads
+++ b/src/common/keccak-keccak_800-rounds_22.ads
@@ -37,8 +37,7 @@ with SPARK_Mode => On
 is
 
    procedure Permute is new KeccakF_800_Permutation.Permute
-     (First_Round => 2,
-      Num_Rounds  => 22);
+     (Num_Rounds  => 22);
 
    package Sponge is new Keccak.Generic_Sponge
      (State_Size_Bits     => KeccakF_800.State_Size_Bits,

--- a/src/common/keccak-keccak_800.ads
+++ b/src/common/keccak-keccak_800.ads
@@ -51,4 +51,9 @@ is
 
    package KeccakF_800_Lanes is new KeccakF_800.Byte_Lanes;
 
+   procedure XOR_Pad101_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
+     (State_Size_Bits     => 800,
+      State_Type          => KeccakF_800.State,
+      XOR_Byte_Into_State => KeccakF_800_Lanes.XOR_Byte_Into_State);
+
 end Keccak.Keccak_800;

--- a/src/common/keccak-keccak_800.ads
+++ b/src/common/keccak-keccak_800.ads
@@ -47,13 +47,15 @@ is
       Shift_Right   => Interfaces.Shift_Right,
       Rotate_Left   => Interfaces.Rotate_Left);
 
+   subtype State is KeccakF_800.Lane_Complemented_State;
+
    package KeccakF_800_Permutation is new KeccakF_800.Lane_Complementing_Permutation;
 
    package KeccakF_800_Lanes is new KeccakF_800.Byte_Lanes;
 
    procedure XOR_Pad101_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
      (State_Size_Bits     => 800,
-      State_Type          => KeccakF_800.State,
+      State_Type          => State,
       XOR_Byte_Into_State => KeccakF_800_Lanes.XOR_Byte_Into_State);
 
 end Keccak.Keccak_800;

--- a/src/common/keccak-padding.adb
+++ b/src/common/keccak-padding.adb
@@ -135,6 +135,10 @@ is
 
    end Pad101_Multi_Blocks;
 
+   -----------------------------
+   --  XOR_Pad101_Into_State  --
+   -----------------------------
+
    procedure XOR_Pad101_Into_State (State     : in out State_Type;
                                     First_Bit : in     Natural;
                                     Last_Bit  : in     Natural) is

--- a/src/common/keccak-padding.adb
+++ b/src/common/keccak-padding.adb
@@ -135,4 +135,17 @@ is
 
    end Pad101_Multi_Blocks;
 
+   procedure XOR_Pad101_Into_State (State     : in out State_Type;
+                                    First_Bit : in     Natural;
+                                    Last_Bit  : in     Natural) is
+   begin
+      XOR_Byte_Into_State (State  => State,
+                           Offset => First_Bit / 8,
+                           Value  => Shift_Left (1, First_Bit mod 8));
+
+      XOR_Byte_Into_State (State  => State,
+                           Offset => Last_Bit / 8,
+                           Value  => Shift_Left (1, Last_Bit mod 8));
+   end XOR_Pad101_Into_State;
+
 end Keccak.Padding;

--- a/src/common/keccak-padding.ads
+++ b/src/common/keccak-padding.ads
@@ -109,4 +109,20 @@ is
    --  @param Max_Bit_Length The maximum bit-size of the block. Padding bits
    --  are applied up to the end of this length.
 
+   generic
+      State_Size_Bits : Positive;
+
+      type State_Type is private;
+
+      with procedure XOR_Byte_Into_State (State  : in out State_Type;
+                                          Offset : in     Natural;
+                                          Value  : in     Keccak.Types.Byte);
+
+   procedure XOR_Pad101_Into_State (State     : in out State_Type;
+                                    First_Bit : in     Natural;
+                                    Last_Bit  : in     Natural)
+     with Global => null,
+     Depends => (State =>+ (First_Bit, Last_Bit)),
+     Pre => (Last_Bit < State_Size_Bits and First_Bit < Last_Bit);
+
 end Keccak.Padding;

--- a/src/common/keccak-util.adb
+++ b/src/common/keccak-util.adb
@@ -238,4 +238,17 @@ is
       return Encoded (Encoded'Last - N .. Encoded'Last);
    end Right_Encode_K12;
 
+   ---------------
+   --  Compare  --
+   ---------------
+
+   procedure Compare (A1          : in     Keccak.Types.Byte_Array;
+                      A2          : in     Keccak.Types.Byte_Array;
+                      Accumulator : in out Keccak.Types.Byte) is
+   begin
+      for I in 0 .. A1'Length - 1 loop
+         Accumulator := Accumulator or (A1 (A1'First + I) xor A2 (A2'First + I));
+      end loop;
+   end Compare;
+
 end Keccak.Util;

--- a/src/common/keccak-util.ads
+++ b/src/common/keccak-util.ads
@@ -131,4 +131,16 @@ is
    --  different to the definition in NIST SP 800-185, and they produce different
    --  outputs.
 
+   procedure Compare (A1          : in     Keccak.Types.Byte_Array;
+                      A2          : in     Keccak.Types.Byte_Array;
+                      Accumulator : in out Keccak.Types.Byte)
+     with Global => null,
+     Depends => (Accumulator =>+ (A1, A2)),
+     Pre => A1'Length = A2'Length;
+   --  Compare two arrays in constant time.
+   --
+   --  If the two arrays are equal, then the Accumulator will retain its
+   --  initial value (e.g. zero). Otherwise, the Accumulator will be set
+   --  to a non-zero value.
+
 end Keccak.Util;

--- a/src/common/ketje.ads
+++ b/src/common/ketje.ads
@@ -60,7 +60,7 @@ is
 
       package MonkeyDuplex_Jr is new Keccak.Generic_MonkeyDuplex
         (State_Size_Bits        => 200,
-         State_Type             => Keccak_200.KeccakF_200.Lane_Complemented_State,
+         State_Type             => Keccak_200.State,
          Init_State             => Keccak_200.KeccakF_200.Init,
          Permute_Start          => Keccak_200.Rounds_12.Permute,
          Permute_Step           => Permute_Jr_Step,
@@ -85,7 +85,7 @@ is
 
       package MonkeyDuplex_Sr is new Keccak.Generic_MonkeyDuplex
         (State_Size_Bits        => 400,
-         State_Type             => Keccak_400.KeccakF_400.Lane_Complemented_State,
+         State_Type             => Keccak_400.State,
          Init_State             => Keccak_400.KeccakF_400.Init,
          Permute_Start          => Keccak_400.Rounds_12.Permute,
          Permute_Step           => Permute_Sr_Step,
@@ -110,7 +110,7 @@ is
 
       package MonkeyDuplex_Minor is new Keccak.Generic_MonkeyDuplex
         (State_Size_Bits        => 800,
-         State_Type             => Keccak_800.KeccakF_800.Lane_Complemented_State,
+         State_Type             => Keccak_800.State,
          Init_State             => Keccak_800.KeccakF_800.Init,
          Permute_Start          => Keccak_800.Rounds_12.Permute,
          Permute_Step           => Permute_Minor_Step,
@@ -135,7 +135,7 @@ is
 
       package MonkeyDuplex_Major is new Keccak.Generic_MonkeyDuplex
         (State_Size_Bits        => 1600,
-         State_Type             => Keccak_1600.KeccakF_1600.Lane_Complemented_State,
+         State_Type             => Keccak_1600.State,
          Init_State             => Keccak_1600.KeccakF_1600.Init,
          Permute_Start          => Keccak_1600.Rounds_12.Permute,
          Permute_Step           => Permute_Major_Step,
@@ -148,11 +148,11 @@ is
 
    end Implementation;
 
-   package Jr    is new Keccak.Generic_MonkeyWrap
+   package Jr is new Keccak.Generic_MonkeyWrap
      (Block_Size_Bytes => 16 / 8,
       MonkeyDuplex     => Implementation.MonkeyDuplex_Jr);
 
-   package Sr    is new Keccak.Generic_MonkeyWrap
+   package Sr is new Keccak.Generic_MonkeyWrap
      (Block_Size_Bytes => 32 / 8,
       MonkeyDuplex     => Implementation.MonkeyDuplex_Sr);
 

--- a/src/common/ketje.ads
+++ b/src/common/ketje.ads
@@ -56,12 +56,10 @@ is
       ----------------
 
       procedure Permute_Jr_Step is new Keccak_200.KeccakF_200_Permutation.Permute
-        (First_Round => 23,
-         Num_Rounds  => 1);
+        (Num_Rounds  => 1);
 
       procedure Permute_Jr_Stride is new Keccak_200.KeccakF_200_Permutation.Permute
-        (First_Round => 18,
-         Num_Rounds  => 6);
+        (Num_Rounds  => 6);
 
       package Twisted_Lanes_200 is new Keccak_200.KeccakF_200_Lanes.Twisted;
 
@@ -88,12 +86,10 @@ is
       ----------------
 
       procedure Permute_Sr_Step is new Keccak_400.KeccakF_400_Permutation.Permute
-        (First_Round => 23,
-         Num_Rounds  => 1);
+        (Num_Rounds  => 1);
 
       procedure Permute_Sr_Stride is new Keccak_400.KeccakF_400_Permutation.Permute
-        (First_Round => 18,
-         Num_Rounds  => 6);
+        (Num_Rounds  => 6);
 
       package Twisted_Lanes_400 is new Keccak_400.KeccakF_400_Lanes.Twisted;
 
@@ -120,12 +116,10 @@ is
       -------------------
 
       procedure Permute_Minor_Step is new Keccak_800.KeccakF_800_Permutation.Permute
-        (First_Round => 23,
-         Num_Rounds  => 1);
+        (Num_Rounds  => 1);
 
       procedure Permute_Minor_Stride is new Keccak_800.KeccakF_800_Permutation.Permute
-        (First_Round => 18,
-         Num_Rounds  => 6);
+        (Num_Rounds  => 6);
 
       package Twisted_Lanes_800 is new Keccak_800.KeccakF_800_Lanes.Twisted;
 
@@ -152,12 +146,10 @@ is
       -------------------
 
       procedure Permute_Major_Step is new Keccak_1600.KeccakF_1600_Permutation.Permute
-        (First_Round => 23,
-         Num_Rounds  => 1);
+        (Num_Rounds  => 1);
 
       procedure Permute_Major_Stride is new Keccak_1600.KeccakF_1600_Permutation.Permute
-        (First_Round => 18,
-         Num_Rounds  => 6);
+        (Num_Rounds  => 6);
 
       package Twisted_Lanes_1600 is new Keccak_1600.KeccakF_1600_Lanes.Twisted;
 

--- a/src/common/ketje.ads
+++ b/src/common/ketje.ads
@@ -27,6 +27,7 @@
 
 with Keccak.Generic_MonkeyDuplex;
 with Keccak.Generic_MonkeyWrap;
+with Keccak.Generic_KeccakF.Byte_Lanes.Twisted;
 with Keccak.Keccak_200;
 with Keccak.Keccak_200.Rounds_12;
 with Keccak.Keccak_400;
@@ -36,6 +37,10 @@ with Keccak.Keccak_800.Rounds_12;
 with Keccak.Keccak_1600;
 with Keccak.Keccak_1600.Rounds_12;
 with Keccak.Padding;
+
+pragma Elaborate_All (Keccak.Generic_MonkeyDuplex);
+pragma Elaborate_All (Keccak.Generic_MonkeyWrap);
+pragma Elaborate_All (Keccak.Generic_KeccakF.Byte_Lanes.Twisted);
 
 package Ketje
 with SPARK_Mode => On
@@ -58,6 +63,13 @@ is
         (First_Round => 18,
          Num_Rounds  => 6);
 
+      package Twisted_Lanes_200 is new Keccak_200.KeccakF_200_Lanes.Twisted;
+
+      procedure XOR_Padding_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
+        (State_Size_Bits     => 200,
+         State_Type          => Keccak_200.State,
+         XOR_Byte_Into_State => Twisted_Lanes_200.XOR_Byte_Into_State_Twisted);
+
       package MonkeyDuplex_Jr is new Keccak.Generic_MonkeyDuplex
         (State_Size_Bits        => 200,
          State_Type             => Keccak_200.State,
@@ -65,10 +77,10 @@ is
          Permute_Start          => Keccak_200.Rounds_12.Permute,
          Permute_Step           => Permute_Jr_Step,
          Permute_Stride         => Permute_Jr_Stride,
-         XOR_Bits_Into_State    => Keccak_200.KeccakF_200_Lanes.XOR_Bits_Into_State_Twisted,
-         XOR_Byte_Into_State    => Keccak_200.KeccakF_200_Lanes.XOR_Byte_Into_State_Twisted,
-         Extract_Bits           => Keccak_200.KeccakF_200_Lanes.Extract_Bits,
-         XOR_Padding_Into_State => Keccak_200.XOR_Pad101_Into_State,
+         XOR_Bits_Into_State    => Twisted_Lanes_200.XOR_Bits_Into_State_Twisted,
+         XOR_Byte_Into_State    => Twisted_Lanes_200.XOR_Byte_Into_State_Twisted,
+         Extract_Bits           => Twisted_Lanes_200.Extract_Bits_Twisted,
+         XOR_Padding_Into_State => XOR_Padding_Into_State,
          Min_Padding_Bits       => Keccak.Padding.Pad101_Min_Bits);
 
       ----------------
@@ -83,6 +95,13 @@ is
         (First_Round => 18,
          Num_Rounds  => 6);
 
+      package Twisted_Lanes_400 is new Keccak_400.KeccakF_400_Lanes.Twisted;
+
+      procedure XOR_Padding_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
+        (State_Size_Bits     => 400,
+         State_Type          => Keccak_400.State,
+         XOR_Byte_Into_State => Twisted_Lanes_400.XOR_Byte_Into_State_Twisted);
+
       package MonkeyDuplex_Sr is new Keccak.Generic_MonkeyDuplex
         (State_Size_Bits        => 400,
          State_Type             => Keccak_400.State,
@@ -90,10 +109,10 @@ is
          Permute_Start          => Keccak_400.Rounds_12.Permute,
          Permute_Step           => Permute_Sr_Step,
          Permute_Stride         => Permute_Sr_Stride,
-         XOR_Bits_Into_State    => Keccak_400.KeccakF_400_Lanes.XOR_Bits_Into_State_Twisted,
-         XOR_Byte_Into_State    => Keccak_400.KeccakF_400_Lanes.XOR_Byte_Into_State_Twisted,
-         Extract_Bits           => Keccak_400.KeccakF_400_Lanes.Extract_Bits,
-         XOR_Padding_Into_State => Keccak_400.XOR_Pad101_Into_State,
+         XOR_Bits_Into_State    => Twisted_Lanes_400.XOR_Bits_Into_State_Twisted,
+         XOR_Byte_Into_State    => Twisted_Lanes_400.XOR_Byte_Into_State_Twisted,
+         Extract_Bits           => Twisted_Lanes_400.Extract_Bits_Twisted,
+         XOR_Padding_Into_State => XOR_Padding_Into_State,
          Min_Padding_Bits       => Keccak.Padding.Pad101_Min_Bits);
 
       -------------------
@@ -108,6 +127,13 @@ is
         (First_Round => 18,
          Num_Rounds  => 6);
 
+      package Twisted_Lanes_800 is new Keccak_800.KeccakF_800_Lanes.Twisted;
+
+      procedure XOR_Padding_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
+        (State_Size_Bits     => 800,
+         State_Type          => Keccak_800.State,
+         XOR_Byte_Into_State => Twisted_Lanes_800.XOR_Byte_Into_State_Twisted);
+
       package MonkeyDuplex_Minor is new Keccak.Generic_MonkeyDuplex
         (State_Size_Bits        => 800,
          State_Type             => Keccak_800.State,
@@ -115,10 +141,10 @@ is
          Permute_Start          => Keccak_800.Rounds_12.Permute,
          Permute_Step           => Permute_Minor_Step,
          Permute_Stride         => Permute_Minor_Stride,
-         XOR_Bits_Into_State    => Keccak_800.KeccakF_800_Lanes.XOR_Bits_Into_State_Twisted,
-         XOR_Byte_Into_State    => Keccak_800.KeccakF_800_Lanes.XOR_Byte_Into_State_Twisted,
-         Extract_Bits           => Keccak_800.KeccakF_800_Lanes.Extract_Bits,
-         XOR_Padding_Into_State => Keccak_800.XOR_Pad101_Into_State,
+         XOR_Bits_Into_State    => Twisted_Lanes_800.XOR_Bits_Into_State_Twisted,
+         XOR_Byte_Into_State    => Twisted_Lanes_800.XOR_Byte_Into_State_Twisted,
+         Extract_Bits           => Twisted_Lanes_800.Extract_Bits_Twisted,
+         XOR_Padding_Into_State => XOR_Padding_Into_State,
          Min_Padding_Bits       => Keccak.Padding.Pad101_Min_Bits);
 
       -------------------
@@ -133,6 +159,13 @@ is
         (First_Round => 18,
          Num_Rounds  => 6);
 
+      package Twisted_Lanes_1600 is new Keccak_1600.KeccakF_1600_Lanes.Twisted;
+
+      procedure XOR_Padding_Into_State is new Keccak.Padding.XOR_Pad101_Into_State
+        (State_Size_Bits     => 1600,
+         State_Type          => Keccak_1600.State,
+         XOR_Byte_Into_State => Twisted_Lanes_1600.XOR_Byte_Into_State_Twisted);
+
       package MonkeyDuplex_Major is new Keccak.Generic_MonkeyDuplex
         (State_Size_Bits        => 1600,
          State_Type             => Keccak_1600.State,
@@ -140,13 +173,17 @@ is
          Permute_Start          => Keccak_1600.Rounds_12.Permute,
          Permute_Step           => Permute_Major_Step,
          Permute_Stride         => Permute_Major_Stride,
-         XOR_Bits_Into_State    => Keccak_1600.KeccakF_1600_Lanes.XOR_Bits_Into_State_Twisted,
-         XOR_Byte_Into_State    => Keccak_1600.KeccakF_1600_Lanes.XOR_Byte_Into_State_Twisted,
-         Extract_Bits           => Keccak_1600.KeccakF_1600_Lanes.Extract_Bits,
-         XOR_Padding_Into_State => Keccak_1600.XOR_Pad101_Into_State,
+         XOR_Bits_Into_State    => Twisted_Lanes_1600.XOR_Bits_Into_State_Twisted,
+         XOR_Byte_Into_State    => Twisted_Lanes_1600.XOR_Byte_Into_State_Twisted,
+         Extract_Bits           => Twisted_Lanes_1600.Extract_Bits_Twisted,
+         XOR_Padding_Into_State => XOR_Padding_Into_State,
          Min_Padding_Bits       => Keccak.Padding.Pad101_Min_Bits);
 
    end Implementation;
+
+   -----------------------
+   --  Ketje Instances  --
+   -----------------------
 
    package Jr is new Keccak.Generic_MonkeyWrap
      (Block_Size_Bytes => 16 / 8,

--- a/src/common/ketje.ads
+++ b/src/common/ketje.ads
@@ -1,0 +1,167 @@
+-------------------------------------------------------------------------------
+--  Copyright (c) 2019, Daniel King
+--  All rights reserved.
+--
+--  Redistribution and use in source and binary forms, with or without
+--  modification, are permitted provided that the following conditions are met:
+--      * Redistributions of source code must retain the above copyright
+--        notice, this list of conditions and the following disclaimer.
+--      * Redistributions in binary form must reproduce the above copyright
+--        notice, this list of conditions and the following disclaimer in the
+--        documentation and/or other materials provided with the distribution.
+--      * The name of the copyright holder may not be used to endorse or promote
+--        Products derived from this software without specific prior written
+--        permission.
+--
+--  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+--  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+--  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+--  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+--  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+--  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+--  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+--  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+--  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+--  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+with Keccak.Generic_MonkeyDuplex;
+with Keccak.Generic_MonkeyWrap;
+with Keccak.Keccak_200;
+with Keccak.Keccak_200.Rounds_12;
+with Keccak.Keccak_400;
+with Keccak.Keccak_400.Rounds_12;
+with Keccak.Keccak_800;
+with Keccak.Keccak_800.Rounds_12;
+with Keccak.Keccak_1600;
+with Keccak.Keccak_1600.Rounds_12;
+with Keccak.Padding;
+
+package Ketje
+with SPARK_Mode => On
+is
+
+   --  @private
+   package Implementation is
+
+      use Keccak;
+
+      ----------------
+      --  Ketje Jr  --
+      ----------------
+
+      procedure Permute_Jr_Step is new Keccak_200.KeccakF_200_Permutation.Permute
+        (First_Round => 23,
+         Num_Rounds  => 1);
+
+      procedure Permute_Jr_Stride is new Keccak_200.KeccakF_200_Permutation.Permute
+        (First_Round => 18,
+         Num_Rounds  => 6);
+
+      package MonkeyDuplex_Jr is new Keccak.Generic_MonkeyDuplex
+        (State_Size_Bits        => 200,
+         State_Type             => Keccak_200.KeccakF_200.Lane_Complemented_State,
+         Init_State             => Keccak_200.KeccakF_200.Init,
+         Permute_Start          => Keccak_200.Rounds_12.Permute,
+         Permute_Step           => Permute_Jr_Step,
+         Permute_Stride         => Permute_Jr_Stride,
+         XOR_Bits_Into_State    => Keccak_200.KeccakF_200_Lanes.XOR_Bits_Into_State_Twisted,
+         XOR_Byte_Into_State    => Keccak_200.KeccakF_200_Lanes.XOR_Byte_Into_State_Twisted,
+         Extract_Bits           => Keccak_200.KeccakF_200_Lanes.Extract_Bits,
+         XOR_Padding_Into_State => Keccak_200.XOR_Pad101_Into_State,
+         Min_Padding_Bits       => Keccak.Padding.Pad101_Min_Bits);
+
+      ----------------
+      --  Ketje Sr  --
+      ----------------
+
+      procedure Permute_Sr_Step is new Keccak_400.KeccakF_400_Permutation.Permute
+        (First_Round => 23,
+         Num_Rounds  => 1);
+
+      procedure Permute_Sr_Stride is new Keccak_400.KeccakF_400_Permutation.Permute
+        (First_Round => 18,
+         Num_Rounds  => 6);
+
+      package MonkeyDuplex_Sr is new Keccak.Generic_MonkeyDuplex
+        (State_Size_Bits        => 400,
+         State_Type             => Keccak_400.KeccakF_400.Lane_Complemented_State,
+         Init_State             => Keccak_400.KeccakF_400.Init,
+         Permute_Start          => Keccak_400.Rounds_12.Permute,
+         Permute_Step           => Permute_Sr_Step,
+         Permute_Stride         => Permute_Sr_Stride,
+         XOR_Bits_Into_State    => Keccak_400.KeccakF_400_Lanes.XOR_Bits_Into_State_Twisted,
+         XOR_Byte_Into_State    => Keccak_400.KeccakF_400_Lanes.XOR_Byte_Into_State_Twisted,
+         Extract_Bits           => Keccak_400.KeccakF_400_Lanes.Extract_Bits,
+         XOR_Padding_Into_State => Keccak_400.XOR_Pad101_Into_State,
+         Min_Padding_Bits       => Keccak.Padding.Pad101_Min_Bits);
+
+      -------------------
+      --  Ketje Minor  --
+      -------------------
+
+      procedure Permute_Minor_Step is new Keccak_800.KeccakF_800_Permutation.Permute
+        (First_Round => 23,
+         Num_Rounds  => 1);
+
+      procedure Permute_Minor_Stride is new Keccak_800.KeccakF_800_Permutation.Permute
+        (First_Round => 18,
+         Num_Rounds  => 6);
+
+      package MonkeyDuplex_Minor is new Keccak.Generic_MonkeyDuplex
+        (State_Size_Bits        => 800,
+         State_Type             => Keccak_800.KeccakF_800.Lane_Complemented_State,
+         Init_State             => Keccak_800.KeccakF_800.Init,
+         Permute_Start          => Keccak_800.Rounds_12.Permute,
+         Permute_Step           => Permute_Minor_Step,
+         Permute_Stride         => Permute_Minor_Stride,
+         XOR_Bits_Into_State    => Keccak_800.KeccakF_800_Lanes.XOR_Bits_Into_State_Twisted,
+         XOR_Byte_Into_State    => Keccak_800.KeccakF_800_Lanes.XOR_Byte_Into_State_Twisted,
+         Extract_Bits           => Keccak_800.KeccakF_800_Lanes.Extract_Bits,
+         XOR_Padding_Into_State => Keccak_800.XOR_Pad101_Into_State,
+         Min_Padding_Bits       => Keccak.Padding.Pad101_Min_Bits);
+
+      -------------------
+      --  Ketje Major  --
+      -------------------
+
+      procedure Permute_Major_Step is new Keccak_1600.KeccakF_1600_Permutation.Permute
+        (First_Round => 23,
+         Num_Rounds  => 1);
+
+      procedure Permute_Major_Stride is new Keccak_1600.KeccakF_1600_Permutation.Permute
+        (First_Round => 18,
+         Num_Rounds  => 6);
+
+      package MonkeyDuplex_Major is new Keccak.Generic_MonkeyDuplex
+        (State_Size_Bits        => 1600,
+         State_Type             => Keccak_1600.KeccakF_1600.Lane_Complemented_State,
+         Init_State             => Keccak_1600.KeccakF_1600.Init,
+         Permute_Start          => Keccak_1600.Rounds_12.Permute,
+         Permute_Step           => Permute_Major_Step,
+         Permute_Stride         => Permute_Major_Stride,
+         XOR_Bits_Into_State    => Keccak_1600.KeccakF_1600_Lanes.XOR_Bits_Into_State_Twisted,
+         XOR_Byte_Into_State    => Keccak_1600.KeccakF_1600_Lanes.XOR_Byte_Into_State_Twisted,
+         Extract_Bits           => Keccak_1600.KeccakF_1600_Lanes.Extract_Bits,
+         XOR_Padding_Into_State => Keccak_1600.XOR_Pad101_Into_State,
+         Min_Padding_Bits       => Keccak.Padding.Pad101_Min_Bits);
+
+   end Implementation;
+
+   package Jr    is new Keccak.Generic_MonkeyWrap
+     (Block_Size_Bytes => 16 / 8,
+      MonkeyDuplex     => Implementation.MonkeyDuplex_Jr);
+
+   package Sr    is new Keccak.Generic_MonkeyWrap
+     (Block_Size_Bytes => 32 / 8,
+      MonkeyDuplex     => Implementation.MonkeyDuplex_Sr);
+
+   package Minor is new Keccak.Generic_MonkeyWrap
+     (Block_Size_Bytes => 128 / 8,
+      MonkeyDuplex     => Implementation.MonkeyDuplex_Minor);
+
+   package Major is new Keccak.Generic_MonkeyWrap
+     (Block_Size_Bytes => 256 / 8,
+      MonkeyDuplex     => Implementation.MonkeyDuplex_Major);
+
+end Ketje;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,6 +18,9 @@ all: kat benchmark unit_test
 .PHONY: kat
 kat: $(OUTPUT_DIR)/kat/kat
 	$(OUTPUT_DIR)/kat/kat KetjeMajor kat/testvectors/Ketje_Major.txt
+	$(OUTPUT_DIR)/kat/kat KetjeMinor kat/testvectors/Ketje_Minor.txt
+	$(OUTPUT_DIR)/kat/kat KetjeSr kat/testvectors/Ketje_Sr.txt
+	$(OUTPUT_DIR)/kat/kat KetjeJr kat/testvectors/Ketje_Jr.txt
 	$(OUTPUT_DIR)/kat/kat ParallelHash128 kat/testvectors/ParallelHash128_samples.txt
 	$(OUTPUT_DIR)/kat/kat ParallelHash256 kat/testvectors/ParallelHash256_samples.txt
 	$(OUTPUT_DIR)/kat/kat ParallelHashXOF128 kat/testvectors/ParallelHashXOF128_samples.txt

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,9 +14,10 @@ DUMMY := $(shell mkdir -p $(OUTPUT_DIR)) \
 
 all: kat benchmark unit_test
 
-.PHONY: $(KAT_EXECUTABLES)
+.PHONY: $(OUTPUT_DIR)/kat/kat
 .PHONY: kat
 kat: $(OUTPUT_DIR)/kat/kat
+	$(OUTPUT_DIR)/kat/kat KetjeJr kat/testvectors/Ketje_Jr.txt
 	$(OUTPUT_DIR)/kat/kat ParallelHash128 kat/testvectors/ParallelHash128_samples.txt
 	$(OUTPUT_DIR)/kat/kat ParallelHash256 kat/testvectors/ParallelHash256_samples.txt
 	$(OUTPUT_DIR)/kat/kat ParallelHashXOF128 kat/testvectors/ParallelHashXOF128_samples.txt

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,7 +17,7 @@ all: kat benchmark unit_test
 .PHONY: $(OUTPUT_DIR)/kat/kat
 .PHONY: kat
 kat: $(OUTPUT_DIR)/kat/kat
-	$(OUTPUT_DIR)/kat/kat KetjeJr kat/testvectors/Ketje_Jr.txt
+	$(OUTPUT_DIR)/kat/kat KetjeMajor kat/testvectors/Ketje_Major.txt
 	$(OUTPUT_DIR)/kat/kat ParallelHash128 kat/testvectors/ParallelHash128_samples.txt
 	$(OUTPUT_DIR)/kat/kat ParallelHash256 kat/testvectors/ParallelHash256_samples.txt
 	$(OUTPUT_DIR)/kat/kat ParallelHashXOF128 kat/testvectors/ParallelHashXOF128_samples.txt

--- a/tests/kat.gpr
+++ b/tests/kat.gpr
@@ -7,7 +7,7 @@ project KAT is
    for Main use ("kat.adb");
 
    package Compiler is
-      for Default_Switches ("Ada") use ("-O2", "-gnatN", "-gnata", "-gnatwe");
+      for Default_Switches ("Ada") use ("-O2", "-gnatN", "-gnata", "-gnatwe", "-g");
    end Compiler;
 
 end KAT;

--- a/tests/kat/kat.adb
+++ b/tests/kat/kat.adb
@@ -31,12 +31,14 @@ with Ada.Text_IO;
 with CSHAKE_Runner;
 with Duplex_Runner;
 with Hash_Runner;
+with MonkeyWrap_Runner;
 with KMAC_Runner;
 with ParallelHash_Runner;
 with TupleHash_Runner;
 
 with CSHAKE;
 with Keccak.Keccak_1600.Rounds_24;
+with Ketje;
 with KMAC;
 with Parallel_Hash;
 with SHA3;
@@ -69,6 +71,11 @@ is
 
    package TupleHash128_Runner is new TupleHash_Runner (Tuple_Hash.Tuple_Hash_128);
    package TupleHash256_Runner is new TupleHash_Runner (Tuple_Hash.Tuple_Hash_256);
+
+   package KetjeJr_Runner is new MonkeyWrap_Runner (Ketje.Jr);
+   package KetjeSr_Runner is new MonkeyWrap_Runner (Ketje.Sr);
+   package KetjeMinor_Runner is new MonkeyWrap_Runner (Ketje.Minor);
+   package KetjeMajor_Runner is new MonkeyWrap_Runner (Ketje.Major);
 
    package Integer_IO is new Ada.Text_IO.Integer_IO (Integer);
 
@@ -207,6 +214,10 @@ begin
                                            XOF        => True,
                                            Num_Passed => Num_Passed,
                                            Num_Failed => Num_Failed);
+         elsif Algo = "KetjeJr" then
+            KetjeJr_Runner.Run_Tests (File_Name  => Ada.Command_Line.Argument (2),
+                                      Num_Passed => Num_Passed,
+                                      Num_Failed => Num_Failed);
          else
             Ada.Text_IO.Put_Line ("Unknown algorithm: " & Algo);
             Ada.Command_Line.Set_Exit_Status (-1);

--- a/tests/kat/kat.adb
+++ b/tests/kat/kat.adb
@@ -218,6 +218,18 @@ begin
             KetjeJr_Runner.Run_Tests (File_Name  => Ada.Command_Line.Argument (2),
                                       Num_Passed => Num_Passed,
                                       Num_Failed => Num_Failed);
+         elsif Algo = "KetjeSr" then
+            KetjeSr_Runner.Run_Tests (File_Name  => Ada.Command_Line.Argument (2),
+                                      Num_Passed => Num_Passed,
+                                      Num_Failed => Num_Failed);
+         elsif Algo = "KetjeMinor" then
+            KetjeMinor_Runner.Run_Tests (File_Name  => Ada.Command_Line.Argument (2),
+                                         Num_Passed => Num_Passed,
+                                         Num_Failed => Num_Failed);
+         elsif Algo = "KetjeMajor" then
+            KetjeMajor_Runner.Run_Tests (File_Name  => Ada.Command_Line.Argument (2),
+                                         Num_Passed => Num_Passed,
+                                         Num_Failed => Num_Failed);
          else
             Ada.Text_IO.Put_Line ("Unknown algorithm: " & Algo);
             Ada.Command_Line.Set_Exit_Status (-1);

--- a/tests/kat/monkeywrap_runner.adb
+++ b/tests/kat/monkeywrap_runner.adb
@@ -141,7 +141,6 @@ is
                if Ciphertext = C.Element(Ciphertext_Key).First_Element.Hex.all then
                   if Tag = C.Element(Tag_Key).First_Element.Hex.all then
                      Num_Passed := Num_Passed + 1;
-                     Ada.Text_IO.Put_Line (Byte_Array_To_String (C.Element (Plaintext_Key).First_Element.Hex.all));
                   else
                      Num_Failed := Num_Failed + 1;
 

--- a/tests/kat/monkeywrap_runner.adb
+++ b/tests/kat/monkeywrap_runner.adb
@@ -123,16 +123,20 @@ is
 
          elsif C.Contains (AAD_Key) then
 
-            MonkeyWrap.Update_Auth_Data (Ctx  => Ctx,
-                                         Data => C.Element (AAD_Key).First_Element.Hex.all);
+            if C.Element (AAD_Key).First_Element.Hex.all'Length > 0 then
+               MonkeyWrap.Update_Auth_Data (Ctx  => Ctx,
+                                          Data => C.Element (AAD_Key).First_Element.Hex.all);
+            end if;
 
             declare
                Ciphertext : Keccak.Types.Byte_Array (C.Element (Plaintext_Key).First_Element.Hex.all'Range);
                Tag        : Keccak.Types.Byte_Array (C.Element (Tag_Key).First_Element.Hex.all'Range);
             begin
-               MonkeyWrap.Update_Encrypt (Ctx        => Ctx,
-                                          Plaintext  => C.Element (Plaintext_Key).First_Element.Hex.all,
-                                          Ciphertext => Ciphertext);
+               if Ciphertext'Length > 0 then
+                  MonkeyWrap.Update_Encrypt (Ctx        => Ctx,
+                                             Plaintext  => C.Element (Plaintext_Key).First_Element.Hex.all,
+                                             Ciphertext => Ciphertext);
+               end if;
 
                MonkeyWrap.Extract_Tag (Ctx => Ctx,
                                        Tag => Tag);

--- a/tests/kat/monkeywrap_runner.adb
+++ b/tests/kat/monkeywrap_runner.adb
@@ -1,0 +1,210 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2019, Daniel King
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--     * Redistributions of source code must retain the above copyright
+--       notice, this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * The name of the copyright holder may not be used to endorse or promote
+--       Products derived from this software without specific prior written
+--       permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+-- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+-- THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+with Ada.Strings.Unbounded; use Ada.Strings.Unbounded;
+with Ada.Text_IO;
+with Ada.Unchecked_Deallocation;
+with Interfaces; use Interfaces;
+with Keccak.Types;
+
+with Test_Vectors; use Test_Vectors;
+
+package body MonkeyWrap_Runner
+is
+
+   procedure Free is new Ada.Unchecked_Deallocation
+     (Object => Keccak.Types.Byte_Array,
+      Name   => Byte_Array_Access);
+
+   procedure Run_Tests (File_Name  : in     String;
+                        Num_Passed :    out Natural;
+                        Num_Failed :    out Natural)
+   is
+      use type Keccak.Types.Byte_Array;
+
+      package Integer_IO is new Ada.Text_IO.Integer_IO(Integer);
+
+      Key_Key        : constant Unbounded_String := To_Unbounded_String("Key");
+      Nonce_Key      : constant Unbounded_String := To_Unbounded_String("Nonce");
+
+      AAD_Key        : constant Unbounded_String := To_Unbounded_String("AAD");
+      Plaintext_Key  : constant Unbounded_String := To_Unbounded_String("Plaintext");
+      Ciphertext_Key : constant Unbounded_String := To_Unbounded_String("Ciphertext");
+      Tag_Key        : constant Unbounded_String := To_Unbounded_String("Tag");
+
+      GlobalTag_Key  : constant Unbounded_String := To_Unbounded_String("GlobalTag");
+
+      Schema : Test_Vectors.Schema_Maps.Map;
+      Tests  : Test_Vectors.Lists.List;
+
+      Ctx    : MonkeyWrap.Context;
+
+   begin
+      Num_Passed := 0;
+      Num_Failed := 0;
+
+      --  Setup schema
+      Schema.Insert (Key      => Key_Key,
+                     New_Item => Schema_Entry'(VType    => Hex_Array_Type,
+                                               Required => False,
+                                               Is_List  => False));
+      Schema.Insert (Key      => Nonce_Key,
+                     New_Item => Schema_Entry'(VType    => Hex_Array_Type,
+                                               Required => False,
+                                               Is_List  => False));
+      Schema.Insert (Key      => AAD_Key,
+                     New_Item => Schema_Entry'(VType    => Hex_Array_Type,
+                                               Required => False,
+                                               Is_List  => False));
+      Schema.Insert (Key      => Plaintext_Key,
+                     New_Item => Schema_Entry'(VType    => Hex_Array_Type,
+                                               Required => False,
+                                               Is_List  => False));
+      Schema.Insert (Key      => Ciphertext_Key,
+                     New_Item => Schema_Entry'(VType    => Hex_Array_Type,
+                                               Required => False,
+                                               Is_List  => False));
+      Schema.Insert (Key      => Tag_Key,
+                     New_Item => Schema_Entry'(VType    => Hex_Array_Type,
+                                               Required => False,
+                                               Is_List  => False));
+      Schema.Insert (Key      => GlobalTag_Key,
+                     New_Item => Schema_Entry'(VType    => Hex_Array_Type,
+                                               Required => False,
+                                               Is_List  => False));
+
+      -- Load the test file using the file name given on the command line
+      Ada.Text_IO.Put_Line("Loading file: " & File_Name);
+
+      Test_Vectors.Load (File_Name    => File_Name,
+                         Schema       => Schema,
+                         Vectors_List => Tests);
+
+      Ada.Text_IO.Put ("Running ");
+      Integer_IO.Put (Integer (Tests.Length), Width => 0);
+      Ada.Text_IO.Put_Line (" tests ...");
+
+      -- Run each test.
+      --
+      -- Note: The tests must be executed in the correct order, since each
+      --       KAT test continues from the state of the previous test.
+      --       This is why the context is only initialized once before the
+      --       tests start (see above).
+      for C of Tests loop
+         if C.Contains (Key_Key) then
+
+            MonkeyWrap.Init (Ctx   => Ctx,
+                             Key   => C.Element (Key_Key).First_Element.Hex.all,
+                             Nonce => C.Element (Nonce_Key).First_Element.Hex.all);
+
+         elsif C.Contains (AAD_Key) then
+
+            MonkeyWrap.Update_Auth_Data (Ctx  => Ctx,
+                                         Data => C.Element (AAD_Key).First_Element.Hex.all);
+
+            declare
+               Ciphertext : Keccak.Types.Byte_Array (C.Element (Plaintext_Key).First_Element.Hex.all'Range);
+               Tag        : Keccak.Types.Byte_Array (C.Element (Tag_Key).First_Element.Hex.all'Range);
+            begin
+               MonkeyWrap.Update_Encrypt (Ctx        => Ctx,
+                                          Plaintext  => C.Element (Plaintext_Key).First_Element.Hex.all,
+                                          Ciphertext => Ciphertext);
+
+               MonkeyWrap.Extract_Tag (Ctx => Ctx,
+                                       Tag => Tag);
+
+               --  Check output
+               if Ciphertext = C.Element(Ciphertext_Key).First_Element.Hex.all then
+                  if Tag = C.Element(Tag_Key).First_Element.Hex.all then
+                     Num_Passed := Num_Passed + 1;
+                     Ada.Text_IO.Put_Line (Byte_Array_To_String (C.Element (Plaintext_Key).First_Element.Hex.all));
+                  else
+                     Num_Failed := Num_Failed + 1;
+
+                     -- Display a message on failure to help with debugging.
+                     Ada.Text_IO.Put_Line("FAILURE:");
+
+                     Ada.Text_IO.Put("   Expected Tag: ");
+                     Ada.Text_IO.Put(Byte_Array_To_String (C.Element(Tag_Key).First_Element.Hex.all));
+                     Ada.Text_IO.New_Line;
+
+                     Ada.Text_IO.Put("   Actual Tag:   ");
+                     Ada.Text_IO.Put(Byte_Array_To_String(Tag));
+                     Ada.Text_IO.New_Line;
+                  end if;
+               else
+                  Num_Failed := Num_Failed + 1;
+
+                  -- Display a message on failure to help with debugging.
+                  Ada.Text_IO.Put_Line("FAILURE:");
+
+                  Ada.Text_IO.Put("   Expected CT: ");
+                  Ada.Text_IO.Put(Byte_Array_To_String (C.Element(Ciphertext_Key).First_Element.Hex.all));
+                  Ada.Text_IO.New_Line;
+
+                  Ada.Text_IO.Put("   Actual CT:   ");
+                  Ada.Text_IO.Put(Byte_Array_To_String(Ciphertext));
+                  Ada.Text_IO.New_Line;
+               end if;
+
+               MonkeyWrap.New_Session (Ctx);
+            end;
+
+         elsif C.Contains (GlobalTag_Key) then
+            declare
+               Tag        : Keccak.Types.Byte_Array (C.Element (GlobalTag_Key).First_Element.Hex.all'Range);
+            begin
+               MonkeyWrap.Extract_Tag (Ctx => Ctx,
+                                       Tag => Tag);
+
+               --  Check output
+               if Tag = C.Element(GlobalTag_Key).First_Element.Hex.all then
+                  Num_Passed := Num_Passed + 1;
+               else
+                  Num_Failed := Num_Failed + 1;
+
+                  -- Display a message on failure to help with debugging.
+                  Ada.Text_IO.Put_Line("FAILURE:");
+
+                  Ada.Text_IO.Put("   Expected GlobalTag: ");
+                  Ada.Text_IO.Put(Byte_Array_To_String (C.Element(GlobalTag_Key).First_Element.Hex.all));
+                  Ada.Text_IO.New_Line;
+
+                  Ada.Text_IO.Put("   Actual GlobalTag:   ");
+                  Ada.Text_IO.Put(Byte_Array_To_String(Tag));
+                  Ada.Text_IO.New_Line;
+               end if;
+
+               MonkeyWrap.New_Session (Ctx);
+            end;
+         end if;
+
+      end loop;
+
+   end Run_Tests;
+
+end MonkeyWrap_Runner;

--- a/tests/kat/monkeywrap_runner.ads
+++ b/tests/kat/monkeywrap_runner.ads
@@ -1,0 +1,37 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2019, Daniel King
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--     * Redistributions of source code must retain the above copyright
+--       notice, this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * The name of the copyright holder may not be used to endorse or promote
+--       Products derived from this software without specific prior written
+--       permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+-- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+-- THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+with Keccak.Generic_MonkeyWrap;
+
+generic
+   with package MonkeyWrap is new Keccak.Generic_MonkeyWrap(<>);
+package MonkeyWrap_Runner is
+
+   procedure Run_Tests (File_Name  : in     String;
+                        Num_Passed :    out Natural;
+                        Num_Failed :    out Natural);
+
+end MonkeyWrap_Runner;

--- a/tests/kat/test_vectors.adb
+++ b/tests/kat/test_vectors.adb
@@ -93,7 +93,7 @@ package body Test_Vectors is
       Byte_Array : Byte_Array_Access;
       I          : Natural := 0;
    begin
-      if (Str'Length mod 2 /= 0) or (Str'Length = 0) then
+      if (Str'Length mod 2 /= 0) then
          raise Constraint_Error;
       end if;
 

--- a/tests/kat/testvectors/Ketje_Jr.txt
+++ b/tests/kat/testvectors/Ketje_Jr.txt
@@ -4,7 +4,7 @@
 # The test vector file format has been adapted to fit the format supported
 # by libkeccak's test vector parser.
 
-# initialize with key of 176 bits, nonceof 0 bits:
+# initialize with key of176 bits, nonce of 0 bits:
 Key = fe9730c962fb942dc65ff8912ac35cf58e27c059f28b
 Nonce =
 
@@ -48,7 +48,7 @@ Plaintext =
 Ciphertext =
 Tag = 068ed730d990617ceb43e5e5667e4e50
 
-# initialize with key of 160 bits, nonceof16 bits:
+# initialize with key of160 bits, nonce of16 bits:
 Key = bc55ee8720b952eb841db64fe8811ab34ce57e17
 Nonce = 7bdc
 
@@ -107,7 +107,7 @@ Plaintext = dafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b
 Ciphertext = e7591f2aaeccd34ed0111e72f75eec8db283ba8d79322e0f037fb5ad3c7712114ff5ca0efbc3fff2f4249b84cf374dc3
 Tag = 65ff8033409c714d9e7c0a1ae846bd9b
 
-# initialize with key of 144 bits, nonceof32 bits:
+# initialize with key of144 bits, nonce of32 bits:
 Key = 7a13ac45de7710a942db740da63fd8710aa3
 Nonce = bd1e7fe0
 
@@ -171,7 +171,7 @@ Plaintext =
 Ciphertext =
 Tag = 26b17b87bd31182956a2b9c6d9de4306
 
-# initialize with key of 128 bits, nonceof 0 bits:
+# initialize with key of128 bits, nonce of 0 bits:
 Key = 32cb64fd962fc861fa932cc55ef79029
 Nonce =
 
@@ -575,7 +575,7 @@ Plaintext =
 Ciphertext =
 Tag = 5a5033422a43400d32639737ae54e67b86b2fce6f4f3f226617d9129c347dc3c
 
-# initialize with key of 128 bits, nonceof 8 bits:
+# initialize with key of128 bits, nonce of 8 bits:
 Key = 33cc65fe9730c962fb942dc65ff8912a
 Nonce = d5
 
@@ -979,7 +979,7 @@ Plaintext =
 Ciphertext =
 Tag = d5ff813f0bf1eae07e9f41c86a10a5ef253db37a370a118366eb2bf8fc40a734
 
-# initialize with key of 128 bits, nonceof16 bits:
+# initialize with key of128 bits, nonce of16 bits:
 Key = 34cd66ff9831ca63fc952ec760f9922b
 Nonce = 77d8
 
@@ -1383,7 +1383,7 @@ Plaintext =
 Ciphertext =
 Tag = 6a8929217f48ba1f0c1c367736086415ad10bbb203657f5b3343fa83c118aa57
 
-# initialize with key of 128 bits, nonceof24 bits:
+# initialize with key of128 bits, nonce of24 bits:
 Key = 35ce67009932cb64fd962fc861fa932c
 Nonce = 197adb
 
@@ -1787,7 +1787,7 @@ Plaintext =
 Ciphertext =
 Tag = d60941a4721770f9aa081d65d87b9dfe3b6948098e28e03e4b13a1e57b33e630
 
-# initialize with key of 128 bits, nonceof32 bits:
+# initialize with key of128 bits, nonce of32 bits:
 Key = 36cf68019a33cc65fe9730c962fb942d
 Nonce = bb1c7dde
 
@@ -2191,7 +2191,7 @@ Plaintext =
 Ciphertext =
 Tag = d1a936c46d8d2faedbf3096eebaa39ce480b1384a8714f94a3fc93bf7cae63d8
 
-# initialize with key of 128 bits, nonceof40 bits:
+# initialize with key of128 bits, nonce of40 bits:
 Key = 37d069029b34cd66ff9831ca63fc952e
 Nonce = 5dbe1f8040
 
@@ -2595,7 +2595,7 @@ Plaintext =
 Ciphertext =
 Tag = f6e24777a436f91215ccaf8d3f23952928db2caa4bfffc25ac6f38a02bb66987
 
-# initialize with key of 128 bits, nonceof48 bits:
+# initialize with key of128 bits, nonce of48 bits:
 Key = 38d16a039c35ce67009932cb64fd962f
 Nonce = ff60c122e243
 
@@ -2999,7 +2999,7 @@ Plaintext =
 Ciphertext =
 Tag = 67cb616ce2c5e01bb09aee89f0bebb23470137299aa02a1f27517dd264de1cf5
 
-# initialize with key of 112 bits, nonceof64 bits:
+# initialize with key of112 bits, nonce of64 bits:
 Key = f68f28c15af38c25be57f08922bb
 Nonce = 41a203642485e647
 
@@ -3108,7 +3108,7 @@ Plaintext = ddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e
 Ciphertext = 1510ba40c235213d54b2c12fcafe25227a5831e673856e2ad91f50e739bb195e56ad00431b67217060ae0037b76b0401
 Tag = 03b7e385c571876b54c77273ded03d1f
 
-# initialize with key of 104 bits, nonceof72 bits:
+# initialize with key of104 bits, nonce of72 bits:
 Key = 55ee8720b952eb841db64fe881
 Nonce = e243a405c52687e8a8
 
@@ -3247,7 +3247,7 @@ Plaintext =
 Ciphertext =
 Tag = 2c49e6ebc4abf2de91a3ea40336075e4
 
-# initialize with key of96 bits, nonceof80 bits:
+# initialize with key of96 bits, nonce of80 bits:
 Key = b44de67f18b14ae37c15ae47
 Nonce = 83e445a666c7288949aa
 
@@ -3445,6 +3445,3 @@ AAD = 029324b546d768f98a1bac3dce5ff08171029324b546d768f98a1bac3dce5ff0e071029324
 Plaintext =
 Ciphertext =
 Tag = a953bbf734348106dca406b86a811797
-
-GlobalTag = 6b2db5c57651366cf83e42dcb3690e51
-

--- a/tests/kat/testvectors/Ketje_Jr.txt
+++ b/tests/kat/testvectors/Ketje_Jr.txt
@@ -1,0 +1,3450 @@
+# Ketje_Jr.txt
+# Algorithm name: Ketje Jr
+# Test vectors obtained from https://www.github.com/XKCP/XKCP
+# The test vector file format has been adapted to fit the format supported
+# by libkeccak's test vector parser.
+
+# initialize with key of 176 bits, nonceof 0 bits:
+Key = fe9730c962fb942dc65ff8912ac35cf58e27c059f28b
+Nonce =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1a9a90e0393719f729b046a4989aa511
+
+AAD =
+Plaintext = 4b6cec0d8dae2e4fcff070
+Ciphertext = f737df7b9e0f80b479ceb7
+Tag = f5f5914f1e10685e6bc584dd2814f721
+
+AAD =
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = cc7d264420d9c9f1edcf54f8939b04342fd17b54a0e944b6eb37cf
+Tag = dc52c899b1750075f9f78b29af5ca9b0
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = e4854090edf62a849a6ee24b85961b4d
+
+AAD = 51e273049526b748d96afb
+Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9
+Ciphertext = 3f7885b4383fa3ef6e8db5b82a72dfe7206806801279ae
+Tag = 41e3da562c819eecdd3f84d0b5dbe1fb
+
+AAD = 16a738c95aeb7c0d9e2fc051e27304958516a738c95aeb7c0d
+Plaintext =
+Ciphertext =
+Tag = 46e036efa0ddf870b6a466eaa0100ede
+
+AAD = 3bcc5dee7f10a132c354e576079829baaa3bcc5dee7f10a132
+Plaintext = d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a
+Ciphertext = 422c52f890f3d32583a366d9327db5270ec9bad67483d435092bd81407963a94a2788fe78e
+Tag = fca1e4548e78dc896f70bea21c3c91bf
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = 068ed730d990617ceb43e5e5667e4e50
+
+# initialize with key of 160 bits, nonceof16 bits:
+Key = bc55ee8720b952eb841db64fe8811ab34ce57e17
+Nonce = 7bdc
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a2fafd7cd87de304cdc2c176466c43f4
+
+AAD =
+Plaintext = 0728a8c9496aea0b8b
+Ciphertext = 4ebf5c655a7fc91755
+Tag = 8957c91f1b3d5b8bc6e0f1ad30dde7d7
+
+AAD =
+Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
+Ciphertext = 53161634129280adea71bee6f7b705c71b40de67f524
+Tag = a48d763e0e3996b22731fa32cfb732fe
+
+AAD =
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e
+Ciphertext = fdd2c037900959f4ac9329ec281c462f122373b5f6aafef8972829b9bf69e73bbc8f07d90c899cf6ff41
+Tag = 35d25d140ba849fc90ff70dc72ab133b
+
+AAD = f68718a93acb5ced7e
+Plaintext =
+Ciphertext =
+Tag = 06ed01f767c4ebf63bc9e84b0e66290b
+
+AAD = 0a9b2cbd4edf700192
+Plaintext = 0627a7c84869e90a8aab2b4ccced6d8e0e2fafd0
+Ciphertext = ba837712c2d768358dfeb613dcec1790a27166d9
+Tag = ac856683ef057efa787097ee98843430
+
+AAD = 28b94adb6cfd8e1fb0
+Plaintext = 0223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3b
+Ciphertext = bbe8c633b2dcfd6197493b6d79e37625da6fa0ce3de667ad800d90fc6505383dd21bafc0c7de05e9020988a0c0c0639baff9
+Tag = a24594995fa5050f87a9fe7cbb334a9c
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+Plaintext =
+Ciphertext =
+Tag = 71acc8f5dec60397fe0169e330c2d9a0
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061
+Plaintext = aacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
+Ciphertext = 1672da5dc6753f421a32642800b33fc807edbfc7ef1f07524ccc13e7a746f1bd
+Tag = 04fd281ff399140a72f648c49d4e8c59
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = 158185a2f4696c401dc8a77930c76964
+
+AAD = de6f009122b344d566f78819aa3bcc5d4dde6f009122b344d566f78819aa3bccbc4dde6f00
+Plaintext = dafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0d15172
+Ciphertext = e7591f2aaeccd34ed0111e72f75eec8db283ba8d79322e0f037fb5ad3c7712114ff5ca0efbc3fff2f4249b84cf374dc3
+Tag = 65ff8033409c714d9e7c0a1ae846bd9b
+
+# initialize with key of 144 bits, nonceof32 bits:
+Key = 7a13ac45de7710a942db740da63fd8710aa3
+Nonce = bd1e7fe0
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2e65540e4307cc869ae2d0c1af0d1a86
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = a719a0523b1b71
+Tag = 5b43b401557aeda5931f24da1d3ca3bf
+
+AAD =
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
+Ciphertext = 83c13be9fe5cb54eb010da6d1540aff75d
+Tag = 447082c71a9484487357faa47376edba
+
+AAD =
+Plaintext = 95b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425
+Ciphertext = d1aa8ff58a984724205d74c190c01f08dfdd15737f159220a631993e1b4beddb
+Tag = 8cca32ae2327ac4f293895224849bc7d
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 61ecb34f417860aa82f8f8e224267aa8
+
+AAD = c354e576079829
+Plaintext = 1e3fbfe060810122a2c34364e40585a626
+Ciphertext = d3cafb86ff6621c1e9942f0d6c9891ed94
+Tag = 809d4b64028b0f279f98aee7e75103ff
+
+AAD = dc6dfe8f20b142
+Plaintext = f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
+Ciphertext = 64063def01d64eb6343af88dcdb7eb4ca98be74b3aa7305b78d171526c4db165250b5f70ad0f67551313
+Tag = 54f05fd18b4ec8c6e79be74cc031f572
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 54af3fd18ef61e30321bfda667e7210e
+
+AAD = 7e0fa031c253e475069728b94adb6cfd
+Plaintext = d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e56586
+Ciphertext = 7771970e781224945b904f6380d53451ad927861ba2f8c665432
+Tag = 0147f092203ab785bd4d9a7702a99e73
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = 8b7438d35960017828edb31777fa3ccd
+
+AAD = 22b344d566f78819aa3bcc5dee7f10a19122b344d566f78819aa3bcc
+Plaintext = 7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff0
+Ciphertext = 1370bc2d0ca973fc9e8fbc5124c5fd21b1b9e929e4360ec282ae16bccb65e8b3adc703d8b997
+Tag = 92b353efc38b174465902303fd9189f7
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = 26b17b87bd31182956a2b9c6d9de4306
+
+# initialize with key of 128 bits, nonceof 0 bits:
+Key = 32cb64fd962fc861fa932cc55ef79029
+Nonce =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 46929f142bb74a95
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c6c6ae6f64b777dc791119f40e1cf74e
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6988e5d798802e40cd3edb14b574d4a842e31208df1d128b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 356a7c7ce57fc097aa4d63c4f1832f20d74bc79dcea45fcad8b0db50b6fe7ef7
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = f6ef31db6d
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 25792d753c
+Tag = c33fc9bcc354170e
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 94dca70658
+Tag = 4d6d363526463bc547991f3ce0c95742
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = a2a54de4fa
+Tag = d02daa219f1406e7c85628bd4f6a03072f848480980a2ae8
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 04aaf72a42
+Tag = 28733820e770c769fbfcb40912d631838dc70cbddf94b9e0ffa792fff2d6fcc5
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 185a5831e1118a041e336489
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 81c2106b272dd7c299462cba
+Tag = a9084576a4918820
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = b22cc11a9d1c1b39db2aaaf4
+Tag = 4cf56cff05e6f17dcde40f30981b505e
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 543c981317a10716b9c97dfb
+Tag = e42668451f63989ed3dad1e80a48e1447763c988039dd63d
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = d4687df4747a9fa0c66db6fa
+Tag = c02ea99d61c7d5997af264f761789964f0ccdca2e8e2999d58772a9f93fd73cb
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = b9d63f93e0ff3a9d075c2a9cfb069cda50bbca95747696
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = bdc11a7ac8fb6afba6ab27749eeebcc0c95be4cf455664
+Tag = 0682262bf4432ee4
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = df40ad600b9a592071c0aa54e833bcb4ddf96fe24e10ce
+Tag = 6dca925458bf4755bae8d0e0e9672597
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 17bf432bad4af768d8fe939f58e1c02b0ef011f6e8275a
+Tag = 2ec0f9c74a4e050b1927af2383395a099196ba9929726be0
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 9f456643ecc0a44bcf947922b605e4c9a1a85fefe8bc52
+Tag = c40fbafde48876d10d0ce05bb940d1d65a9707b837454e2e9eb50cdaf91f3ac6
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 0814b303a277333adf0ef1a81ced752b917b1bc6fb9193fc8e9bc87df7dd7015fad97ed04fe39f
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 2408a5a794aa69a48caa7f0b431cfa020583dd90ad914fbeb0654fc904fa0e7adb69ad5516d619
+Tag = 334fc58fabbf0dd8
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 9f5da96b517f41728b99d05b7427205cc35d5601a683762c26b26db26323231c7a92e4ed36f6b4
+Tag = 67439fc7cca8ded6f12059edf225fd50
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 73db924ee877035d9fb808724e3935ecdd97dfd029c4190036d5ee791505d0d6c4af013a4ced9a
+Tag = e0e6db60a664a7e0f2e872b469730b47ed60b7e6134519ac
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 2e78ecdc812ec6c4ec6d02b2afbc68dcc92f80d84cc9552e089a4a34c3e73ed4eb98c7728c7ebf
+Tag = 51f88bb0e257845a5683e30aa72e5a919f747f167e920a3519e416d566a7d126
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = b894765fa7d1fad8
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 49629fdaf18ce14388dc69ed34a12a2f
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 7059d1fc3cc356775e8d221a6cf841151416d1abd9ac98f1
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = ddeed83735329d2e74b85735009b8d8e50592cae31b96804a9499d5f1f105a1d
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 39063cb2f296865930e45ac9d4cc
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = ead6b274a31051ddb96e659e1199
+Tag = 0720d5e49e717f66
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 02c3ee85630f6a5575eff790d528
+Tag = 55f69ac91e57ba241ec26774bc64eb38
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = c640cafa526a4500db494da51ea3
+Tag = 432417873521a5722c59624c7bd1b6ff2ee80177a8d9c42f
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 49a31cea552f91f23821adc8f703
+Tag = 89a064e8803759bff28d7d77ab681a3349eac486bfea9745205c4f3ab3b359db
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = ea3f35f659018a9d784e95bbc5296652fa54c4a5c1dd169a6b3fdee767926c68e5dc35
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 6ac36dd072104cdbff514f70294e333c7873d627ef10fd7bdb556c2c9f3eefa759765b
+Tag = 9160b3107e7959e9
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = aeda8f2c57da2dc85e1ed50dd327b7f25ee6ce772e4e71c881def11a5b80ff42b4ce76
+Tag = 6bb6ea806e0a1bd697140f1d2be0862c
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = eab51c49c9c8f4d1a5f0fc7c7134d01fd1da1afef6f6cb22f1f684acf31986e1fbdab4
+Tag = 7c2361df1c201668f55273635dd2eab64e2053279fa93d5a
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 36d63c17a45497ad8751ecb1dbfc3a3edf165054bae3915b2f5691d95da9cccd819aa1
+Tag = efd96c14fa43d2c5cfd9b37bd791f23b899d13857acd6cec1a0ca8517bd29f07
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = be55e705d98b7430
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 33520126c23d9ce606f4e1889303575c
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 4aabe53d682ea474e936a8a107ee668f8b873e5110f13dd0
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = e81913eb45e012d0e6e84a38e4f4078d4998396ae2555f1e52bc35bce9377ada
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 7ba364682256f8c4b46e3704fb3c5e06b75f73b8
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 3ba7dce55bc1457c8bc79aef0fd0059eed550f61
+Tag = d00ca1f64539b03a
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 8df43fb8febe2c3a8617c2a6bbaf86e3ab0286ea
+Tag = eba4e18279704ef71fe5763535055bb0
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 5325ce5bb96140ec86cb2ddd16267e5a06f8bd27
+Tag = 58b683027c85fcaaf34c11e81620412cdb99b315560583cd
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 4782944a246dedb2ed7f1d51d2a47e698a194f47
+Tag = 3132d793111504a582f72d9e381a843eb64b0b7fdc0e0f32b09fedcceac526f6
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 8d1577489cc004554062881678c252b8a7140c61347b96a8c6bb8e210c3d6b2ad0bda16d85fdf07f74d92691d5d521e77933
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = b5c4b783974adc6d38d48fe0f276d932fd04875a5c15b4b67a99d47839c668ec00dc5e3842ca75b7f225bc3bcbf55f0030f4
+Tag = 37bf357e62bb6500
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 75680e0ae66482b4a316d35d44f28489456f7a5d9cd3d606dfcb9396917136dc69a73044f094febef7cd5c0245301a379aed
+Tag = 24b17016710c049fbd4b4e66cc6cde77
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 46cd7d66babe09694ff9c483bd6e6d1c8c3034383ee6e02c470e3c05efc5025c570c4a205e9967b5194356397d555dc25936
+Tag = ddd93b4e5a637c83e89403a4d688675f380593ffbd13555d
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = e8e9ed4cfb3fe339027ff9092a119b6ae2076d8c19cee4c431708486751bbd64dad7e41b64d15aaf5672d2692e359444efb8
+Tag = 4a8ba5962aca5493bb57ac75c2d09c8c02bb4cef11eac4a1fe8a3b05974ac3fb
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 5d5f53f644bdecdb
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = b7d7b7cb8ecc64d8495cc7aa1797f994
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = ee97329b93e9f3120718fadd5ca68361a58dc9af5d2462a7
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = d5e874224783c1c0302500d9b49b9a2fe9a30c671e813786b4b849a6d76a8f09
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = cb9dffad38f02824d809e6b4fb5b9526c65d86ad4e4932ca111256ea
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = b5fc83729d6c1dd604d0f94f8d241c3d2c8a04128f57471d6b06d173
+Tag = 40d39fd7900cecc0
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = e56aa2c12507937a9c12f1686ecdeaf641e0b51c609ecce0e58f825b
+Tag = ff2539dd44ea62fb3a277684979ce1d5
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = c485aef5894cbd007307cdda6cc59e859a8ad5d1d1ac489872163ffe
+Tag = a3b2c49011936268a8ea8a701bab32e67afee8e578ed7e54
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 1360b002bb27fd2e35fb1aba761a5a448c4b60ff6b242bcb08cd4090
+Tag = 8353840cc2b7b6a85079e16fc17d64d85ac24cc4ff738cfb99f7b87a24e9e36c
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 4cfe4af16559f8f0
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 4b8588dfb218a9dd2ef9a333580e2207
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = f892d25c1232a753ddac06b0c2030479656de2370ffdba98
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 9c238eebc2fc7b196dda8a0eb25aa7fbf742b3cbc9a78dce125ee596d06b83be
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 85ae7173d8a5efd87b8aad8205d28f2d2293f00158fef1cad2a1ef1de2ec5f5530053d87a7c77f
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 4d390e29cf92411e8c631acc4aa5ecbfdb2fd5403ff9ffde36cd3141cac2a1c9940bf4ef977261
+Tag = 9674df62f1b7f5c6
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 3b731ca0fea2105cba6a4fc732e72ad08e4db2986be0ae6ee1f33325b25d417be4dfa6b2cf15bb
+Tag = c8c089e24cef3b04c6ff65aa0cf64179
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 6e813e8a73170b2d6ccb9017d852422b6823997a5790d0b9bc661d2eb5b00ff990bdf991e33b82
+Tag = 397eef508930383f050b374521ce047109675cfdf78af532
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 987b6172ab3ea22934e97c9807c679bc6a6a6aded5ebea4668dfbaa0b897b950fd12f3f07b5a53
+Tag = d952218bcd9a0fc65c95f11a6914fd3d3f6d0f56bf0bf9ba1e4aec9ebbdd54c6
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = a3ad32db34ff0a88
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 273298b5ca76d09d926a605f8b6f02fe
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 73903f28b8672a4a4ece03916efd11da8cd61e19359ea919
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 5a5033422a43400d32639737ae54e67b86b2fce6f4f3f226617d9129c347dc3c
+
+# initialize with key of 128 bits, nonceof 8 bits:
+Key = 33cc65fe9730c962fb942dc65ff8912a
+Nonce = d5
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6c80ef140e84fd54
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e3e43280095f887c8743e09033148207
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 33d200003ef07e1d63cbb4b33b75f7bb67bb26986c0a4931
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 99e77177befdeb4c6b1e5d1735c213393c248b93a85106ae311bf038e887aaf5
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 0179c2e267
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = f43350fd88
+Tag = 63c8ecbdc38d2f14
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 9d1b0f41c1
+Tag = 5fabda6b71659e6c4a72e7133dd851a9
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 7ce3748c70
+Tag = 32d748cf0b8df0d9f1e8d4b2379780d137cf744f8ef169af
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 0e2d567985
+Tag = 6139fe55c5b5c36886b3cec4ef599125ebc7fb3f02bcd8fee78df440949ceb09
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 54925a1fa9b56e1e29bd24cb
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 80481461221a3b092e4217df
+Tag = 9d4ef9319c6b5cca
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 124635a1372bc91d7252d919
+Tag = 33194d69aa8e0b6b7973bc9ec925ef92
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = a8e01b5a24807a171ab0885e
+Tag = f3786cad5080ff6d865cbdb3deb494f9e9f59cf4b6963684
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = a3f5843abc15ac941e94d1ce
+Tag = 6bce5083991f7d5cbc9589cb3281b611fb2472ed82f19f372f50b2cc20747017
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 5b953de1cb49f67c49858bb7bb502479fcfc00b1b0ba29
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 8709a669d944e2915fef0e807c661d46f3334ba38e84dd
+Tag = 1097b6eb976d67ab
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 09499fe2000f501a108e867b281f8e241263da3a8460f3
+Tag = e4067716f7b42d0231049cde450f2f57
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 3076aa4ad9b08c7ec89fd6901d8200e7f73faa8f936538
+Tag = cbf2e19dfa7c2eac3dea62b1b18d87e06ffab30d9b72939a
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 1176a6b5d9216f8d75e361404e72bd14a2563c31cd6fe6
+Tag = 21179a4e0d0e6e6704d0eb21683acb197913c896fffee6eb608729f08745c383
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 172011e5cf855aedeec1f5d3f00591ab15b4037eb494a0d4d898a2929f1ada750e35ac05d1162a
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 31d43af911e67aad102db81259ef7a8e0af3d3de19cd1aeb25391921a5d9087bc4313e0df45fec
+Tag = 7a3f21943a9b50e3
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 133a3084dea9554fb0e5145a9479129291902d995148a6782d681690bb67b717199d43c3adb3e7
+Tag = 4a40460d4f981bfcebc14cb22a0a2d17
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 81e31818562bcb593c779d50fd2a19d3c0644894e04c5e1a40c7dd8071fd313e86feb6022371e9
+Tag = 28c8d47f64ed7a4e96fdc3b4b68f1881262d6ddaf441e631
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = db13a96403b65dba2c789c8c06f049edb78d5e39ccfba8ce09517fdb96ac565db1fa011113ba06
+Tag = 0845e9a0c5369e9decb7813dd034b4028c0d71411124ad7d038dc3c911a2ede9
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = c701761705a57d06
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = ecf731da745d907355a9ce01f086f5b8
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 92d72eb01de450650b9a0dfa7c94ed5c785fe151080f225c
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 07fb7c29e055691aab03b0cda1669fd432be9416c7a7a37a934cc4ef6f31ccbb
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 1934413973df28400441685e085c
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = e2ae971515f56cdb5b5eba2267e4
+Tag = 39812db4a3356b54
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 098a45d4011d1c1a842d8775dbe0
+Tag = 406c914b1753c974c65d36abcb1cc6d8
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 2a12eb97a4714b40750a82ef8fdf
+Tag = 4dee1b2398a28a68c96b00a2e68b7927109c8bce4b781b20
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = cc96dd02d39d9228342b0ddba359
+Tag = b9fb32e9826e2b8dc3d3c50d18b1fbba067a1dec85c5505bc034951bf51b0689
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 7d313a927d7ae75f2acf0c47a44c899cc5ea77e56cc4a94551afc3147c151577410e83
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 5385c6a12c4bca79eabb86b94bdc9e03a3e091a0ff00f67c107c0169492956f79d1ba4
+Tag = a2066e95998e2a4a
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 3d787d03495c19d865f855cc30631d8a782a3882473c664514de6f526c64132d96a376
+Tag = 4e824a2901415b13ed4270c7857f979b
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = be7dc4e1dfd47ffcd7a8f87ec973f9e11da6f349b4dc415d1972abf645dd44543dd76f
+Tag = 9b53247927e97967904f1953b4d5198b9dd53fdef8048d68
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 821f9d0d5c0ebfe5246db65bd26538600d47488b6cc3151f9728eb5eb371f05e0e5cb8
+Tag = f219be019f76e4f941a7b904bb9237e5b3f342e29a7d10ebcc15c999b892dadc
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 0862c8f955261ce0
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 8248a4c23f59e8896baba54ac734b49b
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = def4feb8da258850d05504ad8d14fe8482ca394b28fc29d0
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 8a7466c0c3ae470ace85ca1a037c31475ee8d7afb712e80f768464ac730a551f
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 292026b7d6e17e3450a94f7b468269e84627e433
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 28f9b76a23885263cdc465a8d1148ecb5b93c93d
+Tag = cc39ec767bade8cc
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 71612797f109749fde0e61fffb810468d3508636
+Tag = 9ee014ad86c46cd214cd3574bab7cb82
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 27a9472fb2e4598e64e10de3bce7a57ebe4fbb30
+Tag = 2b3ba67d4db64a622eb1e30fc1ea9fd4d078d30404fb7dce
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = f97c8db4bbe8107a1e7cc07380b736a03c8ffd7e
+Tag = 86c53dcce0dadae8a8c2c9be23420c8c331f008788bcd807926da3b6fee130b4
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 05541abe071989515b2fce7af49031669db7553e7425c4edf83210a6808945bf3e6e87ce8df36fb7d94ee7e6d2387f1f97c0
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = a6f17e62f9625bdf2cca8e85135827e4a84fe874155b78ececbfc4e32e45389fcea1cf3f62a296a85634b39b57cd54527923
+Tag = 1ba320731da8ea95
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 3e8783a1e633ecb5f883b775b4b167ee905dfd0d2690eb62c1aeda0cd9921fdd15416a8ee4820b5705804c3bd3ae24888cb6
+Tag = d7017ac5041531519476b7f5248bd4a7
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = c59794dc5e459cd1b89017d3613e7c792724fa9d73b5c4889d3ed9cfb15304f6c3bc75f5e636cf79c764565911e70a76f256
+Tag = 2c783a5d8804774488f9b67ad0fc2624590bbb82705608e9
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = d7ab644dd03048d88a9ed6774c08235b283f1c15253075e5e1c0f76997d1c3897ff860f1a483eaa31a48c1b76c9f1f916ce9
+Tag = bbb66e95030f167036eecf4f1d3e472a9e1dacc95c6e09129c69c1e492dc5c02
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = d937dd8bf9c40a48
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 76b2d214c5dbe065efefed7e0172698a
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 613cfad75c10f321d6f324cb4e7f52803dfc81142ed35d31
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 7d2e5b778ea380a4361481e996d560502c886bfb78c5d0abd52a0e7bf88ea874
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = d7ee0674b3163a49ea3afdd17ee273a2f31f4d90d25ee31ed28d746b
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = de10e53c071c3b5c1977ac8e4fb4c4556389dbaa822d67f598ce8d97
+Tag = 96889988987fea0d
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 16e8ee959c1c676c98b3281bf06bae44cb37e6767db25bacf765cfb3
+Tag = 6335940f4188b54368ca3cf3324d5c28
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = c72a50bf2a210e4290b07a51bbbb7137bb62cb2fb73318dd6bb0e1c6
+Tag = 2ba9ec2b2b4cb60b2bf61e2ccacbe9c0d7d8de08d21e6db3
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 8b919cf65c3d33982658bd19d525681f0c2425bde86b353b8332aced
+Tag = 94a428aed4a805753cafccf7d45cccb9308674d34031cc7c7c4d4873820eff2c
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = c349e86ce7dab5ce
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 6e3a5f920a6be6cf8804d9b4bcda1e83
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = bc116dbd580423fcc202aedacaf36d0814bdda7fbd3e9f5f
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = b19873895ec50c76497fd795539a8ed3cde9198569763836b4bed057901a76d6
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = d3a75dc6036fceecd30048b378f3bd178f118520ebceb3099612a26382379970419e28176ea55d
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = a71ff694e719c25418645b43b94edef566beb0e6fd9dee355f6f3ee172fcde7157aff7f4bac579
+Tag = 241c664d3fec7a22
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 0480e211b77ca42c3d1cbe2c5eb4a38edb6e11e77a52eb7af51771579181dc280d2a28ebbce896
+Tag = eea5f65a7b30e58c7d558b6b78433ea2
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = ef0345a61e87d8c1a2d1502fb50683b83a987b39f3ea4efb9d82ebf75ff8103af6b3c57d4b0018
+Tag = c2aabba29e1cccf8235443d68e0bc20eacd3055cae478f50
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 7a28141b25b541e2415b733d6453e297523fb457a7fb775246eb6526f89d5876c17b0a863ae547
+Tag = 13cdeb8bee78446d1c21d2814d93f9558cc324d401d4503b2af2d103bb536e4e
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 409fce6e3a1cc6bd
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = c0f2ae9b7fe46f1ff61e9f8fc36f6735
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = f0cd642b7bcafaba7be77145af9f210de88c5eae1984d205
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = d5ff813f0bf1eae07e9f41c86a10a5ef253db37a370a118366eb2bf8fc40a734
+
+# initialize with key of 128 bits, nonceof16 bits:
+Key = 34cd66ff9831ca63fc952ec760f9922b
+Nonce = 77d8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c650db1b0e5c34f8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ef3a613745821501a33599ce1b5c4d50
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = bc969ae19e5c5a75ba090c60c6b6d3afdce44ac365088784
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f1cf4aa8a3cf7e339f9d147b47fafb347f90468e09eab15d6375aab1deed1d0a
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = a8161cc587
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = ec9bfdb83a
+Tag = 4554f9ce89b2471e
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 4d406852cb
+Tag = 305d5435aa0c62d7bfba9d86b0637993
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 7e88ae94ad
+Tag = 4c5e78b52c64bfe7ddf88f6ea65ef0868809bfc2d2986396
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 8276f66647
+Tag = 7b687f54e2a654bd762105bb937b876dbaf01c485ee29672f5c22b180b134a77
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = ff15fdcf4b25403ee2d84ad6
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 88b5a0077387af44ce41e7da
+Tag = 504628424d62cc12
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = e84d5647c1055b8ace22f521
+Tag = ed931bbecd5a0d8398b6bbe1a47c705f
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 6899b262e26d17d4a9c72458
+Tag = c9840c315682bad87a6717e7ec410a227509e7f1face1591
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 16ba21b17772df925c0d443d
+Tag = 37adb5cba671d7437a91c8a65453601cd261499ab85d0152f6b9f9010f8ba1e9
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = fdb34c586caeb62276b514fdb20ba598e20afba741603c
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 8c6ac53a040efc9a2761c8f472cdfc046eb6b22746de11
+Tag = ccbf3f8fdfffb23f
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = c782fe4d39b6ea141cb59339a5b8765d4beca6bbed7494
+Tag = 1b1743cb4fb4972592bc96fec1612132
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 25cd7654726be14c08dd1eccb82dd343a9d72a751db06b
+Tag = d45c7404422e234146f2b499824b1e3a47febcd51421ecbd
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 6da045e1a73e351332b4d1a9733530f4193db5fc386b81
+Tag = 04262238a488cfe112a4f3f1678a0f3114fad99120572e32ddb62a34cf5d063d
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 8ade97c8e7cadddf8a6b8c6a6a3103706f2f45ec167b65e67734ee26a9cca03ecde0f637bb121d
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 01fd0fe35d4cf4f9e73667c409a5678f66b08929013642c25e574de16518e691685b341a5b7b76
+Tag = e023ca14ec3de2b2
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = f6b459f5fb354e77b52fe0be0cc827a8d0149b59bed951b36349f385be197c7806548bad653f54
+Tag = d8021ab0f6c605d1aabc07d7bf5eb0e7
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 5d13ee679060e87d14944a6fc9df962d7ef48de887e862b0f7762cf522cf2c6de9cc43d3c62789
+Tag = ee3f8e9f5c65cffb7570065e5b16850f2d58ece0861ebf83
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = f647b1cce5f39adeb9fab4c09a3be7f4ea6ea89a86e00cc402a1653036816bc406712880d02a01
+Tag = c836251a88e830a1fe59231b7fb3eb6878cf40fde911aa7602c3fdb145a49dc4
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = c7a9559f9531be8d
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 33d589c2bfacd6e2bc4e09a615fb7215
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 43877bd6c1830f030b59fb9881b3299c8dad0b8a81366eeb
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 26467358857234656823f77ea62abf955da4231bac98f351afde4f321183bacf
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = ae554d2436c34842914ca1219580
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 21641f3b8ba04db46e73c617609c
+Tag = ff3ca8e0d5bd7bd5
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = f9999e7528af1f715fd99b9c6862
+Tag = 570fe1f5b630f90043c1eb2ed95ea60f
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 5185544e5cfd3de6be2dec2b4b9c
+Tag = 93298dd7088690ee8eed9f4346d62cacf88681015d5ef815
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 244e216d9756ab9c850e2dcb7ce1
+Tag = 8bfff5b409eacb2626a9c224dbf83b2ba00e4e126efc8699dcbc8362a0d26874
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = e1f0cb7e8cea95f23cc7f92fbc505a2b90be295aaff03db2447e2d55d6a5eb9b3909d6
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = d85e5bc65506bc2a20396db922bc09df2c7b7b2d42a0caa5893ed84f350fa5af5bda23
+Tag = 5293af25dcc3aa21
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 27f73114fa0ab5f1ee735db8ea5e001e84e11c94f152b5bbc2526f48aa25a310302508
+Tag = f80db2f07fa743a6a165be3b4274c204
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 62013a6acb1ac3233d727b9bcb6da75a4519d122b3378462a5821f3f290eb3a81eaf96
+Tag = 2cb00868c9e32b10d4b18da8d43266c27861e667a17f4ef1
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 4d5e4d632d5f5c980978a5eb96cd59ad0e68e0e519fa083a8a2acd11a591cd3a0bd6e2
+Tag = 47bc61a7e4122fb9026a1562e2027d905c003c68dd49b005c4964df15615ac7c
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 73abeeab0201b7b1
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = a08fb39fa3668d9500add4836adb3d7b
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = a7ca144832e0283ddfcaaf01630492b8ac73ed7fc33eea4c
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 1018ee56a1b7379a751f317f1b40bbcc62f34794c1da54d2df13cb77509cf0d9
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = a669b97f79da47026abcd3bdc9adbadcfeb1fb3f
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = a8f7ec551a6ae1d7e0238beadcf3d9c86ab2db7b
+Tag = e7f5d262a087fd1b
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 4828391cd1996adcea7df6d950d596bc47c5496c
+Tag = 234d938e517f03764f997046e68d1f98
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = d209d3c1308dd518a965961b8d7b417cf9b83b75
+Tag = 1911b3a0739a88c076d44179944a6f3474e174c68fac8ab8
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 414cffb416a1a23c074464716ca799f64c24110b
+Tag = 147099b41f6bd8927189f64e1b35ad2221b375afb6bb08e308d84f93b069767b
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = d0264d5afc084fed5319655e99f979c7e4a84b096aa2e1d1f7c76408685f77db76c5afd15aa633e8c877d494dd17eb654bff
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = e0fc6ccd831739a29f684bcd34ea1d8ff7c5249f6533b8928b10123c53d8a129f70b19f99ff9e7c8c7c02b587577629e7aa8
+Tag = 43fa96732499de23
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = d479aacb708b35549b7dea48281c30dd850b1dad66356d62e2f979173b9b3c62706e4ca4fd9b970011007597398c4e9de2f3
+Tag = 5ef18fdf46acb79b9dd7322416a924a4
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = fb35c7973d7f88151bc47950ab7f419b104e2fcb3c6088ba1dd4bf35537a525052d1e1124d6b5466a24ab33b45e79942bd6f
+Tag = b5df3ec0aa0e5074e7b88dcfe5c42cfeaffcbf5fb126d2aa
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 8db31e999c04e056d2cc2c693679f7fae454aa61348bb2d52fe11e00736530a02db85dbad93927212f44eb20af663021e03d
+Tag = 4787d2fed992115a3fb86fba05437870e978c2dd2ed98e5565f6465f815ced5d
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = a866a4869ce034e7
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = c0f76c76466c006093a452fcd30fdcd2
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = f65568e71cff2513e7bf901d4d7acc9dd08d81f98050f55d
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = d17e2fe49533aaf6413f27b605dc812b0277ef8183bae188669374251362f4b7
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = f104cbe49a3384cfe578247c12e2dba954088b67187e43bf63a0b6dc
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 6de25a48e2abae2fb77cbb9b025833193293af90f81e613d6774a27f
+Tag = bad3eef6187139aa
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = f8d137a1e01b925e3dac55a2633fcb860db6e54cd31be4a4a2ab2b09
+Tag = b8b8f08711a9f71a71f1c72e51faf227
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = d4afd34f16a98dbdabe93db5279e4f05909ea62e16717e538f10be8e
+Tag = 181bdbe2e5275fdc3127d0d4ba06518ec48b355755745c1f
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 29d25a0a6fc4cbcb4c22956716654ce3b21d54b10641c016ddc96863
+Tag = 38daad932ce3ba79734c2e05532c180c3e1831f450bee00b6ce98d83a684cedc
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = e75e19b6fe2ebe44
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = ababd75427a5886cc841bf926b128614
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = d861ffc546191c7d3d86271233dc16d2315b9f8a67094f2d
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = dfe6d710a5ef4c5f1b93259186b75dcff9cd9f5beee28e8c35508346a00c009a
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 5d661dc9e6944052a243e2058f5c8655e0f686bc23d0ff14fc44589f472c042174c1f9f7609d32
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 0f9c4ecd98f65ebb085156732f47628362733b92bc600a195b4f4f46e7c8a344b92db3101900cd
+Tag = 67fd8d1c5116c7a9
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 048ef772458b09ee2673d1d95d1c5372d38653f1253234a1dde0b3c0e5adfcc0ed471d9bd87359
+Tag = 05d134507aee433a42a3fbde79911483
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = e67a0c2d5495e6cf08f4b98608948ac2a83d504273fed7b1ed4616b90b6d9c2fa4b95460619149
+Tag = 49f93c6ea5672cc77cd137fd681b80fb50f89f33892d5e7f
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 3291cb6ef21e9f696d012055abffbf866d15c50035703f2de831efb00d949390de08f44276ee9f
+Tag = 5cc443a0480499fd18131f66db389869f3d97087a6eeb637f9bfeda8dde7a1f2
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = ed99060b1ef07a37
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = c09998e48d64f43d4b3d2578c425d1e9
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 9d5bce15431a7c0a4589e161e6165f05a0e6080aca6282b9
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 6a8929217f48ba1f0c1c367736086415ad10bbb203657f5b3343fa83c118aa57
+
+# initialize with key of 128 bits, nonceof24 bits:
+Key = 35ce67009932cb64fd962fc861fa932c
+Nonce = 197adb
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a06e5596962d29f3
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 91119f7ddf3861bc06827e57ca59a948
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 889a0c51f2f15009ef285313e5d013e6a90a636e64a19551
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 3fc01b5bc20d76944bd4ba289bd7e7c047d42712ce6ab9750e2a7e63232277bb
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = c40c409928
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = cdd127d9bb
+Tag = 65883efc4d868b25
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = aeac86a30b
+Tag = 16a1165a66471ae8de01c9dee7e8566a
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 4d6b09f38b
+Tag = c53eeeff402d797dcf253941c945c5c2f1497c547d442fdf
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 6530f5c7d3
+Tag = 553b8c91128cf28baafb42ec4fc12852fc852a4a4e1542adc8662fc37d3d44d5
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 259d6fbc8332bd23114ae5d4
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = e7cc40ef48329c93b48d1dce
+Tag = 5e7c81664d5efaf3
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 80fd0b3d05610264d6cf213e
+Tag = 74bafbb6a0795dc4939396a346f96171
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = fefd0067b9778bcdd5c49265
+Tag = d7b22a174cb6d8aaa10fa51a311c45355fb5778051f924db
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = c265518a4bcaaa9ab5064934
+Tag = e494eaaf3b6a11dda5dde4ede1a6aaa7f92248fcf3d02b156c4bd6e20b9ccf04
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 0147090ac1c29eaf50860724ae269200a457372dbc4e6a
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = d0f75c8a7a6841b82ed9cd2746787414dad6890861dac4
+Tag = 346b7e2e97889d43
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 58c1d19f1c4686f502d2db933e09af5e5cc54181243055
+Tag = d38b6f00cb512ddfe514cbee77fcfc1d
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 9962445a2a1cec3a88c3574561f900358a25189a6a0b76
+Tag = a8272e315625fc3f8bcaec6ac9a14bd33840ece77d889ad5
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 4e80acc7d129dd72ee502eac84a4e078943157da51adf7
+Tag = 4c9effb71b6a9fa22945765561435d3f1ea14cca38bf3d34d4e2f475e17c2a46
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 6991317cd0ca81a7872acdf5944824995beb8ef845a81e45e2d0c45bcf15db68290e5bb40d1d5e
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 81c09a567ad754864e52585d1d87b212563c66f43e619c92f7ac4c7ae5c3751cd0929aca36207a
+Tag = f962232f473099e5
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 08ddec0b765fd5b1c7163106c79a71db362347ba86a5def3fdb8900102fc056892858a67fa0ad8
+Tag = b43c38a94718f24a426e0dc0bc8e57ce
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 86446fe75c383ca6f47db3936faadc134d336e6b5fa8dee8b759554ea78b910faff9d8f450d1f4
+Tag = 252ca1d3efd811a26bc6dfeb9056ad7439b3af73a5001b38
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = e9f1ccdfb8d05aa03196b436310f45d8b8bbc11f9e2e775771f8a370acbbc44f3af445e2d4c1fc
+Tag = 70ecce1fc66661cb20bcea9548caced84612becda9f23762eddbf822c7c33dc1
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 2090d6fcc57d85ee
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 5f3ebddb0b628579636774fca2880c38
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 5a3e49b2933cb40ecc8cdee91e1d228a764b48e66c4d6e83
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 2269db56d876f21d4f4600bd1ed4520818b2cce45c99f74ae09059673d8a7cc2
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 8e9d5991e004a7439204fee8791b
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 1898acf2840015bf04c1bbb9ab92
+Tag = e108f6f71849df65
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 49fe8e2b3c9bc05d06f4aed07d36
+Tag = 3f615a6f0995218790e41978d887da03
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 592bb5e7b218f5b16a2ae19fe890
+Tag = 4310612785ebe0887125d1c1d9d997f01b34ae1eb916d4c7
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 3bf87560d162f44b42699187c692
+Tag = 2018c3cd2762489c44c6b2b006a6562c78c4cfcd54ef8510d859577c18264d68
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 5baeb07c36123241f12b60b8dafde1d7223ff881cdd4890ba9ba7cc90c4ad205ba94bd
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 1241ae6f3de85691291fcb1081b45ace327e1c60fe7a4d618ff1ee1fbb13844f307086
+Tag = 808583d5aad67550
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 3f5154ba1858480fe282f50e72119271585aed2cf15c5468488bea903d99734467d882
+Tag = 336e56ff26d266645b5a453748605b7b
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = fe37a767d6f5c35da880098678e1025bfdac26c53a501e1191a39f8b59bd2e7b04c2f6
+Tag = 78e9f41d80d8993f81df71d2559b9af4c31a3def6599a3ff
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = a5f4851f98c25e4318ddf65862d1d93feac0b3af2db68e7e2e7edc315023ae5d4210f6
+Tag = fde9ce3ac8d19cc10f85c86022ffbecb97a2540d317ad6bd191272585e9da5a7
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = cd425f68808f6976
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 3c942747f5e3ecb7db94c9e9dce131f3
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 79e6b3c5a6a81016e17d2d46b53d826d0a8cf461cb5b0394
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 19950cebbdb28fe7444073a7bdd51e996fd6c1b8b8d2fab29f979538d3d1e9f1
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 92cd84d76b95feb0ffc0a6179bd1e2ce1fe2b278
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 8d0bc83d83292f892bb2948c92bee0d4d14b3a10
+Tag = a48aba1fd91f1062
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = bbac0b9d651030526a1b1fc1ee928003ebc8099c
+Tag = be5a1c8d7bba08aa245e1ec2eaf3060c
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 57d0227780646b8968ae3346c623d9ebb3cbe9c1
+Tag = 67fc0dbbb3e37a01b84dc92c96e70387589fda6093fddca9
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 206531bf74fbde375a2656fa5c9ca4a008577bc0
+Tag = 560c4bdb1a90e706e2cac5c946448c99be699f4c4eaf2ede6c4891fe98e52f48
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 44891b20ee7c1cce82edf3d572f8603ae8a8ec3e3a59e5603cff5394d21beb229c6d7d62a1592abffdd62dec0da1453ce0d4
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 4114e935ac7f13cca5cade6ab8be93794faa5b5076fb085693c8a35033f5f6fd92065cc8911716b172de7696b4cec7809827
+Tag = 1e01c1d2fb332b80
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 58819b6553cea0fbab2d450cf0cdb91972ead4b638a85a966f234917c9d35df922f58cf32c4a46dc204a8aa09ec0e32e0d07
+Tag = 04ff618824e9b26c4b4eca0fe646bece
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 54cd55301bd661720ae5a3db1db11481abb2cf4c161747cc554359b72bea5298886817a3f6bd612da0d5139eedb8060aff38
+Tag = 750dae0311583af8286a914a6086e228c614ed224aee2465
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = a7b6d9cb949f086a756a46565724a2a8c12592229ac5da2a9b5ca1ec3127a8bdd33a8fa9d038bfd5bf32aba0261e5b655108
+Tag = 5ffd69e3878d6b80af365d670598fdb4ed0df5287f50f40e59128cc2ce8158c1
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 7e3d260a5c4f1e62
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 34efb56e65973d13d7682efb815c0766
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 06876af4767f3b7c30050138ce411ce00f4a1cc71afbc4a3
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = e67333e5ced4d55393c8c0b60fc3be652e4958592f478f9cf83f9a80f140ea26
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = e8debab27cd94235ff5f5eeffa67bb5d27a7ff083c68d5acd4e8060d
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 59fee2a3d765da3300e31cc86f6b326646ab54b26b849988f72c8c2f
+Tag = 43ae4619677ff6b8
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 3e7b34f9a8a37047e05b1d90e6cc4f4a7b0d45c7a54123469f4c95ba
+Tag = e59fccca27f3468ea2fd99f2692afdf3
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = b33eecccee70f6197a8258c1e0c35a45f3fa38bce39a6718f99198ea
+Tag = 939523226265a00305144882fc3a13026431a485ad336582
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = a555a075d678757ef943cbbcb397928a7e864623825aeb6809ccad4f
+Tag = c3e09ded9e601790dc7d22de8e1fa2c902254bfe6f2fa0458b09b591523beb74
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 7e71886f47f38a97
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = e5e6bcb33b4d2a2751acfa9342fd46aa
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = a583403087d612c96d5be72e295ade45cb3b91099abc5608
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 6698f1f8a79d5d8c5750484bbd2e12cef12e4d0e49277f96cd06df0e9f2b46f1
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 1c4c96ac96ea5b1c024955eac284b8f6756d3b5b14ecfdf300f0717264672fba49f3a5700eb075
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 4bf57d91fcc38bc3010ddb11553eb72967f8550f3b13a7890ddf8685b1313f7f26d5398bb56529
+Tag = 0337e8fb0a14d6b6
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = a18c2f707a57303536395dc2c4e7ae9c3d6e916b7c6687b65b88824991a241ba52a7c5e73a3b55
+Tag = af1cfe69996404e49b431f088cd2ce08
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 590a5a8c690d00daa5766ab9efcba0726435a222870cae72ba0610f68e550b12539581fde6e7c1
+Tag = 3b2b4d6ef2cfe90e128d8eeff7b53c2b6bbee384b1bcc964
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = d0d43fd9c2b6787ebaf034a399ac535b3b6b03c28a60ee4dca0f966e6e0df7b509f6e0b6df102e
+Tag = f2b0ef2adca0961c31c7dbb0a300e42492d7b7c8f9b919a385e6abb387736c5b
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 441600596c9c95eb
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 09113e81e1b724e502f35856ca2a0749
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = d14cabe1e72b55511d2540fe9a24ad063ae46b9d8bb2a889
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = d60941a4721770f9aa081d65d87b9dfe3b6948098e28e03e4b13a1e57b33e630
+
+# initialize with key of 128 bits, nonceof32 bits:
+Key = 36cf68019a33cc65fe9730c962fb942d
+Nonce = bb1c7dde
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = cdc2d3ba9b0eae01
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = cf6d072bac6b81b661260e16d734abf6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = befabaa110f188ab21553d4cdf04418ccffd93d8737369b2
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f24dc6a8abf7c04e58192e45f42beda1a8d5f61ef325a8ae0a3a04f9d3ca2bc8
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = ed300305f0
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = cf839fcbe1
+Tag = fc30c23a6918fe96
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 2742350a9a
+Tag = c07fa0d01b7dfe41574bfaeb112e4015
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 480908c8a7
+Tag = 9dc6f35fbde43a2579e435a7cef5ef46a0a26aa9ce0a9f58
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 1049b67334
+Tag = 0042e477d10af02c0e018d5a9ea97cf9da7c9e548ec7d1604033d63f6c98c431
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 188ccd5c2ace388966e7a0eb
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 2bb1d5ce6d4b9223d9911470
+Tag = 7f2a23379281477f
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 626268b7c87e005b68fbfaf3
+Tag = 6fcc202743ce7cee10a9b8cd6ed60424
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 3b4fbb41658447b4cd1d574b
+Tag = 3d92eadee7dd40a82acd1c8007b08610d4b2e16a97a48140
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 471fdbf10c01ba5411ba850c
+Tag = 9402dcab6219b6d9ecdec4d5667946343bd4710b99feb01100370510b57fa258
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 81d9be9582d0db1a9e14de62b42666955148fc2f208ffc
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = d51ea0dacbaa5e0be2e9423fb191facd2c5b5871f63e1d
+Tag = 0994bc5f48e8b351
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = b7a10e72d1a6a2ba96f348bfe82b04a0005bf3a0bd0613
+Tag = 5661eb0540ce2c5c109cf987b4fbda02
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 73448a4ba3bf5c927982fd0defeef78dc6effe84a3cfc5
+Tag = b849d05c301ba30acebf086546671cde5fb181eeae8b0c81
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 0a429ce7c7f7de66538807baebc8b07c36b2b607ad9a6b
+Tag = dad5144c5846bbe29cc9852c664b53d20100d7d5280fa7230c0ed4275fb41cbe
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 4cfbde9af38183406384320a0a921b94b03a9033e9dfd4e06acac0c16e72772b785336ecf6658f
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 803ae0cb4396afbb84215cbbd8bbbb08706989017fd0a583a4cb153f6c9c71d5fb29a0553ec7d9
+Tag = 5b6f7fa548ccb67f
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = e148c5ef3bd43ec76102c2276b5f1c69ceaa9d2e68599600b700734b0f876ffa3fa2ef89e8d404
+Tag = 918b7c4150dbddbb15dac53386f61609
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 067724fa4f417704c33abf73ea845626c83e3b1afda372d28ba01d0d8b6e20857a37849285d34b
+Tag = 48e7579382bf4ec34b5657d2c18173b8440b4fd537a5392b
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 12b8bdc361d8d6487f8194f086e55a1de3ea4f99110fda902ec9ec717c45438efcc2d1e3cc5513
+Tag = 9835085d867fd41bbc357002aa72a6ceb9aeba3ffd7f3623fce41536a22d548d
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 7142c5c1c0125b55
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = fa4c7657123391ae19031907eef6012c
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = b0dbd3da6133cea96e68725fe014265f7fe65b0574e050ac
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = ef53607ca879ea652c553a9030a9f7dbdf95fedce85c48db3008a4af735f52d9
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = dea3b663ecea5656a7a4237626db
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = cda8d7416393443bf2da7f49eddd
+Tag = 9824d7824cd4e457
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 2abbdc096b778e1dfe7be31492d1
+Tag = 746f3807e92fc18a18624c2b34c436a3
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 69516a5ef2e1791a375d6b59a659
+Tag = 46c4614ecaf9a0cb75c044e529780bb64097787a6053156f
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 4886c87d92b29f347ff4a1f0dd0a
+Tag = bef5d7c1e1730fa5aa3539770977ccf1229205529e014f56dd77efd0c6fd67cb
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 09c6e930b6ca0596a1b67ae24232d3b8a557a213d3de20ed59532b0cbd4696b7422ad5
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 403d162f5bd08f296cf017e53cac48669c93b299db4577128714f07bfb5ba4afcab2aa
+Tag = 56cc8ebf38a8d8d7
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = b75b1a24c7e3bf9390e8060608a50e990a0169a94db4d02aaff0d799f9f6f4e56fa986
+Tag = c43b4745ccf44071277dcf6552ac9916
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 83702b3965edd17334aff104b76e0743591a5cd0f6bfe362cf0bf9caf14dbc9bd5745b
+Tag = faf61a70197fa850ac997214719a30d84da13cc6a41b74b6
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 14ce43770da46bcc9ec34c35efce070160e05a729f36a19c5382f3cd15b13968497a3f
+Tag = 4a4d7a23e04e4821fe3d6bf7b7f7302fe82b8298b2367063e7c2ff7826334738
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 26d46b11e7f9135a
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 883d32439112b62bf1c6e2cb07e7ad42
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = c775180b15683c4542a5a45d509f545cd03487cd9dea41df
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 5b4c45b2b2de6c533d25677a6dd97dfc86d5e6a47b22d889d3bd9ac901c80e02
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = d450804bccdad043f813801121e67e53b6fa6c9a
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 513eafbdfe81647c4cd965f531c2110cb26f7d29
+Tag = 71a94de20b1237f0
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 2d9871c36300491ebe323a3d74f5cd5fece1d240
+Tag = faa0c16829d382b30b1f08a4806da3fe
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = a211e996b61fe26a0aa7206bd67f0a952749b8f2
+Tag = 48c363ed66e4a316ab4073901070b29b0ef2e918619a3761
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 2fb2fca54c002376c486ba8f00ffcdf05bfc95bf
+Tag = 0c071d86b7336f96821e01bbbb55fce894d579a85065ad32f3f0dbef9de7f54d
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 39588242e682aa1cd357837ba66ad151d53cdbd995d1d44734172085702e99b001b8e7994de9720a839809f98e3986069622
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 6fe7650c925d2c763e653513539004b16c7a5fcd136206de6a52152b49fd7a3e11a89c1675724f7d81822036a774bb944d50
+Tag = a71b984d07b5e93e
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 343ad6b2c3aa511be258669a521b970e84f0311a5729b4d7e88f02e22f9bb4ca1e5b4795b93f6fac8f2e49a0693faac21051
+Tag = 938a5f7012da0fd94e8f6ec1aa8a5866
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = eaa38d05dd44d118d4a393f7d8497a91039629849af6d50b46fbdebbc3302fff15ce2d1f78241f25a8fa324624302bdcd40c
+Tag = 60446a7e6ee27d5e8e91454fdf394e50d66ad547a50af999
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = ef0284ddbde5ec1f099c0582275f0545b6296efe53197baad5af222d95b009e93f4d97cace691f7506ae872c8eaaee77b31d
+Tag = 89946133b230d1e9edd7a7e7dee4f3298770405ab803d39dcdb35d5c2161fd2d
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = a86c502b02c9cd0f
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 4d7cc92763149c37e9d116f4dadc025b
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = de3b473d8700feb87e70efcd3059d75bceffb5aeee1e91c0
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 9c05826f8a7cd1f4e1fa6063adf4f055a25b666e81c74566cf756933702e9821
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 8b174a6adc37126cc7d4f67f7218289d7ad18dd3630146bd04345390
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = b228565a2a53f0607163ec9ca41acb7a237a5e5990bc23fc48dfef47
+Tag = 932c4f7c64706119
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 169fa8f63845c51a9fd3075426e37f9bb62a6d9337f10c8d0532095c
+Tag = f59cc2b2a17bbfaef752c001d78388a9
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = cf02ec1738afef6edc2487c8c813f446164bfdaa9a067d7a1cd223a5
+Tag = 53a8ddbdc2585b63fa3bb7ec8e9b017ab8b261defb0ffd05
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 191668cdc6cfaf0cec27e81cfe80bc4ee2f52404e28e6b0055d60767
+Tag = 135605d08a0b43407e6533572cd0b1268e1e75103266de58ba259c1b7178f9d6
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 57fff8b8c0d6c791
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = ba4d392406911d8e6758555dc1850d43
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = fc3528db1b82898d5a1f5401e5c26e712cbf78804895c603
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = cf9c6ac0faf7af8e713a66b1f423a05b007dd6920e82800690f13363ad2d860b
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 8f77a9cfefde522254077c7bb1964f11cbea6c3751dbfad50d6f1eff4ce6becaddc6453ea355eb
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 60734e5caa70ca331eabaea193247fef23950e3b1754f9c241757cf610d38d0128baf268a53396
+Tag = e898f37c48c61c92
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = ac9f14e363382339e58c84e2211c0bda4af13ebb90b3c064b492caefa97cd6aeb4e5bfde046274
+Tag = 3788179d0effaf5802b4aa0de3e93175
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = d40199196600e8071c48b30a5df2b539ccfdda18d4e1c32d761b8d77ec95a5bf1677af929b75d6
+Tag = 3606bff5444663aae8b39843d09f5df4d52a5d17679833a0
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 93ed833632176214c1753ea2220d7b368c74dff0c8948917a2a9fcd3f9f98bc7d1a304b2080205
+Tag = 4efb1eca08f6a04c6ab36ae83583403a189c05f430530594054b6ec439d5f215
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = b328651fa39ee259
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = bbf17dff39fa3e6efdf725168b45ee76
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = b98928d713e58ac715ef237cf2fa57c0856fbe565d039e39
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = d1a936c46d8d2faedbf3096eebaa39ce480b1384a8714f94a3fc93bf7cae63d8
+
+# initialize with key of 128 bits, nonceof40 bits:
+Key = 37d069029b34cd66ff9831ca63fc952e
+Nonce = 5dbe1f8040
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a0bf344729866417
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 69174a512fc198b1181e7a4df67d319d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = adeb5e18bf0f939d204a3d868f4cf0834456e5a381e3b97a
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 0144a84b45d5070f38466b7979ae6847c9f15b090f3673b404c78dce92ddb272
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 025d7ef732
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 69c3f1256d
+Tag = d0c4026c185d9dc5
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 972efd7662
+Tag = ce2d22f9244e3fd308550b8703a916c3
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 9ed800bf03
+Tag = 82e847c8e823daefa252563d66cbe7ab1373798fbd31cda2
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = df8f7e4d7b
+Tag = b0ffe5a7d337b6503a9493fa273a1e10d41822e78eea26841c6d6159647c1e51
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = e7bdbb895d4ffe9df0fb25af
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = a555367909d501126fa25efe
+Tag = 8b2841a3c88781f5
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = cd3d7d15e61d7122ebfd7a17
+Tag = 11bc1aa59d1b43ab67b172c32426fd72
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 85aed39b90e8acb4a19d1ab8
+Tag = dc76f95a7ae30cd7a0205a1d88afffa22ecf29b65cae3de0
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 3dd25110d96f8723e504ee12
+Tag = 4d829b3993b7f7e1f02f8580a3027d2c833af27c20983342ecf5199b886fccf6
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = d94b4ea6d2643de3dca20fa356c425a11f701d34e58d1e
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = f82ad54ecb8e5b87725ace7052fbe341873cc2373eeece
+Tag = 4866b1028bbcda0f
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = eaab6fec07dabd5695c707e9c1981025d4bdc7d95ba4e9
+Tag = b514a55147a9d2d1faf43e8dbcbb58f0
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 8286f493db4227e8200233b6244fc49178410fd5152dfc
+Tag = 02967b30dcb213fc81069b7d6a8bc0d94433a4ec452b578b
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 2c477417f67ded6531b06657ef288df794fdb0a610aeb7
+Tag = 2f29ddc34585c8fc995cf620c68246de5095f8b5b9752837e06652293ab9761a
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 0ea2df5c2a34cea7a6c5dc33fa4c71c8070d337e639ffb2c2db3cdb0b628d325a225409bbf565d
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = d5ce0a6106fe8f8b00e76c77082ccec1341fb7a33e6962a64bae63a245f6d748f2f01769a3659b
+Tag = a8393278b05a0f19
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = afd7e5adf765bfc839c9d49c180c91ff681a8022062cb34b45392c37f319ab10396183f4b64ab3
+Tag = 0260d63ad017d31279bcc1391e4903d2
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 6e7d330db5e1251203e560d2e47abd7d5611a4a3b720469da86a76f936165a9889271268c6aff3
+Tag = f9c177c7bdf2036f8f228e6dcbf23c17c7e07833bfc2e422
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 27cbf66e34e38f073f2b81b11d72c22cb332535b1e77a83d34ec7e2a5db4a474d6e457b1ae02cc
+Tag = 13fd78893554fcef432213c2e7d014a7308090b7700757f058621df78c10a072
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 12ccdc38e9d9bd8c
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 0f5d19efdc163633aa386c4b8c5ce6f8
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 4bfaae2d3fd7d71cba683fcf3683791461a12b9bce420b3c
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 62868296d683d43759c6fd6c04a640d5ea226838c376c21a1165f710c53d2730
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = cf9e3622f2fc5ba360e9b78c8fd3
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = bcda25d6c31f6015c6b6a54338e3
+Tag = f3d7ff167b3b89fc
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 53dff3ef8989e7dd63c8721f11a5
+Tag = 76b8d2708624c21df14f922e47164d9a
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = c040fb7c2403b5ca1f73c65623f7
+Tag = a1ad9148eb12819175ba92c0e33e2595553e56b297ad358c
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = c59ef45c6fb945f3fc33b4995f1f
+Tag = caf6a11e62d7719128c5527b05f2cca42beb697b001f90efc8d21694c7d36928
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 85209c4dfd6cdd31f59af2ef4efa63ffde28ac17d95831cabdca71a4fe8d540bc58afe
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = c72b3215c2e62bb5833a3a0e09f0778143a8408aa2284d8c9b636bbc1e5301c966d0f1
+Tag = 95fd3bb9b6c0b0b8
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 1550de9d95781828128c37202447e3858ba33a9a99a7bed49b309f0b6fd72582ed5880
+Tag = f1ad422b42d577742ecd1edff9275eb1
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 048cf3fe6aa873a8a065e87dd2951b39b7f8ed6203c672f4d933206b363065b2dcf811
+Tag = f7cc375bd478e69c1403dbd2f8fea478f3cf3e4f6aba4588
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = e3192664d1be3a56c178ced6a0ca81e073df82698eb8817e3e1a4ffa2477abae6006e2
+Tag = d07e0c4c54a8958c003781f2eb2bffe4a83fe1e95e4e994c734c7a0d1631145e
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = d58b638256c19382
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 6de8d2ee9e52c794dbe35af088baa1ae
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 1d8f4742af14b736a1801b6b962f3135c5ecefbec1e846cd
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 5fda57fa90eb612bf2649b10e138ebefb0b52c2ba7a958d19a5a8b8caefe54d6
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 211a73e28a611b45356a1c209df73a6ed78c1e88
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 7b245decfdb1a00d6b9f572562e62cd278798b5a
+Tag = 4f5de8fddf031b8a
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = f43322657312700c6ccb1d99ec0307a3edb3f891
+Tag = 4ccd504162a5b715b7c81fa7d0f5ffaf
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = b70c0edc6bba0e8148fe91c76cf428939d699976
+Tag = f948f9e05b3f2ba4b405fe67ed5700a2d1a71e20c3267b46
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 3e09f2af80b8ed0eb64550bd852c3625572c433e
+Tag = 232f746a1dace545383820c0916f56a6427addec7fd60f5b92ff49cef15dbab4
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = c681bbca693ba38acbd308281b681672033f7bd06ce89b3ae410b9d2048a4c820d640e77e9b4fda381f9ecd75a5f43450331
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 8389664a845ed8343fa6ca0d17735c1bd067cb803b93a11afc2a8253974e8bffc105dda0dc1999087abebc225ff86daec9b5
+Tag = b395bc5a8a996091
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 4a2840ca81c612baf3ba9349c5522a8fa68e94c95b8a52154991189b86d2d92a590498adf5aa4fde1a51181f3e2a8f0d7357
+Tag = fd4d3b35fad8a34434241c0a067e4101
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 421c9d01a92b7ffe7dca66a26a205e6c5cd06bac1979af45b15207cec3bb6ad6e6f7d3a90bbb35a1cba60aea89bac31b8d30
+Tag = c96da1dfc2c774cd024cdf3f41966a49c24cfbd2db83c16d
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = e4f7c8708a89a4a958c9fe97d5aa0460d1b57ad48d7409c86d4206c124bd36cf3c0896be797f64c99031644bf28d89e9291b
+Tag = 548ae02947e11b16276986dea450f0ab82a1e2f418de58d8593b413d6d885ece
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 315abe33e1fa3a1b
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = b799fe2daf6806e407471b79340129b2
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = a545ce7919908481e462d95aad65c6644a2e692c2dab201a
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 8fc3dd98f5e52b7389659cca0789ef811af4093343d3515f6d58030e4fee3717
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 7d7a9d63ec3c8a4c7dcd737c83fd942c46da79c09952f6b1db79bd1a
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 227c36d848f5460582e0bb43f3a3a9eed31b0b79228797e04fa2c63b
+Tag = 838e5525972d59f4
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 6fdd3baad768bdf4317fbf7e80ca55972c7228eb44cb7a4c0acab219
+Tag = cc7fc1dfe883cda6ae0b2886b15218cc
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = f6682839d5273a39b209d8c3613f0cad901c5813df0e53c1dac06ad5
+Tag = 330ef6eadbb0ed4730a6f45473b0d38ab788bff927dccd9f
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = a8c0e72f1ec9d9c1a3cae4a7ebf8e700fdfe6af96f4e4d803a7465f1
+Tag = 7088ee0942c3da8cf446639ae0f6884fc3ad917f450d7a7ad959becf1e9b169c
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = b7acb4e85e6adc07
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 59d6fe6d5b53e34fd40e8f1c7af4b6a8
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = b2e43d8ebd7abd0bcd0528b88e91ed18f883b29587d849e8
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 510b18524d053cf696cba13e801dd03a2205a9c33d6d587739261d65b938ae5e
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 9b4387c9102209078ac0508d2a2783e46115d8adb4feffc909e68b312595555ee34040fb5800af
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 6710bd78873ccea116fdd99f385d297df5353790fe28c61a82a093633c2ccaeb3b0bfb3301500a
+Tag = af3756fec89accd9
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 893dced334c5d9a2f571743a8474d16689ebc7a547accbbce4902c246140c9e0a6899d3cc1a5aa
+Tag = 49f22e73a2a49cda6f7edfdf492bde49
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 1fbf81fdf405cbfccf1531ff7777efe3891d5605e9b12fdb41c23df0b975072f56fa863296fb2c
+Tag = b06f612809a4a0c6e3fcfa6fe6ee21ac316914cebfef891c
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 214146bd51cfce033e2f705b2364a4bbb0aef70acaad19d1253e282aec1247f0264f731e988608
+Tag = 3b86f2a10563571922c03f7fad4c508dbe76a157b584b92756fb3fe2f05d8757
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = ffc119f7f11d872e
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = d349d363d10aac13b131517195c927af
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 2b8a49fbfe435a8d08257a98903f8930fcdccd0ff12a4e82
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = f6e24777a436f91215ccaf8d3f23952928db2caa4bfffc25ac6f38a02bb66987
+
+# initialize with key of 128 bits, nonceof48 bits:
+Key = 38d16a039c35ce67009932cb64fd962f
+Nonce = ff60c122e243
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 74465aa2941cdee9
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = fb910cb1e42018d35d207b0b61680c22
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 8a04400a7ae4da21463ab9befd7759c367dda38d772d8ca6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6eb9dd8e5d6ad4156cac08ad3438ce476c6a22a83a5f365acf642bc9df53c76c
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 57c8416605
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 665610c681
+Tag = 2f375019ae5f3509
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 9b6a183272
+Tag = 7c98f4bdcea2bb31bca257c08ebcaa63
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 77bbc229c2
+Tag = 82862a74cbf651d5be057fa42200c41b6cb64ece2425cfc7
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = f931863a09
+Tag = 69748d202037dc3e767844e44c345b82ee21d9cd239b28289dc690367ff6ff21
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = ffee65a9ba6d1b29effaee52
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = f8e510975d76ac44b4fe955d
+Tag = 55a6170d970d0d29
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 4fff4ebb0acc57679ea49c2f
+Tag = ffad6857f6d9633d51030cd51206b10e
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 869d873d4ddc68093b0272c8
+Tag = 17147a21cfe855f8b110e8baa1155fb7a46dcb5c63e3819c
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 42cc90f57bb6ef5b0179a808
+Tag = efcca878777651449ff0ca51d0baa0303942c4d7955ddbc321ea8bbfdb53cc14
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 789b9e08e00d9860d7bfdde8c5f7708cb979a001be6d4f
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 2dadbcff21312696a15ea39bcc463e3b482e5cfdf77dd0
+Tag = e64e705556bf4424
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 67ea57e2b7104af240bd832169a8a713e2c7ae51f3473c
+Tag = 7fe5b6b84f71321dafae7de5ce5a2235
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = f2a8836ae20df2942c6dd66533d5d642c04bc6c925dae3
+Tag = 88634a30ec96ad94e38395ef14d3ee7bb1e292c84946ef02
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = f9116a7519660f094d04240a0c9b9236c74aaaef2149ce
+Tag = 82899175311179ab630cb9300ea6f67bf87e41ac8035511342ba355c6dc9e05c
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 20f442e7facf78952733cbc79316f65f9bb94d6a859dc2a15747ec713bad73092057dfec348f88
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 111877b99213423273a9123525df0ad01ec013cffd8073b1ba08917e1b41ade727e21cffa0a122
+Tag = 368641139f731e36
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = afae1b62d437803ec753bb41bc75ea70df27896b4f4b9c5c222d4aa661e9234ab351ed6bbc3a94
+Tag = 2be30f47e7d095e804b3ee515e02c3a2
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 518e4138c16d575d31435e9485bfae56b9a3f71e4d20560370bcf759ef1025185da9d0481ded04
+Tag = 372a68ff4281ddc1494d2ccc270dc631e924bb6f6fa80c58
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = b30b77b3d82cd320d4c603c54c5693e88a20fb5091f7e89cc8de4d51def1d5c73d8b174d1ae99a
+Tag = da8ecbacd0a44c3605243c0b91db4bebda7871e56cbf50c330488d60994f02fe
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = fc5ef1fb8447c830
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = fbcd832c2f9f9a59c9fe597818d91ebc
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = ee59bd76e1ed9032e02f31ed7cb7813d612f390432388f82
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = eb94ed38f3d9f98b5251e44c8f0cebc56da24d4e1b4398d9ee321d9154b4a8e9
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = cdc7498496de94d1e6a17b759129
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 179055f7dc6df8135a092e203d22
+Tag = a0c96f635353c4b7
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 02226d36859c65c897b90a849cf2
+Tag = 8149ada40bcf30f2b0f3a959aaf349aa
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = cbb8fb9a6c20234224f956771e3c
+Tag = 0cdc1a6c463b5d2c10fd78584895ece597d21a1cc0db79ab
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 8bdbde0978b00ecbbbdb6399b9ed
+Tag = e3453ecf7d7aaa3834bb39b52ff8911846c99cddcc559d001dbde0d274cb7536
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 7712981d8f40b8c97688fa7fc5da8eeac421d6b518abf290dde300a1cc3be07988991f
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = a0bb689a2cf59e4f942f9d451f62eb55b222ac9251fb106c4d4fecedffb465b8c2af60
+Tag = 384c326288bee801
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = e0b926b2bd8cb417ee050c92ad2b15e84b7636a9e4284195fca19f934c0016dcef6f36
+Tag = ec044dfd6d64fabb1e4c95e3250ee10f
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = bba6cce2b0715a0695eca0312ecb6b0fd8ecfa3d9c7736f03076b0de0217d1ae2de6dd
+Tag = e288104e34335f6285517af7e53292dcc709feb20ca4ee50
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = b3f71e697ff1d560e2b0bf464f4a0ae6e715f615454af9afbe75fc6a63497ab7253dbc
+Tag = cba3752a024fd03e1ace835878350fab5d3b22230b22c39a33fb7ddaf409caaf
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 41a8fe80c0558ee7
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = a50ff6440c90594ceedf1213c6b9959f
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 2fcfd1941b165ef1292e6fec645bbfa66411b5ba936ab665
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = f5d664a8821eec435ea39288bae1992a7a484f95f9207d915464e3ecd5814fdc
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 9dc9e5a85e07e4324185a5bece9d79c94334b4b7
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 846d5fbdb2c3f6006d7c2612c92379d20c2445bb
+Tag = 4ec4d78a4c2fdcb2
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 7791c77fbe8530ab23b3a4dc35cab10171d4c2bb
+Tag = 07a8bc227db95a0b7c5fc11de1ae45e5
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = a2e9739bcd39cf34f9bea9cf1289a2f449b9919b
+Tag = c7998602fc7ac48e189a950e7fec73ff124fad782833314a
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = c8b0d2d43383f1714483aa9248e73e663f61c845
+Tag = bb6455957edb4d08885139e27ec0996a41a29767d6d8b3873bf0fc0239d34b2e
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = b4f97e2b591400c20f0d22651390731fcee4cda2e0b4a26949b6d8fcb7b83aef3b0ad9454c6700723c4e6cb5eadac8a71fb4
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 3a5df3531bebe00bcf73e499a44576891f724627b20c6ed83082e9205c36da0ee05ffb5bada580bd9e1cd92e975045ac8ddc
+Tag = 8609a1ed1af51830
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 3a753cc236f632b0de309e750088a85f4e574fefea7e80fe761920c7368b14de957ed9da4a9da1e0d26725bc7af292d121db
+Tag = 59066b5796878dfc6de594a5c350e1a7
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = fabb2da76c26a2f31bd8ffff9d705402010d778bf3a1d5097960a1073cc2083b37aa09761af36c12f99efb451c236b24303f
+Tag = 37b132eace996dab7c50b4f57bca5a219f204c2861e54f93
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 29263aa0b00a4dbca4b34780e5bbb9bd2ff88cc7a0e7d275a256bbc428109c7e6f9d68b56df583a86157c13465cb7c3da66a
+Tag = e17513425b6fb50e8d6b8eccc08f483548d2773e141591f72d1cc6c5c948d9f0
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = af8359ecc5781801
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 9108d6f0a8dbb2175d3834326ea196f1
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 9a67a05231138df24a06e1ae024d6b6a70750cd3f5cb36be
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = e8144ef9ebf38000dd263354da8f4fafedf59a542f07829d2a1a214eaaf4d484
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 4642b30ba3ed9f1a18ccc80026582bb07ec96fcd5a3c852fc7c89091
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 60fe9f4b2a84bda3717367fe7adf033a96521214a5bdb9b960246bb2
+Tag = 778ebf7c4281ba8d
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = e58851df73c4995bf9a9668b2b0749e3c7b347cbeae9b9eae184db5f
+Tag = c9330a1ffe006d538aaaebd9d78e215f
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = ed80590c710b9917b97f89b330ce8a4f60a013148b2563a049b4185d
+Tag = 72d4160cf0f12e18c4648f36a769c9ff2438aff2ce171006
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 25bcd4db2d9c2ae5ca695aaee98f52b932d7ee3b69e884aebc92f7df
+Tag = 8c6953b261801524d4fdaf6f2603a10e54ab58610efb6f1ba721bce84d40a4f8
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 7cdc3a4feda0a50e
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 1d15f37546668365f438a1dfa2a14b32
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 8923ce03b3463df41ac7b2448545a49c788d37cdc99a5442
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 0db3e7666116b67b0532293cd00327f85debc27b295be4b424641e0f95e03b93
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = f40dbca4fa0cc685729d8acfea6faf40f5313b30fb336d495263db73b8c4cd90197c365ecace18
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = ab89e3828979c221f5aec60db0b6608fd1471a6e850ba9c86f9f0913e2c276e11772a55805564b
+Tag = 2abbe0e1d237c273
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = cf135b726729e925af07fe32973a062a6c42633433176949bcb85e239135f9244d666b721724ba
+Tag = e7492d1e2bf6bf911ff223e296ec747d
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = bf11954e85898e4a633517dcb924d29815b1871eff36adbdcb6ef5a8549cb2fd308db8aea3850d
+Tag = 3b18380b2c58c79450e1628b74fae4a8844facdc54073b10
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 4c018ac62af8edc80dfd810be0ac5281f9862799d1587708bab211c4d76b9738d5147af41342ba
+Tag = f283b21f2da33069ce42adfa42c7952a5d2320805902c31a870be2ba4809cf3f
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 1825eda11cec0149
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 1f505d3c5463684f7b62b2b172047bdc
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 752a388842b9f995a6569b3eeca15261800d6b4324bf44f1
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 67cb616ce2c5e01bb09aee89f0bebb23470137299aa02a1f27517dd264de1cf5
+
+# initialize with key of 112 bits, nonceof64 bits:
+Key = f68f28c15af38c25be57f08922bb
+Nonce = 41a203642485e647
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = feec3361eb26476bfdb764b7080a5c89
+
+AAD =
+Plaintext = 3b5cdc
+Ciphertext = 0f4c11
+Tag = e28768020e1a68846865bddc68878275
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = d5259380cc43ab
+Tag = 84633603533fc7001b6605374fe503dc
+
+AAD =
+Plaintext = 8fb03051d1f272931334b4d555
+Ciphertext = afb90eefd643221a61da2aba78
+Tag = 1fc98fa7b96ea5b6ea60eb7e3e0b716f
+
+AAD =
+Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
+Ciphertext = f5ca5d62d8a848949f7fe05ab741b72a71573f7d38d9
+Tag = 3e9fd80f6bab5efa1988aeef138fc4d9
+
+AAD =
+Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef
+Ciphertext = fac002871e861059a18163eec80f6679bb8986939230fbbf37dd00fcf1ae9f1e71503be1
+Tag = 272baaf61f68e94192e787dfc8f6928c
+
+AAD = 2abb4c
+Plaintext =
+Ciphertext =
+Tag = 74c4db001fd90a8d2e3f173badc92330
+
+AAD = 35c657
+Plaintext = 4e6fef1090b13152d2f373
+Ciphertext = 1445adc6a5c019ebb9c762
+Tag = 5830834785c584c7ddb2dc96c9bc8f74
+
+AAD = 45d667
+Plaintext = 6e8f0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9b
+Ciphertext = 1e896279917f2aad1a039ab725d04e05c52816ecd3119d25a0e021
+Tag = e235217acd6efc377818e2b25a493374
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 616f42d34076dfde645b33f565adfea2
+
+AAD = c152e374059627
+Plaintext = dafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 684b8d2b49920a9dba8496acb22487
+Tag = 367a60f64ca783965241b04624ead157
+
+AAD = d768f98a1bac3d
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
+Ciphertext = 0bbc2c946057fce1af2b6d837b298bbf1cceee309d78220b12d7e81fa1ea49875ff661f890
+Tag = 7374958744be3129d008a6b950dc3e46
+
+AAD = dc6dfe8f20b142d364f58617
+Plaintext =
+Ciphertext =
+Tag = b4704eaadf0b67f3e32d3d80a3c05d61
+
+AAD = f08112a334c556e778099a2b
+Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d3
+Ciphertext = 29f85d1d755d60658c25191b1f4b77b6818b7067
+Tag = f6dc1187e701e3d5d24faeb10c379dd0
+
+AAD = 0e9f30c152e374059627b849
+Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3e
+Ciphertext = ec184614f1ae738e70afb3a02737ce027142b75e4e6c26cf7c8142dda6d64cbd0e1afbcebe1b8bbc40b6d5cb0635159eb517
+Tag = 18d7e357e3c8a0afacd341f1dd68529f
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = eeedfe4ab439f0cc9961a0be6924d63a
+
+AAD = 65f68718a93acb5ced7e0fa031c253e4d465f6
+Plaintext = 7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2bab
+Ciphertext = d65aa405dc097df7dcc2dc119dfe486ebdde1d945a92cff78ae4c0
+Tag = 30429a55818c7fe453990e45632184fe
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = 70902dac026cd021f71ec9e30e3c3eb7
+
+AAD = 20b142d364f58617a839ca5bec7d0e9f8f20b142d364f58617a839ca
+Plaintext = 395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b
+Ciphertext = 5718bee9b6d10dd0da942a1133661e51ebeb4c7ecd125ab1ad78af8f25ae2142383ced34
+Tag = 0a038c56221a3a1c435c967ae4930c12
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
+Plaintext =
+Ciphertext =
+Tag = 3877f01eb5b6d64539ba496fb9691748
+
+AAD = c455e67708992abb4cdd6eff9021b24333c455e67708992abb4cdd6eff9021b2a233c455e6770899
+Plaintext = ddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475
+Ciphertext = 1510ba40c235213d54b2c12fcafe25227a5831e673856e2ad91f50e739bb195e56ad00431b67217060ae0037b76b0401
+Tag = 03b7e385c571876b54c77273ded03d1f
+
+# initialize with key of 104 bits, nonceof72 bits:
+Key = 55ee8720b952eb841db64fe881
+Nonce = e243a405c52687e8a8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 8750c2d4d7351d28ff88f1bff4305888
+
+AAD =
+Plaintext = 99ba
+Ciphertext = ffc7
+Tag = a89e2efaf43b6ab885e04083d2bf3996
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = cc9eff4b77
+Tag = cf4c7d3f6c6e14bb7dd34d4f0cff33e0
+
+AAD =
+Plaintext = 0728a8c9496aea0b8b
+Ciphertext = 2e5efc6e10ea75b864
+Tag = 3d0130753beface87ddb647a01573a47
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a
+Ciphertext = 8e5e1815b9b361ea2125cb475c75ac
+Tag = 51ed130779cbbfc1bf2f9037680278b5
+
+AAD =
+Plaintext = 85a62647c7e86889092aaacb4b6cec0d8dae2e4fcff07091
+Ciphertext = 981fe0590af5b2dca4c80906e4639005759822d8edb4d080
+Tag = 364a22729a51ee1593cb2058fbd22cb9
+
+AAD =
+Plaintext = 61820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d4
+Ciphertext = f93f38b53ad30aebd02ed3ceea06e292e068281cb6bc5edaefc93d6279137c14d7013d6ae53c
+Tag = a4b59bce2cb127ecbe9d634c552ccefe
+
+AAD = 8819
+Plaintext =
+Ciphertext =
+Tag = 1eecacb20b0e7e7fec49d5084172283d
+
+AAD = 9122
+Plaintext = 092aaacb4b6cec0d8d
+Ciphertext = 83db3629fbc8733e47
+Tag = 89218bd6f160365f5486ee7f758ba9d7
+
+AAD = 9e2f
+Plaintext = 4364e40585a62647c7e86889092aaacb4b6cec0d8dae
+Ciphertext = 7a5e2f42226cc58fd3e61673c515228cfead641ab560
+Tag = 93859e558d9dc29f9d7b1c33c8ca872d
+
+AAD = b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa0
+Ciphertext = 4a64c06c869194d698bb851e947f29ca5dcce1ded3979bcc9a7b88b7de38cc1dd9b0a8ca1cc729a9400d
+Tag = 2392d646fad11d5909937822e1a685b0
+
+AAD = cc5dee7f
+Plaintext =
+Ciphertext =
+Tag = 1bc63333f526ab4c5f107d5d5c4f657e
+
+AAD = d768f98a
+Plaintext = 4f70f01191b23253d3f474
+Ciphertext = 09c179056683acb16f55ea
+Tag = c820b63049a906b34c7beaabbe2570ba
+
+AAD = e778099a
+Plaintext = 6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+Ciphertext = d35f866e0d088fd0a7b6b9f636134823d70c43ca35d4c26296db24
+Tag = 35e0f79f50250cb8003ced10ba6dc53f
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 6e7a1cd387f79d15ff3dc4d636a80d45
+
+AAD = c051e273049526
+Plaintext = 3859d9fa7a9b1b3cbcdd5d7efe1f
+Ciphertext = 7917d7ec8b0aac6fdc02b3213393
+Tag = 74a04595ab0589ef2d1a90edfacebe08
+
+AAD = d566f78819aa3b
+Plaintext = 82a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b333
+Ciphertext = 0f2cac3258718cddaf515a17fe0570d717487c1c45c0d55059b4d08117ac1831766a3a
+Tag = 84e0a4f6b7c4f08d30b97f2068c9b5c6
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 73f5b538edc872bff4e1912bc75665c9
+
+AAD = 4cdd6eff9021b243d465f6
+Plaintext = c4e565860627a7c84869e90a8aab2b4ccced
+Ciphertext = 9236bb7a5e13216177be3dd603d0685173c5
+Tag = bf551d34bd5d362eec05f2c0aadb74df
+
+AAD = 67f8891aab3ccd5eef8011
+Plaintext = dafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+Ciphertext = 59a05ac9f2720e4193d7a96d5b869afb7f1651479c0d9283053ae47efaf0547ab00ec014d481a5364a2bb2a817
+Tag = 366b8d5b7bfcf4d597b5175cdbc2a7c3
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = a29960a564c5aee4c0be50e28328d327
+
+AAD = 7b0c9d2ebf50e172039425b647d869fa
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 76bc3c6c69707d0a390ca89a532fcd547ae515046d0f7f
+Tag = e04cce6da522346ad481f81c201d552e
+
+AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
+Plaintext =
+Ciphertext =
+Tag = aed235e02e2d357a06725e36e95677a3
+
+AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c5
+Plaintext = 6889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
+Ciphertext = 856bb203d6330e3ec20ccdef7881028da3ee533ef8b4658947ef045c6e9c
+Tag = e21af3025eca96af036e426774254bb1
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+Plaintext =
+Ciphertext =
+Tag = 2b945e06a282cd3f9cf7c12108d33474
+
+AAD = ab3ccd5eef8011a233c455e67708992a1aab3ccd5eef8011a233c455e6770899
+Plaintext = 2344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f5759616
+Ciphertext = d2c808f8a075f1a85df7261216a5745e48c43f9e9615d0ce8b5900830dd2aa6f14472ecbd85696
+Tag = f3dc00cd7e5532f3240b078c57f1e0d0
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = 2c49e6ebc4abf2de91a3ea40336075e4
+
+# initialize with key of96 bits, nonceof80 bits:
+Key = b44de67f18b14ae37c15ae47
+Nonce = 83e445a666c7288949aa
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6a16bfa52adc435b4a0dab595c65a226
+
+AAD =
+Plaintext = f7
+Ciphertext = e0
+Tag = abde67188f4372e1fc835de25e9f82b3
+
+AAD =
+Plaintext = 99ba
+Ciphertext = 2cbf
+Tag = cf11b42e06630efcf5cd150f208bdbc1
+
+AAD =
+Plaintext = ddfe7e9f
+Ciphertext = 6236e654
+Tag = 52eb36dd4fa1cd8588bc1ea4826b4eba
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = 38a1662228035f
+Tag = 818e5d59344e813689b0b7b85a2ab72f
+
+AAD =
+Plaintext = 4b6cec0d8dae2e4fcff070
+Ciphertext = b40768aa30bcaacac8e5c0
+Tag = f8e6073c9a866169a762a73ac2bfc8ed
+
+AAD =
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
+Ciphertext = d7434ddcc296fc0d88eff289f0f8cf2946
+Tag = 4b0066476ae08ea9a9f2a8af74d4b69b
+
+AAD =
+Plaintext = c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 89c40d15ab0f03f1122ee44f8becac7f35c2564452b9d5a2cdd7
+Tag = 868b52996b2d495a5979bf568755bad7
+
+AAD =
+Plaintext = a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9
+Ciphertext = e0df42ac20a13984643a1339c71b6a9f9ea87a9759a5ff9cbb37377c5fcc50671864597117fdb370
+Tag = 7a699aee48e60b10a04146f6d1f1fc6f
+
+AAD = e6
+Plaintext =
+Ciphertext =
+Tag = c924da559fdf9ab7484d212c9127a5aa
+
+AAD = ee
+Plaintext = 66870728a8c9496a
+Ciphertext = 365fe5800209061c
+Tag = 8fdd7ff23bf3d5e60c8e61869b8e80ac
+
+AAD = fa
+Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c8
+Ciphertext = e46517e0e4f49341b8c2e9aee7bf08360ab5da56
+Tag = 75e3ab8dbea2c5319e0a77f39ddaf0b8
+
+AAD = 0c
+Plaintext = 62830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d5
+Ciphertext = 6aa4d989bde089ba1aa5e7eafb428c5d064fbda91986a9e56c4bc53fb08873ef84fe49d0ce72
+Tag = 62f7a88dcdbb74a3690faebff9cec331
+
+AAD = 8819
+Plaintext =
+Ciphertext =
+Tag = 5aeb913708b94d6065dbbe98c1204728
+
+AAD = 9122
+Plaintext = 092aaacb4b6cec0d8d
+Ciphertext = b54fbca17181c331df
+Tag = e6158af264bdf3671267a316e228753d
+
+AAD = 9e2f
+Plaintext = 4364e40585a62647c7e86889092aaacb4b6cec0d8dae
+Ciphertext = fdd7ccbed6adb362507f7c2dda08bca172717f04d325
+Tag = ddbc6a9926ef517e4fed3276b1fcdba6
+
+AAD = b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa0
+Ciphertext = 55bc98252ee60867b700dba2959e3fa947c771e0d31e463c56f353cb2f60207888b5cb7f7a4598ea7bb4
+Tag = ff1906f14f4a23cae63c549852ad60e8
+
+AAD = 2abb4c
+Plaintext =
+Ciphertext =
+Tag = a26757b5a5fbcb8d8ea2112ec37e6dc0
+
+AAD = 34c556
+Plaintext = accd4d6eee0f8fb03051
+Ciphertext = b22f6790cb30da19cdc3
+Tag = 97463b670f19a993bc090a6c7d06e085
+
+AAD = 43d465
+Plaintext = 2a4bcbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6
+Ciphertext = b14ba449b2d30294ac94eb13a85c1aca735bd5bac94e37d947
+Tag = becdaf7ee80b544af7f587baf51d7591
+
+AAD = 59ea7b
+Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8d
+Ciphertext = f9adcd1ea805e046ab68fe9e1bb771f8b0741a07b0c0e6db745aed23a20091c1834598c54d5d94b78cca09110ca9b7
+Tag = 4a357836c677709f5523266a78f20c37
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 7c2a4b076e23cdf57a0be0d70366ee86
+
+AAD = 7a0b9c2dbe
+Plaintext = f21393b43455d5f676971738
+Ciphertext = aa10960eccfbcdf86190e2ea
+Tag = add0319ed9717cf6c05c1ec7f4cfe810
+
+AAD = 8c1dae3fd0
+Plaintext = 5677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 347c099243c4fa97cd4b87edd87b1fc06f3577e4cd6c0aceb7d2bb8dd343
+Tag = 6729628493f34caa9f8b9593e9354fe6
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 8f29f5c05f9f42b918c2dda3904b7f65
+
+AAD = c051e273049526
+Plaintext = 3859d9fa7a9b1b3cbcdd5d7efe1f
+Ciphertext = 88e4d0a8770db4ada5665e0a91fa
+Tag = 0a941ca77090a270c70d0154f085fc42
+
+AAD = d566f78819aa3b
+Plaintext = 82a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b333
+Ciphertext = bbd1bd63fca1cd51cd47af2e650dd25cc86b13801f8a405b5428e485e0006b63a03f07
+Tag = 7a685d3eb3fe6f56c181667c3c538785
+
+AAD = 9829ba4bdc6dfe8f20b1
+Plaintext =
+Ciphertext =
+Tag = 55b68eced66f6dea8cc00774a91e0d13
+
+AAD = a93acb5ced7e0fa031c2
+Plaintext = 2142c2e363840425a5c64667e70888a929
+Ciphertext = 54c6f1a434de16def67465570a7d947b1f
+Tag = 4c824ffb309fb769a66e604acbac4b4a
+
+AAD = c253e475069728b94adb
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a8
+Ciphertext = 030fbe3f54f896c5a674ae4218b84651b5989064fb6fffeff5bcbfeaff5d07a6bce065a6832a7ce9dfdd
+Tag = 87db84b2e5a3a737a60429a7d954ae62
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = 88c5c6319ef5509baf3a58da781c34df
+
+AAD = 35c657e8790a9b2cbd4edf700192
+Plaintext = adce4e6fef1090b13152d2f373941435b5d65677f7
+Ciphertext = 8e5309dc4bb9c2b506f2b0c96019ce41bc1396348c
+Tag = 9ae7662bff72d7aa0e140ad361b0bb38
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 2a57c7035138feaa25dd2e8d8c57f566
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f5
+Plaintext = dcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889
+Ciphertext = ea022dad670140e23d03cb60d0c03265ed153a281b48a82d4a6a
+Tag = 1abb16de54b0a828867825be208f5537
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40
+Plaintext =
+Ciphertext =
+Tag = b454178699071efb7b3b32f8db2bc208
+
+AAD = d96afb8c1dae3fd061f28314a536c75848d96afb8c1dae3fd061
+Plaintext = 5172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161
+Ciphertext = 8c28093c776fdfe73fc6d8e3d9b4adccda518f50705b7e266acabaa49b097c5e4b
+Tag = 35bf9701bdbb6907fe0ed3b483e793a9
+
+AAD = 6afb8c1dae3fd061f28314a536c758e9d96afb8c1dae3fd061f28314a536c75848d96a
+Plaintext =
+Ciphertext =
+Tag = a98b374e565b5321c24000b692ae16a3
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182720394
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c1
+Ciphertext = 86a7ad4783f3ac54d838fbbc1b5d23385f4967d233ac70288b0e8effbdcf4a72afc9ed904dbb29e5c099
+Tag = 2446a5bee0a1c8918164ca8a69c871bf
+
+AAD = 029324b546d768f98a1bac3dce5ff08171029324b546d768f98a1bac3dce5ff0e071029324b546d768f98a1bac3dce
+Plaintext =
+Ciphertext =
+Tag = a953bbf734348106dca406b86a811797
+
+GlobalTag = 6b2db5c57651366cf83e42dcb3690e51
+

--- a/tests/kat/testvectors/Ketje_Major.txt
+++ b/tests/kat/testvectors/Ketje_Major.txt
@@ -1,10 +1,10 @@
-# # Ketje_Major.txt
-# # Algorithm name =  Ketje Major
-# # Test vectors obtained from https = //www.github.com/XKCP/XKCP
-# # The test vector file format hasbeenadapted to fit the format supported
-# # by libkeccak's test vector parser.
+# Ketje_Major.txt
+# Algorithm name: Ketje Major
+# Test vectors obtained from https://www.github.com/XKCP/XKCP
+# The test vector file format hasbeenadapted to fit the format supported
+# by libkeccak's test vector parser.
 
-# initialize with key of 76 bits, nonce of 0 bits:
+# initialize with key of 1576 bits, nonce of 0 bits:
 Key = bc55ee8720b952eb841db64fe8811ab34ce57e17b049e27b14ad46df7811aa433bd46d069f38d16a039c35ce67009932cb64fd962fc861fa932cc55ef79029c2ba53ec851eb750e9821bb44de67f18b14ae37c15ae47e07912ab44dd760fa84139d26b049d36cf68019a33cc65fe9730c962fb942dc65ff8912ac35cf58e27c0b851ea831cb54ee78019b24be47d16af48e17a13ac45de7710a942db740da63f37d069029b34cd66ff9831ca63fc952ec760f9922bc45df68f28c15af38c25beb64fe8811a
 Nonce =
 
@@ -13,8076 +13,8075 @@ Plaintext =
 Ciphertext =
 Tag = 93578302626c584b87e55643162def7a
 
-# # initialize with key of 76 bits, nonce of 200 bits:
-# Key = 039c35ce67009932cb64fd962fc861fa932cc55ef79029c25bf48d26bf58f18a821bb44de67f18b14ae37c15ae47e07912ab44dd760fa841da730ca53ed77009019a33cc65fe9730c962fb942dc65ff8912ac35cf58e27c059f28b24bd56ef888019b24be47d16af48e17a13ac45de7710a942db740da63fd8710aa33cd56e07ff9831ca63fc952ec760f9922bc45df68f28c15af38c25be57f08922bb54ed867e17b049e27b14ad46df7811
-# Nonce = a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f3
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = bbe5e399a19e2bc46a043f681199c4c1
-#
-# # initialize with key of 76 bits, nonce of 400 bits:
-# Key = 4ae37c15ae47e07912ab44dd760fa841da730ca53ed77009a23bd46d069f38d1c962fb942dc65ff8912ac35cf58e27c059f28b24bd56ef8821ba53ec851eb75048e17a13ac45de7710a942db740da63fd8710aa33cd56e07a039d26b049d36cfc760f9922bc45df68f28c15af38c25be57f08922bb54ed861fb851ea831cb54e46df7811aa43dc750ea740d9720ba43dd66f08
-# Nonce = 5abb1c7d3d9eff602081e2430364c526e647a809c92a8becac0d6ecf8ff051b272d3349555b617783899fa5b1b7cdd3efe5f
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 84a558f21f3a59a6c682c4590d27a31e
-#
-# # initialize with key of 976 bits, nonce of 600 bits:
-# Key = 912ac35cf58e27c059f28b24bd56ef8821ba53ec851eb750e9821bb44de67f1810a942db740da63fd8710aa33cd56e07a039d26b049d36cf68019a33cc65fe978f28c15af38c25be57f08922bb54ed861fb851ea831cb54ee78019b24be47d160ea740d9720ba43dd66f08a13ad36c059e37d069029b34cd66ff
-# Nonce = 1374d536f657b819d93a9bfcbc1d7edf9f0061c282e344a565c6278848a90a6b2b8ced4e0e6fd031f152b314d43596f7b71879da9afb5cbd7dde3fa060c1228343a405662687e849096acb
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 0407ae8dbee55b240dd16834a0000da4
-#
-# # initialize with key of 776 bits, nonce of 800 bits:
-# Key = d8710aa33cd56e07a039d26b049d36cf68019a33cc65fe9730c962fb942dc65f57f08922bb54ed861fb851ea831cb54ee78019b24be47d16af48e17a13ac45ded66f08a13ad36c059e37d069029b34cd66ff9831ca63fc952ec760f9922bc45d55
-# Nonce = cc2d8eefaf1071d292f354b575d6379858b91a7b3b9cfd5e1e7fe0410162c324e445a607c72889eaaa0b6ccd8dee4fb070d1329353b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667c888e94aab6bcc2d8e4eaf10713192f3541475d637
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 7f90f9047a5a91d81c6c4d9dc4b9c4a0
-#
-# # initialize with key of 576 bits, nonce of 00 bits:
-# Key = 1fb851ea831cb54ee78019b24be47d16af48e17a13ac45de7710a942db740da69e37d069029b34cd66ff9831ca63fc952ec760f9922bc45df68f28c15af38c251db64fe8811ab34c
-# Nonce = 85e647a868c92a8b4bac0d6e2e8ff0511172d334f455b617d73899faba1b7cdd9dfe5fc080e142a363c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e14202
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 62e07ec02db8f7caed806b1e3500cca4
-#
-# # initialize with key of 376 bits, nonce of 00 bits:
-# Key = 66ff9831ca63fc952ec760f9922bc45df68f28c15af38c25be57f08922bb54ede57e17b049e27b14ad46df7811aa43
-# Nonce = 3e9f00612182e3440465c627e748a90aca2b8cedad0e6fd090f152b373d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6e
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 8a34b6e167cd342950d4cc8198e3fdb8
-#
-# AAD =
-# Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef
-# Ciphertext = 046c887cfdf2062edb84ea63771b7f289e8ac8bad182ebc3bdf2649c97f7aaa2aaf09b5b
-# Tag = 8a4bb30e51beb36b62975ba5e101e50b
-#
-# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
-# Plaintext =
-# Ciphertext =
-# Tag = 34214632bea9ed43d46769058acbdccb
-#
-# # initialize with key of 336 bits, nonce of 40 bits:
-# Key = 41da730ca53ed77009a23bd46d069f38d16a039c35ce67009932cb64fd962fc8c059f28b24bd56ef8821
-# Nonce = 63c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d7
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 144a990a573dce2d601bafd071507477
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262
-# Ciphertext = f6fdaf27e9da2d15aff5b7a17760a47e6ddba120faab6c975989c281b5f6fa
-# Tag = 25d555cc575b30d1f1a679b06251ffda
-#
-# AAD = 6afb8c1dae3fd061f28314a536c758e9d96afb8c1dae3fd061f28314a536c75848d96a
-# Plaintext =
-# Ciphertext =
-# Tag = fbff145373bb5e0189f6fe2b0820e2e9
-#
-# # initialize with key of 296 bits, nonce of 80 bits:
-# Key = 1cb54ee78019b24be47d16af48e17a13ac45de7710a942db740da63fd8710aa39b34cd66ff
-# Nonce = 88e94aab6bcc2d8e4eaf10713192f3541475d637f758b91ada3b9cfdbd1e7fe0a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf40
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 80af6610c416327bd88947a1fab735b9
-#
-# AAD =
-# Plaintext = c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
-# Ciphertext = 75784025c1aed92ce4b310cbe8de95cde9267c256aedd82a65e6
-# Tag = ee83df8556ab8bdf2aaa99a7a32a5285
-#
-# AAD = e273049526b748d96afb8c1dae3fd06151e273049526b748d96afb8c1dae3f
-# Plaintext =
-# Ciphertext =
-# Tag = c19c142f7da4ce00ed27d169505b0ac1
-#
-# # initialize with key of 256 bits, nonce of 20 bits:
-# Key = f79029c25bf48d26bf58f18a23bc55ee8720b952eb841db64fe8811ab34ce57e
-# Nonce = ad0e6fd090f152b373d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e74808
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 0135daca621b16cdf3179e2d401e2f23
-#
-# AAD =
-# Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e9
-# Ciphertext = 65ddfd8c4b065178f6a8d44619b7c0a89dfafb75cf
-# Tag = e2c6bbbc891f2c00f0433ed1060e6c96
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40
-# Plaintext =
-# Ciphertext =
-# Tag = 687287251aa6a97c58a6c5bc858d40ab
-#
-# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70
-# Plaintext = cff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
-# Ciphertext = 25bddb6f9bd5782537229dd52ef787e8a809209e6abc0190272b0e22d8e10f959f520cbd07fc044eec0e74c0edb845ae
-# Tag = cb9605d5693a1e7540f15d9a7f30fa5d
-#
-# # initialize with key of 216 bits, nonce of 60 bits:
-# Key = d26b049d36cf68019a33cc65fe9730c962fb942dc65ff8912ac35c
-# Nonce = d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = d133938ac5f2f6e2ee1c7a704b4cc156
-#
-# AAD =
-# Plaintext = 75961637b7d85879f91a9abb3b5cdcfd
-# Ciphertext = 03de093cdddf6c6c82612e5e3669de10
-# Tag = 5490155541fc88a8208f450058061d7c
-#
-# AAD =
-# Plaintext = a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9
-# Ciphertext = 0815b63d5ad612100cad9bba77b1f52d667c5c637b4bf0add14726941ba40cf0458a5a2afdbccc43
-# Tag = d931d1f617ddd7b7500ab6aa9798e8f0
-#
-# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
-# Plaintext =
-# Ciphertext =
-# Tag = 73b88935e03861da9d222740597cb04f
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869
-# Plaintext = badb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce
-# Ciphertext = 899e4fe02d6506ae8f67f936ca04e530a942ec6e544ffb87c0a6ae4c62b8418dbb4439674c8f34a0
-# Tag = f30f894edcef80ac350eb5adcc1eb389
-#
-# AAD = 46d768f98a1bac3dce5ff08112a334c5b546d768f98a1bac3dce5ff08112a33424b546d768f98a1bac3dce5ff08112a393
-# Plaintext =
-# Ciphertext =
-# Tag = 9be57f0a67d11df3e8e76802ec8680c9
-#
-# # initialize with key of 176 bits, nonce of 00 bits:
-# Key = ad46df7811aa43dc750ea740d9720ba43dd66f08a13a
-# Nonce = f758b91ada3b9cfdbd1e7fe0a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 266848eabdcee983c4ba7a6e41c8f24a
-#
-# AAD =
-# Plaintext = 4b6cec0d8dae2e4fcff070
-# Ciphertext = 5f6d0c8404e0813f91ba49
-# Tag = 539ca100934ebeebc9b6b1554cd722a5
-#
-# AAD =
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
-# Ciphertext = 3ff7413bd9e4022790036f32bd4f99a441acb9ad9386e083b8c725
-# Tag = af8bf947f279a3f9ef2579a22b8d1b80
-#
-# AAD = 64f58617a839ca5bec7d0e9f30c152e3
-# Plaintext =
-# Ciphertext =
-# Tag = 316290822e5c0995e942e940cc1da6e9
-#
-# AAD = 8516a738c95aeb7c0d9e2fc051e27304
-# Plaintext = 4768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d757
-# Ciphertext = 4e457c12057857f965216a524ac3cbb8d6eccedd86d0b66d416d5c8e1ae97a669c
-# Tag = e5854765170979069898b9eb65dfc593
-#
-# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
-# Plaintext =
-# Ciphertext =
-# Tag = 4e5fc382485ce1b6e612574bfec5aeec
-#
-# # initialize with key of 160 bits, nonce of 16 bits:
-# Key = 6b049d36cf68019a33cc65fe9730c962fb942dc6
-# Nonce = 399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2beb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 9c0c0add92fba0080ffb98784a1d134f
-#
-# AAD =
-# Plaintext = 0728a8c9496aea0b8b
-# Ciphertext = 126a43acc824c6d2cf
-# Tag = 2d9925422842a56ef8af1284efe033b0
-#
-# AAD =
-# Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
-# Ciphertext = a4fad825b5e5f132abad990324ab40af8a0f10d6ea64
-# Tag = 08af7c227c124d202a1e58ea5ceadba4
-#
-# AAD =
-# Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e
-# Ciphertext = d0178c6e0edfe80a1ed2f6c757e8f89376cc402feda5396c5548cd086a078c6378cfb97cb84b4d2fd29f
-# Tag = 8a350ca21a334ba34f6d0644239bfc24
-#
-# AAD = 20b142d364f58617a839ca5bec7d
-# Plaintext =
-# Ciphertext =
-# Tag = 63bc41c7cf9c2211758cdc076cac247f
-#
-# AAD = 3ecf60f18213a435c657e8790a9b
-# Plaintext = 5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4e
-# Ciphertext = 92ec93172c15e1f4f0b03c23108c86ce24e5cc7df85160950fd5c620b252
-# Tag = 1ce55cf9e62e5cfbc764b79558a98d77
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
-# Plaintext =
-# Ciphertext =
-# Tag = ff0900fb38e572ef096969874433ef2a
-#
-# AAD = b445d667f8891aab3ccd5eef8011a23323b445d667f8891aab3ccd5eef8011a2
-# Plaintext = d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6d
-# Ciphertext = 0d75d18f23a5277ff28fd2e0d7693dd522b6ea5df905d1db801adb6bb25808b86b7bd664e17d9aa7da69a806ebca4f5e
-# Tag = 3c945d5ca3e18f428ef1502acad51ff6
-#
-# # initialize with key of 144 bits, nonce of 32 bits:
-# Key = 29c25bf48d26bf58f18a23bc55ee8720b952
-# Nonce = 7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9b91a7bdc9cfd5ebf7fe041
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 8886656aa52038498fdcbedb99273347
-#
-# AAD =
-# Plaintext = c3e464850526a6
-# Ciphertext = 385aad6803dca3
-# Tag = 84d72a9550c382c2e73a2d065c039241
-#
-# AAD =
-# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
-# Ciphertext = e05c31a49979e67837c73f91a0a363a8b0
-# Tag = 4298b04186f0cfdea42bb2455ca13108
-#
-# AAD =
-# Plaintext = 95b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425
-# Ciphertext = e01db73a57bf5e479bca494ed24d9d46d41f7da014ef22347614b70b09b09ef8
-# Tag = d3c14904dac4f05ec3e3448abe2a670d
-#
-# AAD = dc6dfe8f20b142d364f58617
-# Plaintext =
-# Ciphertext =
-# Tag = 41c145336443f9dd02637144b29ab6fb
-#
-# AAD = f78819aa3bcc5dee7f10a132
-# Plaintext = 77981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
-# Ciphertext = 5d116dda7ff03701b2e1f4691a2bfc422bdea8755c0055d32de288
-# Tag = 099287daf4520c19ca15071cfcc8cd62
-#
-# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
-# Plaintext =
-# Ciphertext =
-# Tag = e183b5fb834705ed4a1c19ec7e62b9b5
-#
-# AAD = 27b849da6bfc8d1eaf40d162f38415a69627b849da6bfc8d1eaf40d1
-# Plaintext = a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdc
-# Ciphertext = 9f4fb229efc3d383be35c76ff749997b9cd3cb491e71bb5adb76d196163addaa1a5d649b5d6b07795c6fb4
-# Tag = bbeb40acbab1b2cb0a7dcc85bcd4fe70
-#
-# AAD = 46d768f98a1bac3dce5ff08112a334c5b546d768f98a1bac3dce5ff08112a33424b546d768f98a1bac3dce5ff08112a393
-# Plaintext =
-# Ciphertext =
-# Tag = 5dc8f44711df0ebd9b0bb5bf2dc45d13
-#
-# # initialize with key of 128 bits, nonce of  0 bits:
-# Key = 32cb64fd962fc861fa932cc55ef79029
-# Nonce =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = c257270f5307aead
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = a3265d5ead58b8622275267c01a8c375
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = fb9a01210b12b8065ef9ad1868a55b8a844de3f7f4a800ce
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 7242ba58fa98cccd789e6562f1c9a6026188f2da49f0bd7d68dea8fd1bcfb2cf
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 1536764dba
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 79dfa059ad
-# Tag = 2ae9e002084aef01
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 88d71b45cb
-# Tag = 35b9397b21cd90c1f455a7e5099cf370
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 7daedf33ff
-# Tag = 8432f093a48b2ae39f7a3f9a3eaefd4d4aa3254a443c9622
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = bcc4e409ee
-# Tag = 7d08db19ae102c32342eb0c76d5f9c304484051d796acff11ab108968eeb7fab
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 45deae65e7f59aa351079641
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = f027a40a925f88f55ec7de89
-# Tag = 41889fe2629fc818
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 93d4d881359a85248718737d
-# Tag = 839412743c1d4edfbd922cb94e922ce5
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = cf5c50b0a059299b9f01062c
-# Tag = 6b39b2b3496c7fb1eae353e27c0bc066c1821cc69dc18043
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 9d9bbbbacd607a6ccf8f8006
-# Tag = 6c470e7aad8469e7cf6867c186a72b2933b71180dc1a687fb9209017bb533619
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 1ef93fe206d4d2aec70c994706a2d7681a316a28e15e86
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 1dc2988e1acec91adb7eafc50a0532f5ea54316b2e9f09
-# Tag = 2a593d89fe00d758
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 71f23b8768f5e0a44902e071d7be1c6db318ee05996914
-# Tag = 65d23e307c00e2daab356ef595a90981
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 3e1c59ba869e1a103687cf01795c48f32d7a734fa3101e
-# Tag = 5583839d9500aa19073fad2d87279c89dffaabc3dfd50512
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = 6ba468e423c5aa880ab0a090f27bba454580bac9e4a426
-# Tag = 445d2b3fb29ab6a7d97489cba3c33af8232b61a17849c8bf83e40148edea2de7
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 6b617b841f6e2fce85cc8e637c613ab7a40306991ecb7bf48fed146447308daf80382a34cbba14
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 23a7570c6e8878f932cc8ca5b58b988956afdbf5adf618156660c66ae4ea828b0450694c5fe9e1
-# Tag = dc06457af296de87
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = cec732f7a38772d2578ececa7184d4c332652d09f95833ad31774dcc0c8263aae520849b4a883e
-# Tag = 0e744f554afa4eafde0741d95e07fb5a
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 3bf74e6bddfd3286993c88bdb2f674c02adcf0e4f237bdbf809dd60319f185277a2c5cb9fcfb48
-# Tag = 8f58df391f0561eb9855d4ae0934accbef65fbf79478fff4
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 701f9b30efcfbd0f228f9ec80913a203e31f4775bc5a1f432f974da5b5452fb881dfbcfd3772a3
-# Tag = e6f1227113211ed73bcdd78f9878e9471f661d03ffe4c5d636cebf9b121381bd
-#
-# AAD = 5eef8011a2
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 66f78819aa
-# Plaintext =
-# Ciphertext =
-# Tag = 36b2ee5662b1ed45
-#
-# AAD = 6eff9021b2
-# Plaintext =
-# Ciphertext =
-# Tag = 2e5eb96356b14595583a984393e90275
-#
-# AAD = 76079829ba
-# Plaintext =
-# Ciphertext =
-# Tag = 23ab68933e746f944f1b197b96b0e2d54e94659e5ebc9f8a
-#
-# AAD = 7e0fa031c2
-# Plaintext =
-# Ciphertext =
-# Tag = a3020de3c9c45233cf88eff8d76100e2fe40173042e454a5f4ceff5fb1214b30
-#
-# AAD = 6cfd8e1fb0
-# Plaintext = 2647c7e86889092aaacb4b6cec0d
-# Ciphertext = 3dec13c04189c388c698c25eb5af
-# Tag =
-#
-# AAD = 74059627b8
-# Plaintext = 2e4fcff070911132b2d35374f415
-# Ciphertext = 1bc3b9600705413fd9f748f2d2b7
-# Tag = 623a213b4d9271df
-#
-# AAD = 7c0d9e2fc0
-# Plaintext = 3657d7f87899193abadb5b7cfc1d
-# Ciphertext = 22d9caf523b4c108c903654a7be5
-# Tag = 94149f06dc63e50a40338e6e39ed566f
-#
-# AAD = 8415a637c8
-# Plaintext = 3e5fdf0080a12142c2e363840425
-# Ciphertext = e3cb6adbfd6570d7f1ff844ca397
-# Tag = d57e82d84379b160acecac0ffd8abe5cfa5985df1e874408
-#
-# AAD = 8c1dae3fd0
-# Plaintext = 4667e70888a9294acaeb6b8c0c2d
-# Ciphertext = a0901513a06ff02ad24cf8a6d496
-# Tag = 6bc348822731af9d854ae4227470e5aa73738115b45ca427d5a43ad13bce7c81
-#
-# AAD = 8112a334c5
-# Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
-# Ciphertext = 4d354307c4ef987fea92981ee5aa989332f5553e8464ea905382259ac422a8fc79ac83
-# Tag =
-#
-# AAD = 891aab3ccd
-# Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
-# Ciphertext = b02dada9fe16df8f207673f8f34e172d9af28b43d3bf21145c4db6f55e21d61c5b96a3
-# Tag = 77048c08aae8c255
-#
-# AAD = 9122b344d5
-# Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
-# Ciphertext = 2b4a0d10a70f3f3a63c03608b39eefd6851ea5135f68c11b5cc415c7ab3a29aae040db
-# Tag = 0e592c4bdc035ee28c7ea27ad173dd59
-#
-# AAD = 992abb4cdd
-# Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
-# Ciphertext = 5faa1793ae497f67d881f79cef5faf45db3361e6681a1d55f4e86f7d065d4dcf71b155
-# Tag = e288d43e688704f7e216da4eb592c55adaa88a3e51ca0945
-#
-# AAD = a132c354e5
-# Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
-# Ciphertext = cff79e4b4481053319300509395f2041ea9cc675638da74da140ab86801f664128a29a
-# Tag = dc5f6bfaf5bdf1f39e569b3e8bd2cb6944dc23efa2bb4310f0c771c601599073
-#
-# AAD = 2abb4cdd6eff9021b243d4
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 32c354e576079829ba4bdc
-# Plaintext =
-# Ciphertext =
-# Tag = b3a7bcca57a8c4c6
-#
-# AAD = 3acb5ced7e0fa031c253e4
-# Plaintext =
-# Ciphertext =
-# Tag = 4b70e798c3bfdf8807a093eb8959c5b9
-#
-# AAD = 42d364f58617a839ca5bec
-# Plaintext =
-# Ciphertext =
-# Tag = 52d4192788f4c9224b24ec20f28f4d8d601eeeb56a783da2
-#
-# AAD = 4adb6cfd8e1fb041d263f4
-# Plaintext =
-# Ciphertext =
-# Tag = a540c44e47baaea2ae4fe73c470dfeb707d8aee365459cd8cb7f28c2c0b29c8d
-#
-# AAD = 3ecf60f18213a435c657e8
-# Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
-# Ciphertext = 0206a65d46bfacfe110455d449ce130aba7540c3
-# Tag =
-#
-# AAD = 46d768f98a1bac3dce5ff0
-# Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
-# Ciphertext = 3a5cc5bd5078f4c8c980fde2f8daf24689101521
-# Tag = deba21df9e6b4228
-#
-# AAD = 4edf70019223b445d667f8
-# Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
-# Ciphertext = d98224d5b02c1bb56d2328592aee4670a3680da0
-# Tag = 127863bac302ea62eed3568a762ee0d3
-#
-# AAD = 56e778099a2bbc4dde6f00
-# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
-# Ciphertext = f9f7c256d997ff9b73e123f2780b86f1c816c03d
-# Tag = dc36190e64613afd16f4090eb1406ff162b4529340ab4231
-#
-# AAD = 5eef8011a233c455e67708
-# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
-# Ciphertext = 6ebdd377525d35001b3281fe307984dcd450c9aa
-# Tag = dba9770c64d91ae1c6d62db6cdd3ba0b921cc0ef52e6fdfa95ee9deb020986a6
-#
-# AAD = 5ced7e0fa031c253e47506
-# Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
-# Ciphertext = 9eed607492d06d9c28e52d644b81f4f632497ad8f3dfef67d05560bf68986252b3466d27d2ed5e1a57a729c9458982be6559
-# Tag =
-#
-# AAD = 64f58617a839ca5bec7d0e
-# Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
-# Ciphertext = 51689f764341213689791a95f6c6ab93b7bb0572843ae2c5aedeb70ce2e87e06b3f35b1b87f312d61cdd8007d2fd81ba3e88
-# Tag = 4a25dcd4435deb42
-#
-# AAD = 6cfd8e1fb041d263f48516
-# Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
-# Ciphertext = a80908eb657fd52d85ae6c8f65eadfdbe3a2daf3d98b6bea4124e4e7830c0b710dfedb8fc278a0a0a0e72f75fac95b50694d
-# Tag = e7eaac443892c88c3dfa714a4409426c
-#
-# AAD = 74059627b849da6bfc8d1e
-# Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
-# Ciphertext = 81178a81d446ac7744ca63ae8f8e732fe4741d415a3629b038973fad935bad465f241f24191cebcdac890fe75c8894ed4163
-# Tag = 840a3ff26cf166840103957502c35542e9b9470b3bd789ac
-#
-# AAD = 7c0d9e2fc051e273049526
-# Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
-# Ciphertext = 4bd8f6c6c26154c1e4ee257332811f86f8baf78c7d0093ab4372454a50bb05559f694058a4bcb702861c2c82d73029237485
-# Tag = 25bf5e634d3d1e30ba3539adde66dfc02f396ab0d41c2a853fcaaaf56e56f50e
-#
-# AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
-# Plaintext =
-# Ciphertext =
-# Tag = cab1947792104cb4
-#
-# AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
-# Plaintext =
-# Ciphertext =
-# Tag = 902b12f2b7c59362296d2f142ddea000
-#
-# AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
-# Plaintext =
-# Ciphertext =
-# Tag = e0dee1833900febb7b9fc53f4f3f1f1e8f6622b7e97cacba
-#
-# AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
-# Plaintext =
-# Ciphertext =
-# Tag = 2680ff11985d5e8f46f92acdbcfbe1cddc0ed470bf8d410daebd89cacf245060
-#
-# AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
-# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
-# Ciphertext = a8461f54d39b094ad4f68806548667bdefa2b7722daae773e70279af
-# Tag =
-#
-# AAD = 5eef8011a233c455e67708992abb4cddcd5eef
-# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
-# Ciphertext = 5f67bacbfc72afe2590c14fc1905f294ad2721ad86764513ad98526f
-# Tag = 09b50ccc9da054aa
-#
-# AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
-# Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
-# Ciphertext = df903ffc4014962e50221b92a1cc72824d9c476cfee7b9844afd3118
-# Tag = a7ee3e5e90af86a02d8a54c06ead4231
-#
-# AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
-# Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
-# Ciphertext = d96b6fe59d9cf286ce5da946a13c3dc2823772abf2428caa42d93b33
-# Tag = aa7dd07546aec6e06a91264b0e2e923895679727c0183e15
-#
-# AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
-# Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
-# Ciphertext = 52f1528781a74988b102b86b5c511170d21ea911ed35bfb7ef33aa5d
-# Tag = f78d4d64ffda574104581159fdca73b10d8649398d9af0b9b32b6089495da775
-#
-# AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
-# Plaintext =
-# Ciphertext =
-# Tag = c9e994c45382f79e
-#
-# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
-# Plaintext =
-# Ciphertext =
-# Tag = dc52c03855ff0a884bd3297659ed1aed
-#
-# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
-# Plaintext =
-# Ciphertext =
-# Tag = 96d9aeb87ab14dd390355dddd668a8a1a0d120bc046c8bef
-#
-# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
-# Plaintext =
-# Ciphertext =
-# Tag = 66cece3ada2732f3b5929293c173e765720ffc2ec85f46b9310bccf56a322b39
-#
-# AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
-# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
-# Ciphertext = 8c76dbed0f043fe68284996a146ad66fcd863019f96ac4ae9448faecd63d874a5a9ec511461214
-# Tag =
-#
-# AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
-# Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
-# Ciphertext = 20cb5a62d45a52cb5f765b3c9a8cc2a3ec14892ff388c87ef58ecb489e08c78ecc51efef539243
-# Tag = c52c81fee99b8a79
-#
-# AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
-# Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
-# Ciphertext = 03cac0b456f7401aa38e13e837d98dbea9f1f3dce9f37eab49c8df431270e2f448afaeff7d916f
-# Tag = ce332a2ccdeaa38c1f302ecf74f177f8
-#
-# AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
-# Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
-# Ciphertext = 79bc7d19961d8ddce9bb2ecd0ca78325b3f40a8e4a4145ac02f170aedb85dc411fe65b245baec5
-# Tag = 8c7a01ff63a38aaeb305772fd070f4dbb22d951770b0527b
-#
-# AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
-# Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
-# Ciphertext = e6c82d9f049d85417a81f3a6c1e06f4da68313e87fad40281dc863e3abd3fb6c021cf448e317d5
-# Tag = 57fadb6f555e5f5b004801924f61981123e45087b3e1d693cfd1ca268d58dc1b
-#
-# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
-# Plaintext =
-# Ciphertext =
-# Tag = a8043d065e854f8c
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
-# Plaintext =
-# Ciphertext =
-# Tag = 46f020350801815c3fb636917b1efad4
-#
-# AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
-# Plaintext =
-# Ciphertext =
-# Tag = bbadac9f062ef1af3c95d7556a604d2b5570dcd190820d34
-#
-# AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
-# Plaintext =
-# Ciphertext =
-# Tag = 9edc390a828f46559ccbbdd5ae61af2a6d8504e69a48674dfc9ac3c7795a77ce
-#
-# # initialize with key of 128 bits, nonce of 64 bits:
-# Key = 3ad36c059e37d069029b34cd66ff9831
-# Nonce = 43a405662687e849
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = c573c668db9a2cde
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 49a5804e793672df058c223218eda8a9
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 3e520289e4410dd64bbac098f84373f5a13799a93b4cff8e
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 1462f86d48360f0f75aa8116f6dc7e2b9693b5a5acb654413db300c686b12b87
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = bba7129444
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 8391224c52
-# Tag = 1f3a848a9ba389df
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = ea22e3836c
-# Tag = 1e337624239888f553f66e4b7dff2c40
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 6bbc8aef21
-# Tag = 415f8a207858a94e571a2bfda5ed280a035459593d67c036
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = db43029828
-# Tag = 4cc94d738799dab1349f6b95c60b3193f35a74295f2ca22bcfda544b224b237c
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 28ce9dec611ddcabebc3238e
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 9ecfb7663894f03ccaf84f0b
-# Tag = c8d14b9c946db692
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 12e624e4d147980570b80955
-# Tag = 91fbf17455d8984e1549e8691d6ead48
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 71bc91cd08c052d43a8d5bf0
-# Tag = 4177b11d3282717652f331b82aeb9156374ca22e05affd2b
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 2b4416219aa4a008af0436d3
-# Tag = 84afab4a839306ebe27e5dd8ed28fc160d8c760ff87a58cdf03dafa6a12b2d2e
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 0227b76c1f04d51e0904be270a864fd360d7fa98bc222f
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 94944b7ac542e82368e5fad4147f1cc7c40d28858fd782
-# Tag = 08b9648e7eda5c45
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 418b8c74daecb6ff9bff4a4d485ea8f5f3fd3fe69b8974
-# Tag = a470da07888f08c96902a88e63e03ea0
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = bd4ae91ddd48102e7554f52416364d89ef00a3fc7f65ab
-# Tag = 8a0b8d08f74fd475b183fcf3d0d69ab972e3b17884973972
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = b4e86dbfdf8f55108c46f4bf6e0e7e3e6269f6b886cddb
-# Tag = 28feca673322552f8198cf1fc7e8e3e23ab464c2d2a8df62602ddc05e170ad5a
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = ac6a68b52e4abd416b9abeda553ed24563cba6b6f9c3ee38e8183af40224b020822f813dc2ffe9
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 2099370162f199e32c59198619fcf9d03c5f23ca62e9ceae94bcd4564854959de229c9c6fa43d6
-# Tag = c897b557338c1ef0
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = 07a97204e88c9a9cb9921cf9097930e002a3fc50d364dbea014c4cd74d05ccef1cb4bda48e0254
-# Tag = a5e3e29ec24258b8f50127a73b8ba819
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = bf721016121d2c99fe532fd02b2aee9ca993232968d93ea4b83e7f0aca2a18c2e4c8fb48df7377
-# Tag = 8b91f0e9f4b454c7a4132e76d6b6d391654bdeb899733f7f
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 743dbf795a4d9898acd236d98df514cbf76fa8a4fd1f28ae8f609a476ee04fd076a2bac09b70c7
-# Tag = 054827132710f3649787818ab92c63fd1eea84f086bb4fba0071f35ef15264c5
-#
-# AAD = 5eef8011a2
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 66f78819aa
-# Plaintext =
-# Ciphertext =
-# Tag = c7015bba4d8e2b0d
-#
-# AAD = 6eff9021b2
-# Plaintext =
-# Ciphertext =
-# Tag = c3ca67db5a366800128cb16bfcc2d619
-#
-# AAD = 76079829ba
-# Plaintext =
-# Ciphertext =
-# Tag = 541a746b262465d66bfd46b11663711c0d0a6d99523ea788
-#
-# AAD = 7e0fa031c2
-# Plaintext =
-# Ciphertext =
-# Tag = 4e31633765ad386a57ae21fad661a54445ddc60d62817331477b064f9ce2dcab
-#
-# AAD = 6cfd8e1fb0
-# Plaintext = 2647c7e86889092aaacb4b6cec0d
-# Ciphertext = 901199708970911f0b437f72abdb
-# Tag =
-#
-# AAD = 74059627b8
-# Plaintext = 2e4fcff070911132b2d35374f415
-# Ciphertext = 38f83ce83bc0e8df0571dd47dafd
-# Tag = 007d040d02599afe
-#
-# AAD = 7c0d9e2fc0
-# Plaintext = 3657d7f87899193abadb5b7cfc1d
-# Ciphertext = 0f52b34f45657d31b40ca0d152c2
-# Tag = dddc87ebaea140b3b3193f2eae23d3ae
-#
-# AAD = 8415a637c8
-# Plaintext = 3e5fdf0080a12142c2e363840425
-# Ciphertext = 94d6c7fb56cf26e1ee3e79b96bb9
-# Tag = 09ffa07a977e64007e0088dfb680a5b34768ed04b835d0d6
-#
-# AAD = 8c1dae3fd0
-# Plaintext = 4667e70888a9294acaeb6b8c0c2d
-# Ciphertext = 5abc35ee82d84eeec5bd64030d18
-# Tag = a668139b031344833b43896d6730379a7c436b85e7abc4988dd4041021d130c7
-#
-# AAD = 8112a334c5
-# Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
-# Ciphertext = 332e7242a34f4d2a3a793ff792371f7f19a1a4b404c98e0b2b79a8b54cc9fff4a5d190
-# Tag =
-#
-# AAD = 891aab3ccd
-# Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
-# Ciphertext = 8f0cd16b164da3fc37c51fd5ed48e78ad0b663db7266038751d1214e59adb11d9dada3
-# Tag = d4e321ab327f6b55
-#
-# AAD = 9122b344d5
-# Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
-# Ciphertext = 5586ac97bfce4eec9389db476d0f7dcb1b963fd863608c062551cd801bb2ad99619003
-# Tag = e3a05acabf5929ff98ab62f30cf3a29e
-#
-# AAD = 992abb4cdd
-# Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
-# Ciphertext = 9628f3b8273f375f069444b22bb178307d563a9373d40e47129468c0ebdc4ac4630ff6
-# Tag = 84674da9be31c6bc75b0d52b34c9d1daaccfd348b42a1a7b
-#
-# AAD = a132c354e5
-# Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
-# Ciphertext = f43321d40d605a351789132778ec4ddbfe2eb9f50c426d84b245f5816dfaa87a184873
-# Tag = cf54cdd4955d6c6c4896f7892a261d7b7e9dc400dcbd0030f86fd3c5429c5dbe
-#
-# AAD = 2abb4cdd6eff9021b243d4
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 32c354e576079829ba4bdc
-# Plaintext =
-# Ciphertext =
-# Tag = 12354cc75633edf0
-#
-# AAD = 3acb5ced7e0fa031c253e4
-# Plaintext =
-# Ciphertext =
-# Tag = 5c77010dab4820d7a7aedacf0015ebe6
-#
-# AAD = 42d364f58617a839ca5bec
-# Plaintext =
-# Ciphertext =
-# Tag = bf803e85954b76712604c790a45f79e10dd7e9ab0f52c869
-#
-# AAD = 4adb6cfd8e1fb041d263f4
-# Plaintext =
-# Ciphertext =
-# Tag = 60a325f3974cd0369f2d3f9befdb313813da5a631e51ef98686513379be67428
-#
-# AAD = 3ecf60f18213a435c657e8
-# Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
-# Ciphertext = c1d0707ac5ed5d045196ad51b5b17c87ea3aeeb1
-# Tag =
-#
-# AAD = 46d768f98a1bac3dce5ff0
-# Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
-# Ciphertext = 17c9e112056f4cbdb4b90ec97122a1afb6273c68
-# Tag = 42e3eef1ef27f836
-#
-# AAD = 4edf70019223b445d667f8
-# Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
-# Ciphertext = 7ac94af5965e971d7bce0ade73af17ab9483eb25
-# Tag = ea3a52d59ae27c6a8d91ae5756cc0dbf
-#
-# AAD = 56e778099a2bbc4dde6f00
-# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
-# Ciphertext = f07a2cb30cf16af25b63327f5b41e790f4ddac61
-# Tag = ff1259225b38b5ebc48b5537d3a26bac81b868cc12d79083
-#
-# AAD = 5eef8011a233c455e67708
-# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
-# Ciphertext = 86a38441e5400bf9247cd79f11f349e014e88dad
-# Tag = 9e4490846a0bb8e9833292518408f8c20f8cde6f62b750b6e2ba346aab8e2782
-#
-# AAD = 5ced7e0fa031c253e47506
-# Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
-# Ciphertext = edfdb988245eb4ebf5abb9c7476b47076c37ae18559bd3d6a7dba12e99073db363608ea0c2dbfe52a3c2c835cb902ff3e773
-# Tag =
-#
-# AAD = 64f58617a839ca5bec7d0e
-# Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
-# Ciphertext = d4e7b7534bcb39321ca3e1f5d947b5856a54decc03743b2214853e67345170a9543ec279ddf555d5920f43a9ca2b8726d39c
-# Tag = 41b4cfa9ee4f4f1e
-#
-# AAD = 6cfd8e1fb041d263f48516
-# Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
-# Ciphertext = 444ef3909e42fc7975423dc913d16258b4571565a16f09fbcaf02660547cf98f633c51a1a48c0b0251481ffc10d0d9c69105
-# Tag = c62bfc0ad8d1c17e52b607e106b519d2
-#
-# AAD = 74059627b849da6bfc8d1e
-# Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
-# Ciphertext = 074cf9d5991a47686f27e964139fc9ed429c65765afcfb92816b09b2397e33cc33eca03b45179be90c4223e2b419cdec81ac
-# Tag = 8f159958db825f91c369e0828b98af5791b6ba2b52c8b9f0
-#
-# AAD = 7c0d9e2fc051e273049526
-# Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
-# Ciphertext = f72d2c35ee563e3d12116e5e57b012ac0ee9802f8d9b5980fd8a6b83fb1ba476920c5646e029cdff2a32901ae36c6da30b2a
-# Tag = 8ab9b32a8bd02e41ecdcdb480495540ef1a98e38188beea71c59f83a5d3fab74
-#
-# AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
-# Plaintext =
-# Ciphertext =
-# Tag = fed5f9442eab657f
-#
-# AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
-# Plaintext =
-# Ciphertext =
-# Tag = f56dd58f778d3cb827491ee97d778f05
-#
-# AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
-# Plaintext =
-# Ciphertext =
-# Tag = b5c3bf1bf8220c4ad5821422c308fcdff09cec9bc32a32cd
-#
-# AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
-# Plaintext =
-# Ciphertext =
-# Tag = 72527969077c44b56e7f606b8c558c41e997e0e2e94bef92852a78c74f836476
-#
-# AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
-# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
-# Ciphertext = aa35d8d1c3c497d160818a7bea345a6fd6b570161d19586567ba9b53
-# Tag =
-#
-# AAD = 5eef8011a233c455e67708992abb4cddcd5eef
-# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
-# Ciphertext = c735063fafc2f9182a48d51766e5d55286b245d59772875f68c134f2
-# Tag = f19e9e7796343464
-#
-# AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
-# Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
-# Ciphertext = 1dd5fb71639af22b3e95efbe49f4b5f99186618101a4e7a9cb29be5f
-# Tag = e627e774ce97b963120a9be4e6cb7094
-#
-# AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
-# Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
-# Ciphertext = 6c542540d2b25b6ec8a5ab8adcc320ef235895caec25f16fae947114
-# Tag = 05f5e23aeec52199b2d81569605d8b47d2775de217c99eb9
-#
-# AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
-# Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
-# Ciphertext = f312506614208f2878b15fcd1877f3109b1cf3115aedd6bf9097fc39
-# Tag = 1a0948f718583f284de252043c916e35764223efc7df327a22160c2d7cf09cd1
-#
-# AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
-# Plaintext =
-# Ciphertext =
-# Tag = a68fe52f5c9ab1df
-#
-# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
-# Plaintext =
-# Ciphertext =
-# Tag = 4b6ad1f60a60b882065c91a6637b907c
-#
-# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
-# Plaintext =
-# Ciphertext =
-# Tag = 66bfb808c4ff6bc4c98bebdd10b04dcc8fc57251f39c523d
-#
-# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
-# Plaintext =
-# Ciphertext =
-# Tag = df0c0b6b9dd6ed0d30326d641dfd14c90c51d1cb11fc9cd5d7760eeb541aac3c
-#
-# AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
-# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
-# Ciphertext = bf31a38b08ad11ec8b63e5495422d14695556c01303502d0216d6cba2f7051e545db62458467d0
-# Tag =
-#
-# AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
-# Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
-# Ciphertext = 088e87b83fa45a11644cc538e5a0e23948b857f6854ff70086de482ba5287524c6a5a529ef7eeb
-# Tag = cb0e80bbf1166cd4
-#
-# AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
-# Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
-# Ciphertext = 00d26600fa1a1e7ca99b894c1f346fa7b25b8fdb7dcedde364937461031aec413a02177200b2ac
-# Tag = cda56e0d87855622c289ffde95a161a4
-#
-# AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
-# Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
-# Ciphertext = 478e36aade320ffe032a78feea6a8ac395b9133c46685a41dd7b7a30325734c59213ed57ebc50e
-# Tag = d8a9e962427494404d2ca13b2c4dd815c378a5c8e1c5b35f
-#
-# AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
-# Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
-# Ciphertext = 799f6fe70703d63674bd1a6313816fbaa699c85286edec43c9c8c733b70efb5d4beef0ec4468d0
-# Tag = b31990acf77426d6f722f0a14ded00fdd3c93ec41cb186d47e10de8ad22680ee
-#
-# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
-# Plaintext =
-# Ciphertext =
-# Tag = 5894b487dbc95146
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
-# Plaintext =
-# Ciphertext =
-# Tag = 2ef165935539576aa9f184c02ea17718
-#
-# AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
-# Plaintext =
-# Ciphertext =
-# Tag = a23085aac48ec1ecbd1676d468c3bed02237cfb50c5885f5
-#
-# AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
-# Plaintext =
-# Ciphertext =
-# Tag = c6bcaf17d8b8678e9d48669beabfbe469f562eec532b2d5b52efa87c449cfb59
-#
-# # initialize with key of 128 bits, nonce of 128 bits:
-# Key = 42db740da63fd8710aa33cd56e07a039
-# Nonce = 53b415763697f859197adb3cfc5dbe1f
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = f01de38c5b735fb3
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = d5b6c0aa25c2847186a989df1b987ff9
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 87cf1e801dd4f5f338bd878642b209bea5216f16614da576
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = a3c9756a3d9fb78f5553575c57c590e4d31e06fbd72e41d27baa4a00f3873c94
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = ccbf98112c
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 6b5a4ec120
-# Tag = a99938c40dba7435
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 46907bf76b
-# Tag = 627c1d6fcbc266d920f1b0795d115add
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 7c00fcbc92
-# Tag = 5d06ac15c8d823b2b7eb26f98659916d0121bbe97a1a1fd1
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 2e3f9db491
-# Tag = cdbdcbf2863dd35d3c43b1c50a49b52d3ee11edf0aae210ae3cb560b0866dd4e
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = abcde4c398c3b761bbed9d1b
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = fecbc4ed172e789940af03f6
-# Tag = 16406b3367485c7e
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = a0ce9342721a70a90c667dc3
-# Tag = 58508c833afd4e01e0afa87223c80ea8
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 1fd541a0482e7ebd512f9440
-# Tag = 21a1c3f4d06a58a51a1a442162646c192d345e85a6d04a1c
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 98f2b52d6be9232ab8575818
-# Tag = 0207a1a039bd4e4384d12117e60536707ac9ffa1fa582e314614372ce2583f1a
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 49fb9cad51c7e92d859b674557a75c88c3d1fd7572cc7c
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = b96460ac9cb4595f14443d79acd0ef181c1abe6cb0f658
-# Tag = 0786d352a10a1b25
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 42c458451f12c3709d44e36d2c8d8b7fe5e637be526fbb
-# Tag = 170469b41bca1dcf15db479e66f7c915
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 5b1eb8c37d0a9cd5113b02a87417d9b5ddb4238dcce56f
-# Tag = b8e6965d7635a2fad3bb97aa51b038c9adce7963106cf2d9
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = 36e11f9cb68e3da538619ba973885101c7979d669c8d68
-# Tag = a46925acdcde5b8545e18512fd23d2003449415eebefb84edc370ef0a08d9f7e
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 6f4625c1878c6cb2dfd60a082a37f220af0521f1c6ece37bd67862f7ada6e603b4fa51fedadffa
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 20e9bcc0c8d4fdcf66682d61e9694a63d9bccf552220b9290c2269c4af57172598ca9a0b37ec6c
-# Tag = c59997244f2438ce
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = 402db5fee89ba59384bb57d6ce01ab12eb562a95b40d5ad86ae7cc7a0aa597202c6d5588eb1b8b
-# Tag = 130920a0597ef972058c8a1370f99d06
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = e3c0a4e28e9837d6946770c3fd0bcf0fcb30b4d49bd61a4aa4416b88a83cfd764198a3931c7bb7
-# Tag = ad335b876bb7766036c7597a785e60cd50bf830ce5150d65
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 4152ef9317983bdc31e51e1948362ae1b66451c68934f29c988e73ba96512222ad85b011f401c4
-# Tag = 3aab47470d3f4196fe0b912c4bb97858ddf594405aac5ee04438d5b0f9608ed0
-#
-# AAD = 5eef8011a2
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 66f78819aa
-# Plaintext =
-# Ciphertext =
-# Tag = 864465e910bb6f22
-#
-# AAD = 6eff9021b2
-# Plaintext =
-# Ciphertext =
-# Tag = 7e5b3ac40ffa3c1c9226056cf0774bbd
-#
-# AAD = 76079829ba
-# Plaintext =
-# Ciphertext =
-# Tag = ad5fc9751493a28e886073b4c4bc988c545d86a6ffc70db7
-#
-# AAD = 7e0fa031c2
-# Plaintext =
-# Ciphertext =
-# Tag = 70f25d2ede47f2cf4df63d62842427f7a6a92a8d30419df49a39c5737a35707f
-#
-# AAD = 6cfd8e1fb0
-# Plaintext = 2647c7e86889092aaacb4b6cec0d
-# Ciphertext = 81fde86151462a3cb478af8e47ee
-# Tag =
-#
-# AAD = 74059627b8
-# Plaintext = 2e4fcff070911132b2d35374f415
-# Ciphertext = 941178eb365991c5a91d1978f1f4
-# Tag = 5911a8888f045974
-#
-# AAD = 7c0d9e2fc0
-# Plaintext = 3657d7f87899193abadb5b7cfc1d
-# Ciphertext = 4fdad42e51078f251690f0d25ed6
-# Tag = e8b20f223a33623f9f1250ab17b471bd
-#
-# AAD = 8415a637c8
-# Plaintext = 3e5fdf0080a12142c2e363840425
-# Ciphertext = 0e6f03a74dd33b8cc2d90a181ed2
-# Tag = a21685b3c127deb18d7e07ce8bc4a04f5ca2fd8bf0ee365c
-#
-# AAD = 8c1dae3fd0
-# Plaintext = 4667e70888a9294acaeb6b8c0c2d
-# Ciphertext = 06fa46a34e5b68bb5842dd2f550b
-# Tag = 39e1303de8938846aed77273936940831610363e82228c11ef3e6f60fe9bf201
-#
-# AAD = 8112a334c5
-# Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
-# Ciphertext = 54190c5e51edf97feb6ae02cd8a58bd81273222f302f8ca00fac16cb6db7355b6aa0fd
-# Tag =
-#
-# AAD = 891aab3ccd
-# Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
-# Ciphertext = 28cd29dfea7a6c47b3a581a127d71f5319c650d0ba151e667a9a61646a7fbf8fadde84
-# Tag = 5c7f2445eb156621
-#
-# AAD = 9122b344d5
-# Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
-# Ciphertext = 305e20e4bb35794b4d70507a9be23c4bc1be0b9ae0f4766a1d8c726b5e9d9b7e9d8cb4
-# Tag = 5726dcbe930b1a75accdf44ace9d7819
-#
-# AAD = 992abb4cdd
-# Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
-# Ciphertext = d7aa36133b0e1ba190fa42993093173e256db61aa124e0057633231c707b936d9b3296
-# Tag = 6158f65704de932fa093cf1c0bf57f4c242582a6ee0a5d09
-#
-# AAD = a132c354e5
-# Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
-# Ciphertext = 8e7898a8d3575c019307d4efe609ce0717b8a1bc68507d0f5b5ab65fddbd67e37f6e87
-# Tag = ba3edc080c91cc234c0beda88a257ad96de0af3fea4e51e67a917efd896c5069
-#
-# AAD = 2abb4cdd6eff9021b243d4
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 32c354e576079829ba4bdc
-# Plaintext =
-# Ciphertext =
-# Tag = 4e570238bd11eaa2
-#
-# AAD = 3acb5ced7e0fa031c253e4
-# Plaintext =
-# Ciphertext =
-# Tag = 64587fb1293fb8e146a67c1badae7fcd
-#
-# AAD = 42d364f58617a839ca5bec
-# Plaintext =
-# Ciphertext =
-# Tag = 8a3f1852ed0e4de2d4959208bc5a57b5e871139f292efa79
-#
-# AAD = 4adb6cfd8e1fb041d263f4
-# Plaintext =
-# Ciphertext =
-# Tag = 9d5c83a916f935c1c11429080a6b2cca5166f5ba13dea1715a6878651bbc197b
-#
-# AAD = 3ecf60f18213a435c657e8
-# Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
-# Ciphertext = 67fd9c22f8041a49c45995f438c5510f07b88b06
-# Tag =
-#
-# AAD = 46d768f98a1bac3dce5ff0
-# Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
-# Ciphertext = 0cf6566aa858d796c394db94d61f86f31c12ad33
-# Tag = 07e011ce81326d87
-#
-# AAD = 4edf70019223b445d667f8
-# Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
-# Ciphertext = 879ed7c06fb02397cb533ef2d245f63d28cad418
-# Tag = cfa761ef76f4e3e6287930308e78fa0b
-#
-# AAD = 56e778099a2bbc4dde6f00
-# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
-# Ciphertext = 6b55228d76dffbe0fc89856a5853afb7df77e302
-# Tag = 7a241bad2f9ffc92715956a4385d8c03a3c57f06773faadb
-#
-# AAD = 5eef8011a233c455e67708
-# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
-# Ciphertext = 1e6910aa6187a4414226798d065fcab8dcc48c74
-# Tag = c854d5356604a0cf3f5dbdb06cd640b99ae235544c3bd19aa6173265aa64fe97
-#
-# AAD = 5ced7e0fa031c253e47506
-# Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
-# Ciphertext = 975ebbae0a4366225cc784ed34160f3892fb43cdb80b372b4c29a9b858e274e0208647a07cc4e7f82f0b88f426ba2591761b
-# Tag =
-#
-# AAD = 64f58617a839ca5bec7d0e
-# Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
-# Ciphertext = e07e4e961713de115d537a739aa4d4da0295c351be19da34c585c4dadc2db3a53f902f03a3d4668f5723850346de2bec035c
-# Tag = ea5c28ab883369a2
-#
-# AAD = 6cfd8e1fb041d263f48516
-# Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
-# Ciphertext = d2b045f1bc359baf02d762470663c4c642dc4d5e5655215a1cc57e57b9c29877fc153ef77865f5b70acf52f1d2adea99da7b
-# Tag = 096604780770de73b6ac9b42c3f68fe5
-#
-# AAD = 74059627b849da6bfc8d1e
-# Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
-# Ciphertext = 7a80e3335667fa4ec2ed850780998bcb33c53dd35677a7960535f912ceda869a053c3c29c92e2c706b62314ef0cef5ff559c
-# Tag = 6b78fe154d77f7e20ad8a880ffae3a268e5615fd187da453
-#
-# AAD = 7c0d9e2fc051e273049526
-# Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
-# Ciphertext = 945c9830513f2de1802a4223479653e74022dd6ec359a6cb9e2f8fd6b3f4ef30078757d7c90838b9408837f093d496e075f0
-# Tag = 99e28c7a09caf792bb6197b2f8e59a0650a1b64c8894dbedf9f23a8851a6c64e
-#
-# AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
-# Plaintext =
-# Ciphertext =
-# Tag = d85536be6605a09b
-#
-# AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
-# Plaintext =
-# Ciphertext =
-# Tag = d7f56fd8a18a907a248ee32e16c69d6d
-#
-# AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
-# Plaintext =
-# Ciphertext =
-# Tag = 2aa6b125e018c070f923fcaa28882ce96b7f11fc4dd9efa7
-#
-# AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
-# Plaintext =
-# Ciphertext =
-# Tag = 1c7c7563f0ff06f27ee1c557796026a7fb8ed2eff502988411df3f70e61a862e
-#
-# AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
-# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
-# Ciphertext = 579e2338f901bd405e4becbfb02c2087ea8174b32145fafa189d0452
-# Tag =
-#
-# AAD = 5eef8011a233c455e67708992abb4cddcd5eef
-# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
-# Ciphertext = abc014e2583feb0cc5ff795364b05b5d9e07eecd76d367a6e6aff318
-# Tag = 36d475d41adaa0f8
-#
-# AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
-# Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
-# Ciphertext = ed529e35862473f0c289d4446974139e093f183573de2206553bb05b
-# Tag = ea9c440235433adf412051041eecd2bf
-#
-# AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
-# Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
-# Ciphertext = 4a749c17d277e8e183ae670ea2d9758715f57d1d57625e8e570a7fd2
-# Tag = b1bc4d70e3ab206e55fcb90c26a6e6f6f00615e4c638d337
-#
-# AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
-# Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
-# Ciphertext = 41dd6b31cdfa6b9614c183a6a1b85a689b0ce954cb621fd13b5a321f
-# Tag = f4e1f035025c91934bf8937f2f5ae76a6fcf40f9023b37cf4a7668059b55f5d3
-#
-# AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
-# Plaintext =
-# Ciphertext =
-# Tag = 36cc5d3c9ac3964a
-#
-# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
-# Plaintext =
-# Ciphertext =
-# Tag = 278a3a8d8192209243de0a30a1439433
-#
-# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
-# Plaintext =
-# Ciphertext =
-# Tag = f12aaa04ad45b5d4be440a15cabaadc02a30c2b29709a0dc
-#
-# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
-# Plaintext =
-# Ciphertext =
-# Tag = b88321c856864a79dbb2c3064e85040da9a90284766533bb755cf89d6d7ec45e
-#
-# AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
-# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
-# Ciphertext = f6d7e5117119345049edde892207f49c492cde9f7ab06e22870ddaf20798abc71c121c9296b917
-# Tag =
-#
-# AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
-# Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
-# Ciphertext = bdc067759d881b19cb7a355a2ea5b3860fb020496473437cf9db9d997d7c19161d054234ded319
-# Tag = f9270b4596c4e115
-#
-# AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
-# Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
-# Ciphertext = b0b86b4d85ccc9248573df04d880df9a9fb9f9ea47efe3fe58eb627f80759fcad1b2b1edcbaba8
-# Tag = c641c221e317a40d4378151741f15b0b
-#
-# AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
-# Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
-# Ciphertext = 43ac00b42ff5a94902f8b7ca0a18e359d4c6d597880d12fac2050da367e69b6bb42df7b5a976d4
-# Tag = b20d55ed33bee294e8781c97170e087ef5172face14802bc
-#
-# AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
-# Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
-# Ciphertext = d0903161726608dde2ad445f3ac017fee13c6b894f8fe2b8b743d43468cbc50063702430efd4d1
-# Tag = 1b442200c295a02a64b1a31f9eb6644aac518d243de096fa1dc5f200b604750f
-#
-# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
-# Plaintext =
-# Ciphertext =
-# Tag = 00dedfeb15275248
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
-# Plaintext =
-# Ciphertext =
-# Tag = e4fa7e13aafcf199af09df9c0d6524bc
-#
-# AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
-# Plaintext =
-# Ciphertext =
-# Tag = 6c6eb3f9222cd98e89eadc5aaf685c980f15eb0036c0a5b7
-#
-# AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
-# Plaintext =
-# Ciphertext =
-# Tag = 2a69d16663196738753f42de5bb4f082038bdc4a9e4f72e366488ee92e1e209a
-#
-# # initialize with key of 128 bits, nonce of 192 bits:
-# Key = 4ae37c15ae47e07912ab44dd760fa841
-# Nonce = 63c4258646a70869298aeb4c0c6dce2fef50b112d23394f5
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 5d9cf1a04120cd48
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 3a3f256e7e6b754299de8dfceca4b0d6
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 891b7bd6878ab1bbe707740d415aaa3e1b8363d942441c26
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 365bd8e6490d578e204c93a0088cfe47e0b38cc56882773cba1e742dfe21b77c
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = f9b7e0c2ba
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 5856d3f8e8
-# Tag = be4a85f723669be9
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 09a411660c
-# Tag = b2d2b0fb22829e9e4fca1a1618ff9971
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 57fdc06bbb
-# Tag = c273bce1a25df2d0920c99bd786483f1c94ce8e8ffe49716
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 7a60cd1fe0
-# Tag = 898642dbacc36fc1b52167f23fd59fd9cb38c025d7fbfee6758633601bd989ea
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 7a8e03245262f46872980346
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = a5db2340dba9063d4034388a
-# Tag = abe584316f8724a6
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = e219fe7b037461490e52f256
-# Tag = a852afd69dc636c7c50ff440b277c701
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 7bd14f10746d87c296b31703
-# Tag = 6648cceba2be7d7ae8270e4428b590513b6eabec4edce28b
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = f093e30763727722ec97bf22
-# Tag = e4dcfe0def1895a263aed90a5ff926a132d8f97aa85ac7070f1472c57a454aca
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = c2ccbd6f42bddb9435fe2c4a97bfb679a8c898da1187c2
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = b82c070ad8c00df0de3a801bd8a7b8f35afedc4ea99dc2
-# Tag = 7613e9db87e4b839
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = e42305dc5ac4314a548d1eff9e78b20b631a90890234a0
-# Tag = 4c78b5c1cc208c02fda9688692f46064
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 91b418b493600d02f4ab3ddf0dd9e834395ecde84c3963
-# Tag = a517d3017015ef74c6990954eb8dd38a1cd02d20646555e2
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = e50db89aeec8e83477a210c94042869a5ac3d959f3d0f4
-# Tag = ec08938e92ccab6b633ba276c665d3000d1241ee41d4969785f9f12ae1a32a44
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = e879c0344953db3f51756fa819ce33a94d8f32b2762f000c024fa141ac9494dee249845fae3b07
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 7d8bd79cab9fae137f32669df7792d1f4e0fd173888499b1ee7527b9a1b31fc691fe8b026e0847
-# Tag = 1afb1ac8277ff6f5
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = dad47b79240216a136c2a2f939872d4a8902a6d5f7e45afe1e0c681f7f4af3f7ce55fea0e23e88
-# Tag = 56efdb0d526bcbd43bc3dd64d96c3ad5
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 4251a236cd83c7331ed29e962d7c276b764f6aa0036c4d92240f38bbbd9a81da98d8a23a01518e
-# Tag = 367eb7a2082f45ce7e843e810fca6fda00fdbad6db0f2c4f
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 4694c0285290fd545a4a585b9d8965434612ab8c2b48e30214631b9dfa71879883fd2df69372d6
-# Tag = 08cb6a7a2fca7cf59803a3d446e19dc8ef876496771ffd6fbb480095a11d0b2a
-#
-# AAD = 5eef8011a2
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 66f78819aa
-# Plaintext =
-# Ciphertext =
-# Tag = 3c3d4f47164fc01b
-#
-# AAD = 6eff9021b2
-# Plaintext =
-# Ciphertext =
-# Tag = 991b19e728c79b4526a87ca97fac9fb3
-#
-# AAD = 76079829ba
-# Plaintext =
-# Ciphertext =
-# Tag = 6430d665d34e2d62719d6e41be67236115e7bdf02a311250
-#
-# AAD = 7e0fa031c2
-# Plaintext =
-# Ciphertext =
-# Tag = e2d514ff12117f9dce6cae7ee77e557ec1d8a0a2ca08d43cd5065a574726f515
-#
-# AAD = 6cfd8e1fb0
-# Plaintext = 2647c7e86889092aaacb4b6cec0d
-# Ciphertext = 9be1fb814b18d9ab1058fd70842e
-# Tag =
-#
-# AAD = 74059627b8
-# Plaintext = 2e4fcff070911132b2d35374f415
-# Ciphertext = 37d38c41a86514b70612d54d965d
-# Tag = 6c3f47cc571ccee7
-#
-# AAD = 7c0d9e2fc0
-# Plaintext = 3657d7f87899193abadb5b7cfc1d
-# Ciphertext = 4949cafdb36d48b2ba21d9607939
-# Tag = 9909096fe46c52262bfe70cdbeb619b6
-#
-# AAD = 8415a637c8
-# Plaintext = 3e5fdf0080a12142c2e363840425
-# Ciphertext = 28736e5d21e81dd91af7cab41d57
-# Tag = 1873ec3a7a7bfbed18cfad957297f2ad5a8ff4cc13fdf298
-#
-# AAD = 8c1dae3fd0
-# Plaintext = 4667e70888a9294acaeb6b8c0c2d
-# Ciphertext = 9091e155a60f5df82886c75ac714
-# Tag = d8f719d5f8bfd062771de1b6daa540a0ab8662a48104274b81b797256b20728c
-#
-# AAD = 8112a334c5
-# Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
-# Ciphertext = a822beacafa73ca8ba0dfb3c6ceb6a62451bdd6ddcbeeddcabd1164a61300f212836f9
-# Tag =
-#
-# AAD = 891aab3ccd
-# Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
-# Ciphertext = 1ef03fccd83aeb58765898fa93ffc7b8dfe1f434610a381c14bca46d6a4283a3e7731d
-# Tag = 6695c68c1a8d2393
-#
-# AAD = 9122b344d5
-# Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
-# Ciphertext = 2cb00b41814ad79b83105d7cda712d15af16d6eee2af9ef38b817ba1edca8c1724bc98
-# Tag = a0d91236f9382be295d806aaae062b74
-#
-# AAD = 992abb4cdd
-# Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
-# Ciphertext = c7af492b410b4209f40cdd1a7e341be6d2d621c41ed257c3e165ba1bd5afe9b6e0c11b
-# Tag = eeb66a917f3ba8ec5d8a4db217bb77945a7fd712aa1f10dd
-#
-# AAD = a132c354e5
-# Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
-# Ciphertext = 51f215e0079bc38a2da9a9ec76059ce1e7b46300c08517af37f457599981cdf3cb51a4
-# Tag = b3780aa11e8a3394435eccff3d0f69887aa88816f33fd766c56f740935b21a72
-#
-# AAD = 2abb4cdd6eff9021b243d4
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 32c354e576079829ba4bdc
-# Plaintext =
-# Ciphertext =
-# Tag = b16a5ee2f7ca6eec
-#
-# AAD = 3acb5ced7e0fa031c253e4
-# Plaintext =
-# Ciphertext =
-# Tag = 12ae71447494005aebbb5c5b5a80d1f8
-#
-# AAD = 42d364f58617a839ca5bec
-# Plaintext =
-# Ciphertext =
-# Tag = fff6b46274083e16e4b04c2fc4470b52c8d8c4d043153edf
-#
-# AAD = 4adb6cfd8e1fb041d263f4
-# Plaintext =
-# Ciphertext =
-# Tag = be9d80d82a45ff7e77e9535f9b08a5516d5222c001d2437b8906bc48a76fd026
-#
-# AAD = 3ecf60f18213a435c657e8
-# Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
-# Ciphertext = 67d178a120fb450da7c99717e062e0f346f30609
-# Tag =
-#
-# AAD = 46d768f98a1bac3dce5ff0
-# Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
-# Ciphertext = 64fcd0b67205358381464830a8c039b4755b6b4b
-# Tag = d037acb17ae8cfb0
-#
-# AAD = 4edf70019223b445d667f8
-# Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
-# Ciphertext = 5cdead6540223a0bd34c23d8a09458fe4dcb90f8
-# Tag = a78223ea699aff53a370d2fc83928e48
-#
-# AAD = 56e778099a2bbc4dde6f00
-# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
-# Ciphertext = d1789cac538ff960254a6ee8fb64768aaa1f8a73
-# Tag = 585acfb1452b3a11184876b3cef13d5b4062c3f480e07353
-#
-# AAD = 5eef8011a233c455e67708
-# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
-# Ciphertext = 357918e31730ab2524abb8b40b28d3b7aaa8b2c5
-# Tag = 3f2aa72ba4b245b36fd761f4fcefb4652d527795e650558fec9e92b111d546e7
-#
-# AAD = 5ced7e0fa031c253e47506
-# Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
-# Ciphertext = fa8fa69e7b126eef5cde5b9c2c709a3b4c71732343564d9078694fcfbdff4b6f89882053dc9e652d510ebbf95e8367c2e5ec
-# Tag =
-#
-# AAD = 64f58617a839ca5bec7d0e
-# Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
-# Ciphertext = b8b0d0e53afa91f36711ae9a50e7f58565c5a3ac7ff6cd3086610aea7f31241883d5a454665ebd2dd485beca76d4d1c4e1ce
-# Tag = b5d533f11a905cd9
-#
-# AAD = 6cfd8e1fb041d263f48516
-# Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
-# Ciphertext = ec865ef9555cd6e157c16ce50f371bc4d46bb57e63df480634c17fd4fb092c982eec5560f75d9e17350ecba8af24aca795c4
-# Tag = 057835dbe4a9d36796a671a53ba4d636
-#
-# AAD = 74059627b849da6bfc8d1e
-# Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
-# Ciphertext = 8cb49c33bb3a7912503737c7a99c35242852e5e69b4b28b901b20ce5b83f4446aa18da3d90df5bcd313f49f5daa42d07f8a4
-# Tag = b25b450f0d1c291c70bcd980467524ba0f4c4914b4ac8101
-#
-# AAD = 7c0d9e2fc051e273049526
-# Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
-# Ciphertext = 3c9cd1dc604701a1034e89d01b6ed741eaea2791dfd3e3ac7eec51cbf8e782ff33e83b822a27f062ac1065f2060a56ba737a
-# Tag = 10b96effc8c6df792443f24d7a3020a8fd929f59672abbffd9af6acad752f4a9
-#
-# AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
-# Plaintext =
-# Ciphertext =
-# Tag = dcdb07a03cce06c0
-#
-# AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
-# Plaintext =
-# Ciphertext =
-# Tag = cb16261513f0c66d38c858a43f36a404
-#
-# AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
-# Plaintext =
-# Ciphertext =
-# Tag = 94221a06f04750141f3e3fa92c85394c196998ff3aefcbfc
-#
-# AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
-# Plaintext =
-# Ciphertext =
-# Tag = afa0e7bfb1ef40107c368c341c2e1d6441b6f8b73405155d6827cee309cba5ea
-#
-# AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
-# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
-# Ciphertext = 835268370835c02cf7d0aff668deb992da3e1b4053127bc7e8a85c06
-# Tag =
-#
-# AAD = 5eef8011a233c455e67708992abb4cddcd5eef
-# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
-# Ciphertext = 5f131583ac0902eee3d7a1fc6547d89c6c47689de66a77281ea0c1d8
-# Tag = b71ead7e40538487
-#
-# AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
-# Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
-# Ciphertext = d4cdb4ea88a33482a535631a52f8eeb1067b1386da02e90b96363632
-# Tag = 2c58522f1c4cbe65975a766dac36580d
-#
-# AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
-# Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
-# Ciphertext = d9c7bfcbc34d2dafdbf28bdff08cbd3ef44455f43781a70cb5077be9
-# Tag = 2b369d68f37f33d2e5783fbf54d0bd6761afdb1f6eb8d085
-#
-# AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
-# Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
-# Ciphertext = 0aad1378ae47d665823096c057256c03d178988b6ebabcdb67fc9723
-# Tag = 210c21e4597623303773b1783edfe3e900c6e017de51f3a364d092c7ce7fa318
-#
-# AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
-# Plaintext =
-# Ciphertext =
-# Tag = 80d50d3000048bb4
-#
-# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
-# Plaintext =
-# Ciphertext =
-# Tag = 7b443e9c36d7510c639356b5200eed28
-#
-# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
-# Plaintext =
-# Ciphertext =
-# Tag = c518ecd02f96d441bbd6bd80c5fb3747f50780408f2d9b7b
-#
-# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
-# Plaintext =
-# Ciphertext =
-# Tag = b342703337a1c4dbe5c76bb21b9eef97ce594f35993a249c9fa153c5d1a4d309
-#
-# AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
-# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
-# Ciphertext = f793e0b7305345349c6ff5fe5b91477fa1ff5bcc33f60d636940ce215edfd0acb85bc728e049dc
-# Tag =
-#
-# AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
-# Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
-# Ciphertext = 480b42a015bd4a32d28892b6628d106c7f7c47d99e7b9abb5327e07792929eb0ae4f32db0496c6
-# Tag = e508e9d57d293a87
-#
-# AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
-# Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
-# Ciphertext = 33214e912214095dc2a77b841e065b396ef5d62923217f9969b4df2897a26465da5f69cebcf89b
-# Tag = 88fe9a32263e0729ee38cbc6797e7df4
-#
-# AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
-# Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
-# Ciphertext = 33be45fb86e8916407ee5b467d875104c30f99aadc79f2038c7ed6f0db9b1c575dd74f26140645
-# Tag = 8ff1d969eb75f3eb599308eee9ca8f8986496b4b7e9fa0e1
-#
-# AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
-# Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
-# Ciphertext = 3e93da072de4e5f8822d302986836c318b3ada4a1635d3a14589ff5db20cb796969e9ab216a1cd
-# Tag = 94459906f4ac2fb8124950bb34b1523ae382e49337629250254e30c414a54152
-#
-# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
-# Plaintext =
-# Ciphertext =
-# Tag = a0003c2678b72299
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
-# Plaintext =
-# Ciphertext =
-# Tag = 16d89e1a94bbceed3bd6671b8973d9d8
-#
-# AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
-# Plaintext =
-# Ciphertext =
-# Tag = 7b9109ca8ce27af66ddb1a984f6eddad81970b2179838c60
-#
-# AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
-# Plaintext =
-# Ciphertext =
-# Tag = 777f84396a2af2c0f910cd4106e3e1e9d9df8b7a30673d1d6af3a9eb4e3c83d1
-#
-# # initialize with key of 128 bits, nonce of 256 bits:
-# Key = 52eb841db64fe8811ab34ce57e17b049
-# Nonce = 73d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = ec3f9d4af684fc30
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = b5677631be872409ce3b5e90e68e4af8
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 3949b3fbe718a3659d1ece3bceeb3bf16f0166cdf55b10ba
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 98679078026a8a57c7c864b5096e8bcb0ebc76ba0cd57130d2daf9590e90b590
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 5bdeefeee7
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = d5f452950e
-# Tag = 1fa70d9164b76af7
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 55be83e3a6
-# Tag = e111e701020fefc66fa5012329abe291
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 6e1e3612f8
-# Tag = c3b186d5d8586f14d0907cc5a2c3ce525ae37f9f36a5b98e
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 3ffc3d69de
-# Tag = 4e4944c0ea5bfa9acb68ded84f121bbe38d9c048fed61c3b3262510d0e633c2b
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 565684b8098058f5abe724c3
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 5d428d3b53d42604adde7eba
-# Tag = 568a0f025a682d7b
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = bfaab6b19838ebb9fe4aae88
-# Tag = 03bc4fe9fc625ecee778238251a31e2b
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = bdc84948297c6cc2706619b2
-# Tag = 2b0abd5e5d780b6e1baabd86478967b79da4cdeb9d1b1a02
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 4e6276d92f9def56625d85f2
-# Tag = cf33aec3b17711ace84e38915490214c8174d1cf38d1607d17b1a9e00d132661
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 1715925d3bb7251daf8cb668b7bb1ce75c7def6b915f46
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 945385f1afb37d8c114324474e068cca76470c92a6172d
-# Tag = 5ab6407cb916f91f
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 5664a2e1580b4d530b30edfed9d0b17afb0089aa9e34c9
-# Tag = 6241ab653d5720529fc26b858e400131
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = ae94469f2603334d7cbbd48c99674256251b43e7938ea4
-# Tag = ce939713384dfb3e0b466ca17fd069c3e4f51533ca4a2301
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = 2b1b043e8563bf1b58b8866536bb01cd256f083198fac3
-# Tag = e7a5c603aff7fbe357a6de5be7547a5b7fb10eb71a81c8e67942c4970ca08a7a
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 5727e96de9dc5f364ac84c04c8d275cd0773bd935725547c66e33159556f82e1b036df43a1990d
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = bbddc30fbca9dd94ded431b51c9c728f94ad3c6c7855a85e22697b6991d1cffdaf7684f7ae8afb
-# Tag = f6c0f142c1affde9
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = dd48f3255811289ceb2ad0438d2e6340d2cd8c54be53cab4dbe703c210ed7187fec47bcfa29c6f
-# Tag = 0a919ab65615c048f69e140b3499a318
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 4a114b0a0299a22b4cd02261d7f660ad76024bc8a25cb9b6562e0eafbf113b484a0e2eb9702c0d
-# Tag = 5ce96860a4e27c827baf02b9c8dbd1eb2bf6620c4ab9ade8
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 7bbbc8adf730c86da4d2b89a48462ade68c4c373ff1deee525bc8730245fd44d0943d78b1735a2
-# Tag = 5c0e61374a3409722b7e3db0d2c26cb96d59e34c9171e98341f4c14b9abccfc4
-#
-# AAD = 009122b344d5
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 08992abb4cdd
-# Plaintext =
-# Ciphertext =
-# Tag = 633ada10e19d0e95
-#
-# AAD = 10a132c354e5
-# Plaintext =
-# Ciphertext =
-# Tag = c19c7c32ddb929662e01dc603897bddd
-#
-# AAD = 18a93acb5ced
-# Plaintext =
-# Ciphertext =
-# Tag = 32d1b20ca05c82bcb0073472babb200a58c057d21691522b
-#
-# AAD = 20b142d364f5
-# Plaintext =
-# Ciphertext =
-# Tag = 11ae3b92353c2148120b944e4ef0623af6a4b6d114767e365370bfb9129bd01f
-#
-# AAD = 10a132c354e5
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
-# Ciphertext = 446cf8f9ef4c89952dce894f6bfd25d0
-# Tag =
-#
-# AAD = 18a93acb5ced
-# Plaintext = 73941435b5d65677f71898b9395adafb
-# Ciphertext = bf98f647e020671f789c24a436251581
-# Tag = 61d14fe682f075b0
-#
-# AAD = 20b142d364f5
-# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
-# Ciphertext = 2042e7d79add4dc5415116a94dcbffc8
-# Tag = 7a6916e877d555e43d3059e5246ea8a6
-#
-# AAD = 28b94adb6cfd
-# Plaintext = 83a42445c5e666870728a8c9496aea0b
-# Ciphertext = 67fa98704ecc6d28b53c2105b8cb7744
-# Tag = 64c89b8734f7be9301a83a6b1ed55a7b774146334b916e62
-#
-# AAD = 30c152e37405
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
-# Ciphertext = 5c2df6eab54a2f6c6be510589b667d70
-# Tag = 942af8ac0482d01439aec934816cc827d7ff9c6a9885df738ba01eb15b368093
-#
-# AAD = 28b94adb6cfd
-# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
-# Ciphertext = 8a7b52eb2704716b3f7befaec3755f116e80f456c2864aed8d9ea1a0eb674da2512efed1e067077d
-# Tag =
-#
-# AAD = 30c152e37405
-# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
-# Ciphertext = cea7d8c02d11cc9c6c7435bba1dc7f162aa6b565a70090055dc90fa133f5c13986f5ae647c34cdc1
-# Tag = fc27cd9a225e9aac
-#
-# AAD = 38c95aeb7c0d
-# Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
-# Ciphertext = 91a69d72e2bf41ab6ea30ff092f4b94cb2d26702e55982570077b12895f329cae218669a9e9d20f8
-# Tag = b1678967e65fec170ef86c973d62fc3a
-#
-# AAD = 40d162f38415
-# Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
-# Ciphertext = 92d1d82c9af7ee2b3e68b7b923dea7bff481d677fff9738777220cf3a3d4e523a9527f4a18b98f7e
-# Tag = 8e7f221b8bfea7c07715428af7276c4b6f8f929fdb80fe5f
-#
-# AAD = 48d96afb8c1d
-# Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
-# Ciphertext = 2f5626ecc1edfe26e2110f96cf4353d88917302a084aee9450b10c55421173941ddacccf6fd4074c
-# Tag = 4ac40ea1a83c8b43564d02b3112819d2da2a31b6dfcf30ac248953949bf30760
-#
-# AAD = 10a132c354e576079829ba4bdc6d
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 18a93acb5ced7e0fa031c253e475
-# Plaintext =
-# Ciphertext =
-# Tag = cf04c2d861dbac8a
-#
-# AAD = 20b142d364f58617a839ca5bec7d
-# Plaintext =
-# Ciphertext =
-# Tag = 487ac1a9ade8492bfa3965bf8f6cff3a
-#
-# AAD = 28b94adb6cfd8e1fb041d263f485
-# Plaintext =
-# Ciphertext =
-# Tag = ae1f3511477518c57bbbbb5ca7b9fa507228aa60655881e5
-#
-# AAD = 30c152e374059627b849da6bfc8d
-# Plaintext =
-# Ciphertext =
-# Tag = 6eaf0b2af0de1b47d1d1420aa16729d2b4ff0433d152ccd284ece73bcee422b9
-#
-# AAD = 28b94adb6cfd8e1fb041d263f485
-# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
-# Ciphertext = af19d4c675e79ea3d7bc2dbd9030fc2732b3acbf3e8411b6
-# Tag =
-#
-# AAD = 30c152e374059627b849da6bfc8d
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
-# Ciphertext = 447289611d625f0b672d402e7734fed7fa0eb114bca114e4
-# Tag = da97a33eb8b85b67
-#
-# AAD = 38c95aeb7c0d9e2fc051e2730495
-# Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
-# Ciphertext = f6716111439219a0258f7e4f8be15b3f3d5b55d19706f3f5
-# Tag = d6fd768a99c68fb5c9328c92269c1443
-#
-# AAD = 40d162f38415a637c859ea7b0c9d
-# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
-# Ciphertext = 81a647add0b3b0626b3656665e5fa58be89c3523d3883606
-# Tag = 73ae026412abf0d1d57abbcc0b004f5afce1b4f0e3756b62
-#
-# AAD = 48d96afb8c1dae3fd061f28314a5
-# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
-# Ciphertext = df39cd3fd8cff12a212ae6adc2907c7b211774d9e5034714
-# Tag = 7d266042b3499f9668619d258868ae29ef8a1ae5d3078d20af9d12681d0f18ba
-#
-# AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
-# Plaintext =
-# Ciphertext =
-# Tag = 300ef30f9416e1af
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
-# Plaintext =
-# Ciphertext =
-# Tag = 26c08b700224ce26edd193cd4a304239
-#
-# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
-# Plaintext =
-# Ciphertext =
-# Tag = 454d90413ae61aeddc059af247e02f948cca8ca7f2f7e048
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
-# Plaintext =
-# Ciphertext =
-# Tag = 94214f9ba55c987b37f8a66fb8efdc9fc1ff685a0d23d2c9ee4a23d7f48dbd9b
-#
-# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
-# Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
-# Ciphertext = 1e961bf5039442ddef30e97efc6d3006bee03946889893f691d47cb15933f733d859
-# Tag =
-#
-# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
-# Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
-# Ciphertext = d3e7012bba9bf695fefdbd01ef5a4c51432847eb189b7269e154c153566c7a9c2789
-# Tag = d3077531f1893b4c
-#
-# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
-# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
-# Ciphertext = 90501b5a13bb93278ad58c4625301e4f54527ae772fab9fefad969cf438629f63feb
-# Tag = 64ca5ea05b4e5afee3377a11fdc913bc
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
-# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
-# Ciphertext = d5f7e55308b1a328d6ca2e798f738bb690128263ab4d9ffb3d4832aac522e16832c9
-# Tag = 48d5a8dd5a750907a4889bf360256f842459bf86991f79da
-#
-# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
-# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
-# Ciphertext = ebed339ac83122e1c47aa79af3a4e13ab0f24f43c00b0d5cd9ff9a129315933ba381
-# Tag = ca38384a722ab520af59a1af3995bea58ffd730c5b30defabecd948719638dad
-#
-# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
-# Plaintext =
-# Ciphertext =
-# Tag = dab67d70c586b854
-#
-# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
-# Plaintext =
-# Ciphertext =
-# Tag = ab2350219956b07d02ab0f9da46fa035
-#
-# AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
-# Plaintext =
-# Ciphertext =
-# Tag = 0c07aa05775f046a5897a7805a3e52a5df0ccecbd46d76c1
-#
-# AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
-# Plaintext =
-# Ciphertext =
-# Tag = 2fa40a1d66c7812246fd3c9ee7ff28f777efb55eea0a6a8341639845efe7ae5e
-#
-# AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
-# Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
-# Ciphertext = e66aa6cec08acdceba9b1e6538d9fcdcd58bfa05a704bba6fb185ad662c1a1bd764c460fdb041fc91fb2570ac321c9ed
-# Tag =
-#
-# AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
-# Ciphertext = ed5d9eb35f61a03e893a0b14654f4778912de4a00ed675da6b3548538ef18b5a0d144e359cf40fcfb4c47868d93f0192
-# Tag = 6d6abcdf34312faa
-#
-# AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
-# Ciphertext = 3c937834e46ad473c35e14c35a628fc6f9bb8c60277717445352d1399339314651b84b84c00e27bfc5136c5cd028246a
-# Tag = b8eaf56d0e68f82ac7ab7854fe5f1a93
-#
-# AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
-# Ciphertext = 9197c92446a8f15c29186b6998d49bc54a6e0616fee5c2dcbc199a537d785231290e0ff14cccfb199eeb74a36c4555dc
-# Tag = da54a12c6c78d24c9b244dacf94379628db6ccca9dcdab1e
-#
-# AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
-# Ciphertext = 66aa91f0e3e5b76796567f23a3e14d7131601562c88043d1752501e6cb9ee22c92fcb54a8cff22c3070d1d215203da9b
-# Tag = 5bce7dc98f773c642a07a84d453136dd1c897822792e077f152c34624f331568
-#
-# # initialize with key of 128 bits, nonce of 320 bits:
-# Key = 5af38c25be57f08922bb54ed861fb851
-# Nonce = 83e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a1
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 33c6886a75558470
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 317e3a631888a56aad4c1ee482ce89ae
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 580873c91ad3f23190e91dfaa7c0fac13a84f78825010ccb
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 1f4248f1b764463a3716e752acb84fa4b653e3609ec7bf71904144604e5ccc53
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = bdda3298dd
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 5c4c9c28f1
-# Tag = 075aa59b618cec47
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 21914c7cfd
-# Tag = 1ac5d263af357a1a819559cfc838957c
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = e670e37036
-# Tag = 5a6e023ae43c7ba27b80da673e8da5ebec5cb78e52869065
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 752bf9072c
-# Tag = 5d7ac8a32f75b3efa871eb4dafcc46080d057d2565117a035b86551ea465cfa0
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 88ce16c77c1dc5c155fde9a4
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 20beaeac25cba8284de4e12a
-# Tag = 8f4560e157dc76c2
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 4b8e7f9a343dc6facbe7109d
-# Tag = 0f0bf50ede1ff1845b431758f9fc4c37
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 130958faaa50a03f4e45fded
-# Tag = 0abcdcb6721e63d55de64880ff813cb1d9a51f279305ebc3
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = c18a95d7f05a8d083d5464e6
-# Tag = 3d9a8cc0f7dc0ae00c4abbbe163d53705ee1c90ceeee94c3b3abf3ebc5f6f0d1
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 2f98a72d459d2acbaa45d50f1706a1bcc1151f15b1ac39
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 62898f252d32784126eed963f5fbfa9fabe23c63a180c1
-# Tag = 581820f2774ec539
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 8fd95206b34ac713ae730a525020588cc0797dfc1d0e50
-# Tag = 4366d564edf5f10a9e7dd6b7a19893e6
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 0a3541d8492008fa8b4e7b847d6f9dd88c31baf8e95df3
-# Tag = 46129a971085e56b4b0c6049dcc31cbd169f4996153ecf5d
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = 2f4ea9dafc472204ea45af4566aa1f81382244944b6cfa
-# Tag = c93886f11a528f088e203940eb7200258e924eb0845d5de39b91d9f577a82bca
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = ed8070ae2d13cce235e9195f39cad658367994edef0f99827cea1dcc26126e713f709fe6b30e46
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = fa8ba14e87e9a76f281104423b240290ac3db5eb53bed893d13b2dfc79d281b12dbaccb9689c55
-# Tag = 7b1d463602c4f47b
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = cefa642470d48b0bc07ff5d3095d9a02cf69f5cba4456f804d1f26e6cf757b2698349370dffd68
-# Tag = 2b155898f7f6cac331a7a4434305456e
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 6f83aa1e58b5904051262ae78868cd4b950fb179c34b8d15dd75b27a633fd5b828226f20e69f3e
-# Tag = f8e640ea6b2ff5c605bbda8e1d92d81ee56f90d79cefadae
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = f17bf45efa7c8104a51d3b32f1bf89477baec26bcae6efebd90bc06a96a79dcb0b5b16989d182f
-# Tag = db91d29cea7dc3049a0e324c31d6d1a391b5e6c97043521c9c8bd2f02ab4961e
-#
-# AAD = 009122b344d5
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 08992abb4cdd
-# Plaintext =
-# Ciphertext =
-# Tag = 9c2bfea21d84095d
-#
-# AAD = 10a132c354e5
-# Plaintext =
-# Ciphertext =
-# Tag = 3654a996b299267bdef2ee6365fb8458
-#
-# AAD = 18a93acb5ced
-# Plaintext =
-# Ciphertext =
-# Tag = 52c8fcdf77acaeed1346d2fc75a31237af581a0ad1839f15
-#
-# AAD = 20b142d364f5
-# Plaintext =
-# Ciphertext =
-# Tag = 308a18912768ad5a02cf30edcdfc5f1c1a1c444a47db7165246192ad1854ac01
-#
-# AAD = 10a132c354e5
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
-# Ciphertext = 8bc00291fa7b0585282241056af9b07f
-# Tag =
-#
-# AAD = 18a93acb5ced
-# Plaintext = 73941435b5d65677f71898b9395adafb
-# Ciphertext = a0c0e8d2f58b582b167a00782137fe3d
-# Tag = 7f5dd38259fcdbba
-#
-# AAD = 20b142d364f5
-# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
-# Ciphertext = 0b9698e76fc95e74c17875278ab6bbdb
-# Tag = 122bcd16c6e8d5cc7b7395eea6cd3863
-#
-# AAD = 28b94adb6cfd
-# Plaintext = 83a42445c5e666870728a8c9496aea0b
-# Ciphertext = dbd205ba35225a79ff1cf5b67c95ecbd
-# Tag = 4f121807e73fec40c80190d54a44b8f2b3ccf3712ad0b846
-#
-# AAD = 30c152e37405
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
-# Ciphertext = 24324cb20f33a884205be98266c73bea
-# Tag = e8851d955d79962e52405269c41274b1b6e9f436e2029cd63df0a0de12e8c486
-#
-# AAD = 28b94adb6cfd
-# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
-# Ciphertext = 94cafb7bece73507f3d4651e3e38a44861a71919c2c9a40da6b7d6e81ae3f5cfb8d0c9f4ba6c8609
-# Tag =
-#
-# AAD = 30c152e37405
-# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
-# Ciphertext = 1a787ec69cf48434a1a9ddaea5b2ff13115e7c587756b3146f79a90b90a225a122ee46822de04339
-# Tag = e2756cfd5e2d3543
-#
-# AAD = 38c95aeb7c0d
-# Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
-# Ciphertext = 1ed653991d96a33aa66dc9021dc8c91507c505caef2322b241387ca20d7008ab517fe0c96c76559d
-# Tag = ca0c357a43f49f58b98ad6538e818375
-#
-# AAD = 40d162f38415
-# Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
-# Ciphertext = febf40050e7d6b2750f9cf6346a8196580f16ebe72c0b2cd7f8b76755036aaa5c478a935f7282f44
-# Tag = 0ea19e4e7c3158cd617d6e5e58ee0684867dc50f4f65ab19
-#
-# AAD = 48d96afb8c1d
-# Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
-# Ciphertext = 60a27e48774bd7944d283f375e703803ab90aaa49206248109327b50f52239061b4eabd1a5f45429
-# Tag = 35a9626b6c5ab890a6f1ddb51fabce072284177485bb6c4396c22c16651b5eaa
-#
-# AAD = 10a132c354e576079829ba4bdc6d
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 18a93acb5ced7e0fa031c253e475
-# Plaintext =
-# Ciphertext =
-# Tag = 37ce2a4766d4f600
-#
-# AAD = 20b142d364f58617a839ca5bec7d
-# Plaintext =
-# Ciphertext =
-# Tag = f911b2515fd2b355baefbbb6bafe380e
-#
-# AAD = 28b94adb6cfd8e1fb041d263f485
-# Plaintext =
-# Ciphertext =
-# Tag = f4676e080c21abaebb9f41058f92ad646858d805ad10e5c2
-#
-# AAD = 30c152e374059627b849da6bfc8d
-# Plaintext =
-# Ciphertext =
-# Tag = e3c152adc177ffc95a1a8a1b0480189bdfe67cbc6eadb2694a7d5f420db83868
-#
-# AAD = 28b94adb6cfd8e1fb041d263f485
-# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
-# Ciphertext = b19dc93693416101902ce076b7e91627c9b4e902828f6369
-# Tag =
-#
-# AAD = 30c152e374059627b849da6bfc8d
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
-# Ciphertext = f388ed4470a0ce45d1442bb9667b48c0b1ef1695c4809491
-# Tag = bd781d2b3d2bf51d
-#
-# AAD = 38c95aeb7c0d9e2fc051e2730495
-# Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
-# Ciphertext = 64888c085894b42bd22bf1b0ebf00f1630b9a37d3011edef
-# Tag = b91b97c8d8db75d73a7b32d424574547
-#
-# AAD = 40d162f38415a637c859ea7b0c9d
-# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
-# Ciphertext = 39ecd0e89eee9ad862263ca0d1b7476068d1be0fcdf5721d
-# Tag = 6180425ec307fbbaaaf882972571a09855dea06cd5ca3402
-#
-# AAD = 48d96afb8c1dae3fd061f28314a5
-# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
-# Ciphertext = b1074a6c95232cf26cb192867e473cb757cbbe9e659ab3f5
-# Tag = 1cf6d4e8e888c69d1c4bb987bccda34aadd3c3076c1872f686a5bd12ca6b3c65
-#
-# AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
-# Plaintext =
-# Ciphertext =
-# Tag = aebd9cf884f74757
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
-# Plaintext =
-# Ciphertext =
-# Tag = 0d962653b4ae7abe67b1107d02ec4262
-#
-# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
-# Plaintext =
-# Ciphertext =
-# Tag = ec26c17d22565218fc93518ad3162d8a40686674fd7f3296
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
-# Plaintext =
-# Ciphertext =
-# Tag = 60c4b9e709b8bdbb5f40e11e65876c248962685b5e1f447dc331a1e22cbea2c6
-#
-# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
-# Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
-# Ciphertext = 0bbfcb099e0b51c45bd8cef5ac667f869a9ab37bb5806941c34d4835913babdfd1be
-# Tag =
-#
-# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
-# Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
-# Ciphertext = f9fc9fd9994c2c07450d234b702c94760e478db02daefa6da971a58ba80e27ec1332
-# Tag = f717e153396f6d35
-#
-# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
-# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
-# Ciphertext = aca9ab8ffc23e0fc59f2b3b3c56a12237319595006c23e2339c8a28c1eac1d668682
-# Tag = 33106fccbe6dabfe1c404decafb70163
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
-# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
-# Ciphertext = f230fab4b5caea8b23aafe2c0bddb834315cf19425769da3561ea428b96971f14e24
-# Tag = 4529511b9a0f1e1d563cf098e518b074284cba7cfa697a46
-#
-# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
-# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
-# Ciphertext = b0f27308679344eddd009ee7a34797266d24654b5f0256c0241e5df2943d56037ac7
-# Tag = 73a222bd7571c507fc9d57b8bd467d4838ab600a587a2801aa8f09b27d4871d4
-#
-# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
-# Plaintext =
-# Ciphertext =
-# Tag = eff98cee9f0d33b6
-#
-# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
-# Plaintext =
-# Ciphertext =
-# Tag = 1677f99114a5b2512c07f2b3630c0cc5
-#
-# AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
-# Plaintext =
-# Ciphertext =
-# Tag = 24708526b7fc02a0e9d860317c619983151f11d5445ecacb
-#
-# AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
-# Plaintext =
-# Ciphertext =
-# Tag = d58de5c577649c65cc5e70910be8102223e0fab6b45294d242c2cdad1b4ababc
-#
-# AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
-# Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
-# Ciphertext = e0750abe2ca1a6916bfcff289a5fafab3b5ca7ff1a0af7c610755a035100ecdf056c6f1ed7e575a7aa51522e1cfb4711
-# Tag =
-#
-# AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
-# Ciphertext = 5e468462de8df190a0ae118794cd5b5060691fbf6c72e6c43d19681a4dd8ee6dc5c12ab761115491f98b4da40480c746
-# Tag = 5e6f0c7569da4969
-#
-# AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
-# Ciphertext = 96fcd6af42e60464054efbfd398f4167c63258c7557ae4e1867ab49ebea19ac258eaf6e364942b7fb3d644868e65799b
-# Tag = 48d02a5fa9eee22b2ca24cc058002552
-#
-# AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
-# Ciphertext = ce9e3b8a23271c857e0c83b70419a3f3857fe5cd9281ba5b66533fd7029d7e1903517c48b71fa8a21e4dc00e76968a0f
-# Tag = a03f35ab5b3cc1e4eef8cf7f3417f840215caaab795d46fa
-#
-# AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
-# Ciphertext = 60e96cc6d9316a0aefdf3b78e9a5dd40930e7a1b3c185339b1270fa0ed79e8c31d809b6742b4505a038783977a763465
-# Tag = 96bb15d078716eb3825fc993f9a0550236a23363a04852f5c71fcf73db02ce4f
-#
-# # initialize with key of 128 bits, nonce of 384 bits:
-# Key = 62fb942dc65ff8912ac35cf58e27c059
-# Nonce = 93f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b51677
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 571313513bd4262c
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = de6083c874a85dd899452412fdaf07fd
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = e5b166a31961513a09fc22fc129bbb1000126ba9f40df139
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = b6c882262055a78a773bb4b6c313381d32f3566ebe736ddee9b1f4f6e7c16fb2
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 5dce2896a0
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = f8646ef4c4
-# Tag = 197acc5cae6bf7c0
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 208b24a97c
-# Tag = c283bbb8d77b14f25e36235f860dabea
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 383068884c
-# Tag = ce9bf97b3c22ce2e8e9c4f9a17bf91e393e480a7de25098a
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 8cd6fa0a49
-# Tag = ac6df31c36a94d784d50331e3923e1000907e5d1f3a228215c7262de3b0941fc
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 8d443fa2b4320b6a44549806
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = f51d37020cc24e65c2376d1a
-# Tag = 93de418245e33671
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = cbcba4f882709cee93e9f37f
-# Tag = d852dc36025e92ba08d90d9c8025d9fe
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 168e8f47f2e209a2b35f2d59
-# Tag = b1b4ae787512ee83ee240120ced75a265bb06e81f1e07849
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 2dbf65e63e9065e35777aeb1
-# Tag = 9f2a94d42f1b274904e44a3749dbd7159ffa5321a6de03a44c50cd81cedcf2ae
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 6c6f2c5e1a4f580d0cf864c5ecbd0dcf37cda8dc3e2aca
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 3844c4fd2f14c1d9697411097d3742b8f82f17e9d2dada
-# Tag = 18f33fe8e1c28393
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 3202c93475c720f5e55e565a60fdb5c8c45694f8b99fe4
-# Tag = 73215e3aade83c700ddb16c8abd43c65
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 6a254459419e8151227829772fe3af83634df20f6df4d1
-# Tag = 4c0a7aacdf0d52138449ccfd600416e03b73aec612f5ddda
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = 131c3a5c1707d2a4917fc8b23e8095129d7529c6f97340
-# Tag = 7e1f74c26479cb2165aebea892f90d8bfeb34e318d0e18f8dbb9d3a045b6cc37
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 6effde99cef27db4b0e61974f02fd4f6da8fb32186b031a6d7240c44dc28a889aeacd06218e5b3
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 0c2fbfe9e3a9843266ec035fa18b8c47d8deb200aaf79ea929035339c13ef43a583bfbfced0bcf
-# Tag = 60fbda8ba378104b
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = f9adeaba73e9f078ba884ce0addd2810de4cb1f382bb10d9258297410534c4334200d5ed0095b5
-# Tag = 7f2b6be7fc815aa25917fef343f4adf7
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 6748e417c5442bdda9f7222a863284787123e49215d4c6fcffe7e5bb4915a19767ff267acd13a3
-# Tag = c7a083621308bc8bd5913446de4b96a07f653130740eafdb
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 35f7b6ce274f780cdf1cb98f2f89aeabd18dc17b5a2edc27505e45895789c2643fa29cdab46127
-# Tag = f50073c04086248f0dce842ec7dbd2a9da2abf037210c32d49cc06b193b9757f
-#
-# AAD = 009122b344d5
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 08992abb4cdd
-# Plaintext =
-# Ciphertext =
-# Tag = f5e4675a3f53158d
-#
-# AAD = 10a132c354e5
-# Plaintext =
-# Ciphertext =
-# Tag = c38f82e37699c876e17fefa7f787bd2e
-#
-# AAD = 18a93acb5ced
-# Plaintext =
-# Ciphertext =
-# Tag = 064d9b4fac9682792fd36cc0174a0aae72a86921d7a22877
-#
-# AAD = 20b142d364f5
-# Plaintext =
-# Ciphertext =
-# Tag = 53e0bea2ba4a71b762e03121160912353e81c0d975fc300771d960897f1f32af
-#
-# AAD = 10a132c354e5
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
-# Ciphertext = ac5adb532f7d9e16772cdddd58e1fd45
-# Tag =
-#
-# AAD = 18a93acb5ced
-# Plaintext = 73941435b5d65677f71898b9395adafb
-# Ciphertext = ffb12ceb64e0ced771fd03ee31cc2554
-# Tag = f5ce95f53ce55519
-#
-# AAD = 20b142d364f5
-# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
-# Ciphertext = 17b0678aabb70d6bad68db105a3d3f5d
-# Tag = 4a2b60cfa63794771f4ad7a0cb0792f5
-#
-# AAD = 28b94adb6cfd
-# Plaintext = 83a42445c5e666870728a8c9496aea0b
-# Ciphertext = f5c779f93a1799c7cc4d7ee5cefaf07d
-# Tag = c95c2e0fb4d7d13eb61f3b075194e5c4485d2d399bc45db1
-#
-# AAD = 30c152e37405
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
-# Ciphertext = 80beb3540e10b10e13d53ea9ac4b2a53
-# Tag = 76edb785ec99c8f9116cdeac1bdef646cfddba96d88e64c84599785b00af49cf
-#
-# AAD = 28b94adb6cfd
-# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
-# Ciphertext = caa8307da38712ba141b0aa3fa61b496b4b81cb5fa966b33e7d7725fb58160e3069b010af355c8c7
-# Tag =
-#
-# AAD = 30c152e37405
-# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
-# Ciphertext = ea224ec7bac4f317bfdf5a728e3fbf68cfc71005e649ccadfa0b4614ec19880f30fad129a910389a
-# Tag = 2a70c062a8a80c14
-#
-# AAD = 38c95aeb7c0d
-# Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
-# Ciphertext = a15f68ed18b5a313b299f763a2b0fb6bc55b43ed3a61731f6ff9756e6096995604b54b2e5f43e7e8
-# Tag = 06e3984d53e8588daaf211f5d918662f
-#
-# AAD = 40d162f38415
-# Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
-# Ciphertext = 45807d264008a91cfeda84d58ddc562c17151b80f57d8f8c78ecdaebccf6535e731eb8c6c9b37ef6
-# Tag = 2f2c98d89caf21b014800841d0bfdfe1f6f458d1ace3b94c
-#
-# AAD = 48d96afb8c1d
-# Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
-# Ciphertext = 8e6367b8e319f5304c3cb8551c472016a3800f42384c336f9b21ef454938be8183b736006b922f19
-# Tag = ae42584e785e9904e4032103dd6d01873f59ff7c878b6096f89518a5e93776e8
-#
-# AAD = 10a132c354e576079829ba4bdc6d
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 18a93acb5ced7e0fa031c253e475
-# Plaintext =
-# Ciphertext =
-# Tag = 4fc8d21cdb08e4b1
-#
-# AAD = 20b142d364f58617a839ca5bec7d
-# Plaintext =
-# Ciphertext =
-# Tag = 966792d102b8c89b4381d07c570efdaf
-#
-# AAD = 28b94adb6cfd8e1fb041d263f485
-# Plaintext =
-# Ciphertext =
-# Tag = 7277214a93d5b83f2349388aa8220b10d520d07f83adc041
-#
-# AAD = 30c152e374059627b849da6bfc8d
-# Plaintext =
-# Ciphertext =
-# Tag = bc820ae6ad83cbcdd2b13232b5641c06483c27cdf8cdc2cce5555717f3f7c84d
-#
-# AAD = 28b94adb6cfd8e1fb041d263f485
-# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
-# Ciphertext = a10667884bd3d1d47cdae7ca2ff2ac8fbcd24ed2522dac87
-# Tag =
-#
-# AAD = 30c152e374059627b849da6bfc8d
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
-# Ciphertext = dc17b6e4d5bc1632999e960ac529259499c8553c4b9951c5
-# Tag = 98df3eed14cc7ce6
-#
-# AAD = 38c95aeb7c0d9e2fc051e2730495
-# Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
-# Ciphertext = eb745c48e9c4a6fc0fea561dc411c3ddc6a868f23d3dea08
-# Tag = 200eee9cfca4ad4783dbfcb0bc724cc5
-#
-# AAD = 40d162f38415a637c859ea7b0c9d
-# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
-# Ciphertext = a5840630e35bcefac8c47c7e7fab453dc973534d18007726
-# Tag = 36d70c77add47fc614a1883581d6df8267d16ae3e4006827
-#
-# AAD = 48d96afb8c1dae3fd061f28314a5
-# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
-# Ciphertext = e1648e6c2c3e1433fbef56276ab22f99e79110dc386e1f17
-# Tag = ca9b407a3d0c64f5c76a239be3c71305548cea53360bc118b6fb726b6e43303e
-#
-# AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
-# Plaintext =
-# Ciphertext =
-# Tag = e05105d4024e23e2
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
-# Plaintext =
-# Ciphertext =
-# Tag = e499e7abe08cf101aec2191652a86d44
-#
-# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
-# Plaintext =
-# Ciphertext =
-# Tag = 25fa5d8c08d2d10e3076183add992efae277260fdfe258d9
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
-# Plaintext =
-# Ciphertext =
-# Tag = 4f2418966f2b7a018485e06fc68a5973708759a3876969daf577fab7310e0bb3
-#
-# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
-# Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
-# Ciphertext = 47744da4149b82b28045c3badf3b78e4b0f758efa8ee9fb158263c17a216cad89e9c
-# Tag =
-#
-# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
-# Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
-# Ciphertext = 648598f0e8a4832526b12d039729945fd90fb7e04af9d257977c7cf659cc66caf159
-# Tag = 572aaab24f5d697b
-#
-# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
-# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
-# Ciphertext = e0fd6e8dd069f90ced363ac631f74c6376475c205531c7c6b93548692d5eb305c003
-# Tag = 341acdc2245ed5a48a39376e1d1797a1
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
-# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
-# Ciphertext = 72ead0d8e021004086e3a7081afa467bdd5c15899ec8e8fa1c52050082460e405355
-# Tag = 8174a3d3a31572ac292fc0e6834537ef55286d3b6b20fa0a
-#
-# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
-# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
-# Ciphertext = fff4b85e7c94e8820122010e33f054638b9c43176df032b04bdaa580b44c3174a77d
-# Tag = 25074507d30bdce23686d795eaeb4a0598e616d71a9a7ad1264f46654d7743e6
-#
-# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
-# Plaintext =
-# Ciphertext =
-# Tag = 0c9e39aec40f615a
-#
-# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
-# Plaintext =
-# Ciphertext =
-# Tag = 5ff55d0b20d2ac202a497122e618f6e2
-#
-# AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
-# Plaintext =
-# Ciphertext =
-# Tag = 16c9640f019e79c303ff6b4315ef792a39d6692ded4eba63
-#
-# AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
-# Plaintext =
-# Ciphertext =
-# Tag = e2219b9966890eeb6b9681a5e249a84b7adcb1911e985770ce67c2e3cadabb59
-#
-# AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
-# Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
-# Ciphertext = 1098281fb1e09cc24f4447c94f6e252f658779e1349b5dbb3a5fde9d02c4534aa92fd057ecf17d89c7340d32eaf63870
-# Tag =
-#
-# AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
-# Ciphertext = 59e77313463c9e9a01eb729515a1317a1203aa4c31aaa4aa6d62df3636e03a895675ebdd151365ce5987a64012e600a6
-# Tag = aede2eec0b2b61ba
-#
-# AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
-# Ciphertext = 6f38f841f42bd75936e44213eaad82f0b4bb6d4321ce21bf04ccaba7edf7fe73167bd34408ad5bf007f520677e6ec487
-# Tag = 18642b8b7282a97e5d19accd18ec5b35
-#
-# AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
-# Ciphertext = d139bbc47afb30f6a548d853dcdc104c6eb17f8774d2a283fd4ac42aa421e3d6bf603e7cfeb0ffa3f496a386dca9edd3
-# Tag = 43ab79ce624a79978d4052b61e409bbbc0243d07567dec21
-#
-# AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
-# Ciphertext = 0c7e8cea9fa41ae007a889bb894075d70c3c37862b1ee12c0879ad23163d8c7d593b33892d88c2d445238df1309d5268
-# Tag = b86d266de6fd520d575a0907d2e80803d89979f9f34ac6538216ee828e24e8f4
-#
-# # initialize with key of 128 bits, nonce of 448 bits:
-# Key = 6a039c35ce67009932cb64fd962fc861
-# Nonce = a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 08ff1d91194dc1aa
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 0224ef0d359339fb1fed06779ba113b6
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = a6f5141f46eb2e763641af3ff2aa7a0d3a3c164b5d1e714e
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = aa51299dc97d4732a453488e9fc78a0c6a4b1d5cfe2b14c997ca743529d7045b
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 27534e46f6
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = f2ca63474b
-# Tag = 1f1504028eaf581f
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 10fb31de68
-# Tag = 9e074c80f64633dd2ce07bc9997269eb
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 0d681ff46e
-# Tag = a1f2366973045d7403ce9719a6391d2ef095673a2badd664
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 84abff25aa
-# Tag = 07bb8752dcfba3a846706cfdc84f794a2f5e0e33a369c61e2f82c7e1e9a40bcd
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 3ea90051c693049dcb87b9a6
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 8ad2cb42984c740079859cc4
-# Tag = 36bd6e615cf481b7
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 38319286958daf0c360de893
-# Tag = e1db2cdfc4a9d04cd2ae6d2aa0d7b41c
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 653cde5fc6d52cf264b0f406
-# Tag = 3e070ba358bdf0c25eac3b31b23c7730efdb272c032eceaf
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 20a5850a9254d6d5aff1e67a
-# Tag = dd522ba2a154f282eaa7c2bca4aa674c07ce207e5aea83da069c1100c4eab2a1
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 483819fd19e5908846944acb1e8f72c8956b05b7abf712
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 28ea1bb87d7f1cccaa333534799b8cd495c76471c19821
-# Tag = c2e4a346445b54a7
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 9a37b61b7972d0ab9eb3a7703451d416556c2b21955418
-# Tag = ece568fff70ddb4ba42eb1d56c1d37db
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 24e2282581d1a1c7338fe4621fba695b12eaf079bc77ea
-# Tag = 9446780c6a1c883b1524a1afe1a1cacb59ce458787e7451d
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = 66cb522b7300c48bf931dc3825276e974a78ca5d4bb16e
-# Tag = 70521fe6d4b5ff2166a2f0c4284241064e8d00c8004497eb23ea7734c86c72e3
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = b39b26aeeb5673b4af24ef5f72f2bea17c800a71fcc829e55eb66946e8ac9481054961570ed11e
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = b3121c219f99e949a0c87395adfd764844e6d2238a621ce13f094199c4e9133dd9bed2045c1edc
-# Tag = feefaa4150a4992c
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = a87c98f3ac6d1daf2b559afb9a31c96a40a320d1a374ca25b9d545eff1bf30483d217538300d33
-# Tag = 13fc58be1601e606c6cb1b95b3880889
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 374ba9f85d34673494f466946edf93917234f0d735b4639c197aaa22f57a15c607c9056a5bce49
-# Tag = a979ba8763533c4bde1f9d049c8f912186d8ea6ae00b9d70
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 224a5ea3ec73c7c7e5e11ce3e18d1c4a3a1a0597702d4c8541b17ab2c637e465ae5b19c5a507af
-# Tag = 51009753c2a4056b18041394a9cbd0a5d8b7518aafc95dd1a117a0ee7e149752
-#
-# AAD = 009122b344d5
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 08992abb4cdd
-# Plaintext =
-# Ciphertext =
-# Tag = 0df8274329fc945e
-#
-# AAD = 10a132c354e5
-# Plaintext =
-# Ciphertext =
-# Tag = dc73120d7c16da28dd2faab3f0e77c73
-#
-# AAD = 18a93acb5ced
-# Plaintext =
-# Ciphertext =
-# Tag = 06ce8b91a772d578f542dd5b530feb22bd037d6a9495fa4a
-#
-# AAD = 20b142d364f5
-# Plaintext =
-# Ciphertext =
-# Tag = f974bfcb95d2cf46cd039c04a3156c67ec8c058830431c3784ec8ca533297ad6
-#
-# AAD = 10a132c354e5
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
-# Ciphertext = e19ffcd638c13b4f47af0e1f6390d8b2
-# Tag =
-#
-# AAD = 18a93acb5ced
-# Plaintext = 73941435b5d65677f71898b9395adafb
-# Ciphertext = eeda1fad83277f6b85eb66dbd33adb7c
-# Tag = c8dcc191800e030c
-#
-# AAD = 20b142d364f5
-# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
-# Ciphertext = 5872063c27a26d3fcd5f48026e538343
-# Tag = f48dd313ab28904c4bd64a09d90e02e4
-#
-# AAD = 28b94adb6cfd
-# Plaintext = 83a42445c5e666870728a8c9496aea0b
-# Ciphertext = f22c4d27a51c962375ad663eb5525031
-# Tag = 8423df7eb27720b65b8fba738fc89c5f54d55da8ca934bfe
-#
-# AAD = 30c152e37405
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
-# Ciphertext = a3a1c9939e78e3bb8e9522bdf6959bbe
-# Tag = d043a566676630809387549785b9a65045eda6699349d331a993e02e7a596bfd
-#
-# AAD = 28b94adb6cfd
-# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
-# Ciphertext = f18aed0d42dfad971fc221e0c84983777a95225086e754894b6a3434273c92fb9e35da5318fd3439
-# Tag =
-#
-# AAD = 30c152e37405
-# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
-# Ciphertext = caa99496d713de3bb1373abbd37efc0db62f98f7ecafe7e742cc4099605ede648ed0bdbc58563ef9
-# Tag = 6db9da89f2ec41e5
-#
-# AAD = 38c95aeb7c0d
-# Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
-# Ciphertext = 524c8528f8391fcdbb9e94feb2deab3fb99fc53ef822df797f13cb69e7f8b270c634ac0cbf939fc6
-# Tag = a1ae6851f72b33f214d2f8361e892f2a
-#
-# AAD = 40d162f38415
-# Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
-# Ciphertext = 4b1c820b219cfbb35ff35ccae0281fc27412bef3bda3cfc2b87e0dfa3029629215a3d002766cfefe
-# Tag = 78615ea4874949cc9fbb4193b9ae5e2ce44ef6c5b6351c54
-#
-# AAD = 48d96afb8c1d
-# Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
-# Ciphertext = ece3b6fe1679bf2d962086702ccc22151bcf8392611bb0622be00c8f176ef1fc896f107a6e4bd59b
-# Tag = 05424d1b35d92ede8bc0fdc65a09164e4ba8b0559111a9e89b72c22bb65605c2
-#
-# AAD = 10a132c354e576079829ba4bdc6d
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 18a93acb5ced7e0fa031c253e475
-# Plaintext =
-# Ciphertext =
-# Tag = 82ff7c893f93f13b
-#
-# AAD = 20b142d364f58617a839ca5bec7d
-# Plaintext =
-# Ciphertext =
-# Tag = 5aff6166f4aa2e5558cb9aeac4591a61
-#
-# AAD = 28b94adb6cfd8e1fb041d263f485
-# Plaintext =
-# Ciphertext =
-# Tag = 83297838074ee2e658b33a2688f64b63e1b04815871fe941
-#
-# AAD = 30c152e374059627b849da6bfc8d
-# Plaintext =
-# Ciphertext =
-# Tag = 69825e54860fd0ea22f9b4a28df2551fb423f1d457d1ce2e3408bf687ea45e5b
-#
-# AAD = 28b94adb6cfd8e1fb041d263f485
-# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
-# Ciphertext = f53b878d1e248903ca1ce24bc54f5455c15fdbb547a2adf9
-# Tag =
-#
-# AAD = 30c152e374059627b849da6bfc8d
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
-# Ciphertext = 029a7d95e4b793eefc088303414b1181e6a3a4d4b29f03d7
-# Tag = d20a6bf859a1e951
-#
-# AAD = 38c95aeb7c0d9e2fc051e2730495
-# Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
-# Ciphertext = 5c0063c79c13896ede0cd4385df5e393ac306cd5689bac4f
-# Tag = 509fbea6351709b879708957fdadf1f7
-#
-# AAD = 40d162f38415a637c859ea7b0c9d
-# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
-# Ciphertext = 8eb882e8e36013d7524b76552db48d6b02d419706e06ce1d
-# Tag = d5c5bc6e39f4ca973877dfb85be6517ed286013fb758abfe
-#
-# AAD = 48d96afb8c1dae3fd061f28314a5
-# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
-# Ciphertext = d0fe9622f6b5d08daa1fb954301273a554f49f475c6ad900
-# Tag = 0b59d2819aa13cd739cfb90e7df2d19fb7b470ff913529f7f78f88022abc6b22
-#
-# AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
-# Plaintext =
-# Ciphertext =
-# Tag = ced39c0c97518a24
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
-# Plaintext =
-# Ciphertext =
-# Tag = 53112dd7173a81fef5dd09c53010c2cf
-#
-# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
-# Plaintext =
-# Ciphertext =
-# Tag = 2f3ece12c744bdb3d2527ec09311661415442165f239850d
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
-# Plaintext =
-# Ciphertext =
-# Tag = 0a48f447b84732ae3ef126559bfca5727318c26cca101e2198fc4cebc6dd9ea6
-#
-# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
-# Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
-# Ciphertext = 8a4588eb33f1b5e9f99bfe3b9b55ac3f3398c4799e5c9e2d03fd1a08a8bc3d5188e3
-# Tag =
-#
-# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
-# Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
-# Ciphertext = 9c1b357ecf416145d3293f78f5a26e29ab26eb60d0c619f306f7ad67d14577cc3333
-# Tag = 9fd2c538ff1ce98e
-#
-# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
-# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
-# Ciphertext = 2953c02f6bd50deea3acfa59dc8d00b0f6d8c1de65bdd72546a02f3f435787fa963e
-# Tag = 4f6f31b8362db6e275b7eb8366d38ebd
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
-# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
-# Ciphertext = 22455e74e0377c242963f1bf2bbdc523ee1ef46ed92a9b45a1f86b10d91f88920201
-# Tag = 595b02ce805297131bd60a439aeea89413226131533aeed4
-#
-# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
-# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
-# Ciphertext = ce1d230b9c7f4f870aeea3e5edec0f998cda5ac8e59898f04316476d2b26595f0c2d
-# Tag = 0f64bd294b056c993da0957b1018446e916e7577f97829af8430208fbe72e984
-#
-# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
-# Plaintext =
-# Ciphertext =
-# Tag = 7b09a5db16efffa1
-#
-# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
-# Plaintext =
-# Ciphertext =
-# Tag = c6f4ba4a5a38ca38424241819c6ffaa4
-#
-# AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
-# Plaintext =
-# Ciphertext =
-# Tag = 9494000b2b5e97d5e2299b2efda0362aad491a483f4e5255
-#
-# AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
-# Plaintext =
-# Ciphertext =
-# Tag = 78dc81a30bcd126a126f1e6f118856023227931b3218967e2dbd9b2623ff046b
-#
-# AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
-# Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
-# Ciphertext = 1c622ba6ea9a64464a75f7899f938a44c40fb0c2056e0d822c24937bbe48c24ab7895e921a57d93bc10da14153bc3f15
-# Tag =
-#
-# AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
-# Ciphertext = 27c9fec932e0735e9142c61edc741b8b8fe5f390d63e87da5be551d5a2253a08eab15cd843cbbb8e5ecb56e555d45b10
-# Tag = 6f6b8f5cdd53a107
-#
-# AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
-# Ciphertext = c7c55742545fc75abed2e82464b9f1aa025c52ef9dc93b455da4863b443c20dd7618b11850f315faf0a6c05d145e0ff4
-# Tag = 7dd3e4c1c3450b49756230e3a5bef7d6
-#
-# AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
-# Ciphertext = 2e48f1d4d2cb82548ff0d9f84d5fe8d07d0ac7dbc436d6cf7bb83f912cea633a5ff2f7d5cc311b5ac3dea476bc85c81b
-# Tag = c2fd550cb3a886dfcd13a30db9902bc3c2d238e5922ebaa9
-#
-# AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
-# Ciphertext = cb7db9cc0ae4dfe2058050305d3afd9d57bc9fc4941dee17be60473012fcf00529754f4399fea0a1fa6f79664d1f1729
-# Tag = 21f163383b986f2e82192aedeb15f1d3c40f658860d78452c481339fa94530f2
-#
-# # initialize with key of 128 bits, nonce of 512 bits:
-# Key = 720ba43dd66f08a13ad36c059e37d069
-# Nonce = b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 905046161006f352
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = fca34b92a4c445d526e0574993ad70d7
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = c5f94db645ce0fb0ca9fe486cf3644b5c228e007e93ba56e
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 2ebd7f041980350cae468d65a6d35723bdaf91a1248bfad8651335c15eb19b33
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 49bbc22b69
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 772cce6b53
-# Tag = 84d06d6439824c4a
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = f21cb71622
-# Tag = 85a06b965e29c6498c3e3650c12e8570
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 91ffcba7c0
-# Tag = 22333b5cc88b9360e7c15bcef994c3a8d543fbaec2e0ed88
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 96de28a8fd
-# Tag = 8d4f91f34590e05e53594ee0631853cf02b6f7c927bede68d71f84d9e9c88ce3
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 6ef5d1ef7fee39fde0f04114
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 45dc364bf86f640f8e124136
-# Tag = a467b3e43a7dec9c
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 0bc3417ff2ebf75b8d124595
-# Tag = 51b040a36a78cfce302b9605365ea0bc
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 4ba955721cc2b536768ad63b
-# Tag = 5099c8e0126008480c16ee132d69a354805116955b385b0b
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 5dc0dd591ef4f61f27d7bc62
-# Tag = 0fbe83ba59db64ac65523b52b1307987d9451385f1e5a047835e1c70f35b47ca
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 33aa70ce5daac7bae38797406fa2d7eedb690154d5ad74
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 6cc291ea01afe9bb00aa5567cc10f9805f080d81e4676f
-# Tag = d00063a42b2e5bf6
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 1a093e725c45e4d5cd99e84286225d0d6f3d9e698fa598
-# Tag = 80b057c5de064041ae3ca0a73ee3741b
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 5ab6e11cfa3da31dede2027affe7684a72248407d687f9
-# Tag = 4bdc2bb651cb7c6f5edb4c3993cd8f5eb5602890fd3a5f6f
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = d28b4e37588fd6438631eb365d96fa7a414c614ff06582
-# Tag = 3e34d50cd166138f1587e17913f0b871207e42dcc0647702b7fb2be14d493500
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 7554dc82810e872ead74e663b8b57c1e1162393abd68cb47415dc411426ad0c807131f4f5affa3
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 106360255bd91d2ee690d9c00dfa051914869c84ec3e3dd19e9bed820148cb00f40a1c807575c3
-# Tag = 0ffa80e6c2328d0d
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = 2b64c4320865bbad01d876da3389e6f17fcb46110f135a10bcd0ceb02340518dab5c4fa2e64202
-# Tag = e3ffa809f90675c61e8a0073322180b3
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 1a008e963a02a8effd5c304e12abc094c569cee490540b8efa4015fb6c9d870220559f49160b16
-# Tag = 5c444c6f8884872d920bdf9551cc7f9ce084a155840786d2
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = fed1ce12b252b5042e7eacd9b0ac74642374087ad6fa19e026d6fe6f22ad3f52ddaeb17be9eda8
-# Tag = f338b20b8d2586b40dab687a83053c766a876bebbcba65074c80ffef818ab9fb
-#
-# AAD = a233c455e67708
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = aa3bcc5dee7f10
-# Plaintext =
-# Ciphertext =
-# Tag = c1d31635c4f98113
-#
-# AAD = b243d465f68718
-# Plaintext =
-# Ciphertext =
-# Tag = db2b7a97acd4513dafa3434b5e759ba9
-#
-# AAD = ba4bdc6dfe8f20
-# Plaintext =
-# Ciphertext =
-# Tag = b1cd6a550efde4066a4877da8f0c3e950a2e15c747bc07e9
-#
-# AAD = c253e475069728
-# Plaintext =
-# Ciphertext =
-# Tag = 47a6c74a97e72e8c6775ed88afbcbca54dc9e5ac23a562c550b173306edc8ae3
-#
-# AAD = b445d667f8891a
-# Plaintext = b0d15172f21393b43455d5f676971738b8d9
-# Ciphertext = a8d439334057340f76972eb975f013949f72
-# Tag =
-#
-# AAD = bc4dde6f009122
-# Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
-# Ciphertext = 599ad42db14944a04f4b895c324a8f29fe2d
-# Tag = ec2f1668abb8fe38
-#
-# AAD = c455e67708992a
-# Plaintext = c0e161820223a3c44465e50686a72748c8e9
-# Ciphertext = 7f1bb2a3aa0800a700b228d8cad2bc0bae5c
-# Tag = 3db8abe18ef4c9f787878b2d3bce67d1
-#
-# AAD = cc5dee7f10a132
-# Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
-# Ciphertext = 445688f97ffa18f9c81036ea7f615bc356e4
-# Tag = d45a9fc385458dabed21708d3860e623f4974c16830cdc13
-#
-# AAD = d465f68718a93a
-# Plaintext = d0f171921233b3d45475f51696b73758d8f9
-# Ciphertext = 4233e0023acb329c5deac2e94296f2917c5c
-# Tag = d3ce972af1b3b32fb6942be3d53af68f8452be5c7bb4805ae81dc65cbceef150
-#
-# AAD = cf60f18213a435
-# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
-# Ciphertext = 88796533cfb16053184ba07f938881f8de5b950198aa998c442d8e26ca784d9513aa12d1c5c2c4b49e4c9bc33d
-# Tag =
-#
-# AAD = d768f98a1bac3d
-# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
-# Ciphertext = a4d2441687115184d16145dcf1d94628ca3658b092f0db4e8b271e88e96b9b3206edd357292a2043e3e504e355
-# Tag = 7652dedded3ff10c
-#
-# AAD = df70019223b445
-# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
-# Ciphertext = 9c8b1e71d5a7554a530d76abed2ec5436133218a8221ee60a069fef9dfac4837f404fc1f1159417889cb3dc437
-# Tag = ca68b24cae556ff70f57f0e9d1aa53d5
-#
-# AAD = e778099a2bbc4d
-# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
-# Ciphertext = 1472188ebab2d275f5ac05c4c32fa5a0138234f89b431c6ec162c9002e39c4964a16df7ae56a0ba82d93cb9884
-# Tag = c8a6067affe7bd12bdd519a5e9800f0082425e5dad11997a
-#
-# AAD = ef8011a233c455
-# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
-# Ciphertext = ea140108fe42bf79cbc9fc64ff368cbba04cb8086ed7749cc192e294f1acd893b6057bbf61b5e5a0af3b3113c4
-# Tag = 9b87e885eee374166d34dab4efb0752dc36aeef25e6f55f3256c6a1ccfca0c33
-#
-# AAD = 54e576079829ba4bdc6dfe8f20b142d3
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 5ced7e0fa031c253e475069728b94adb
-# Plaintext =
-# Ciphertext =
-# Tag = 78e185a427aa5c4b
-#
-# AAD = 64f58617a839ca5bec7d0e9f30c152e3
-# Plaintext =
-# Ciphertext =
-# Tag = d97d28d5480f8517d2ca8231c272d30b
-#
-# AAD = 6cfd8e1fb041d263f48516a738c95aeb
-# Plaintext =
-# Ciphertext =
-# Tag = ef3d2178003bd945296db5373c97d2d4f5d3e791f9938d61
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3
-# Plaintext =
-# Ciphertext =
-# Tag = c2109612c8f59cde3efec1ee35e838451442227db9987b8b3490336cc2d38ae0
-#
-# AAD = 6f009122b344d566f78819aa3bcc5dee
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
-# Ciphertext = ba4b172d283be1dc213a677fd3cef7cf037da33602976431afab98
-# Tag =
-#
-# AAD = 7708992abb4cdd6eff9021b243d465f6
-# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
-# Ciphertext = 32cacbba8fe93c876e246ef2c77b3c170cef0cacd1fd34a9c0e109
-# Tag = a8a97bf98213581a
-#
-# AAD = 7f10a132c354e576079829ba4bdc6dfe
-# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
-# Ciphertext = 9bda8fbe8b655b532324f2af5639a4da595aa4b3726d3ddb557ac5
-# Tag = 4a2bdfb3c303134542ec4d3329b60667
-#
-# AAD = 8718a93acb5ced7e0fa031c253e47506
-# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
-# Ciphertext = fa8f743130153af92f82ff330202903fc9d3001b25f229accf31dd
-# Tag = e294bd382afc4fc2f7fb5f8dc5454b8ed3161eaf904cf370
-#
-# AAD = 8f20b142d364f58617a839ca5bec7d0e
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
-# Ciphertext = a1ef2836a5eceb2a5b3d5f03d0313b31d14154e0642a3e986d7c37
-# Tag = a45d2f551a838ad93eb9f02e99356a9d8ab99123b9506e992ce392b3017ec209
-#
-# AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
-# Plaintext =
-# Ciphertext =
-# Tag = 3829f81492e158cd
-#
-# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
-# Plaintext =
-# Ciphertext =
-# Tag = edd1afe90988348617acabbcebe995be
-#
-# AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
-# Plaintext =
-# Ciphertext =
-# Tag = c6586d0191aba33c64de99c658a481cbaf3be98e72e1327e
-#
-# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
-# Plaintext =
-# Ciphertext =
-# Tag = 2f23568e1d513a7de4a7bf63101dcde3ecd84ee49d93740971a5e2b221fabba4
-#
-# AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
-# Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
-# Ciphertext = db5644acb7482cc41880121bae45fb51b3f2d65f1e1a7ff36c1882be88a5710383addea69e7a9e
-# Tag =
-#
-# AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
-# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
-# Ciphertext = 8a116781f063ec62de53f2f871db22625e6617ea8e49a2501b3d58f62a26a4616d216cc08f9b6f
-# Tag = 93a65e16230a5fcc
-#
-# AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
-# Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
-# Ciphertext = 3f4217c53ef9ae72010e5850708c5435f512be53592e2a75ddcb740e13d1f79acab62f61447c39
-# Tag = 7935c9b4b0ce34403ed2b71e68471651
-#
-# AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
-# Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
-# Ciphertext = 1680c5d1a435ffddbdfee930671c2f4f795e7976b535de762cb9e81837d93fe4a8ff54723aacdb
-# Tag = a7f57679beb465aa7e2664ed1d6121b7de2cbbc04a8a20e4
-#
-# AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
-# Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
-# Ciphertext = 4d50207e294ecef0e2297d32f1f52cdf51adf242708e102b395566cea5e88d511199570d3d5f21
-# Tag = c2a29af7af5e26e3d5174f3baca706ac52998488eb3686bad515707671e21064
-#
-# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
-# Plaintext =
-# Ciphertext =
-# Tag = 7d9f2411cc6470a5
-#
-# AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
-# Plaintext =
-# Ciphertext =
-# Tag = 69c595b5161d1c01c429e402cefde72b
-#
-# AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
-# Plaintext =
-# Ciphertext =
-# Tag = 8bea3967c172b80269d1a20d1765f68cd2ac0866a4ed5e4f
-#
-# AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
-# Plaintext =
-# Ciphertext =
-# Tag = 4b9c3fe2fe4e1da6d7c609c5e5baa0eb17d2fcc2693125518da0673b08433b08
-#
-# # initialize with key of 128 bits, nonce of 576 bits:
-# Key = 7a13ac45de7710a942db740da63fd871
-# Nonce = c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 1d1cc6fd62c7eaed
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 64d9a3b5b3a2c70de7a1be4883eea935
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = ff4d9ffc5134b5312fc6b1ab51d1419498a23ab30e9756d9
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = f87dc6fd2332628c39769f259b597ad74ed7d0063e36dbd180660bd8e07f6b98
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = f88f5730ca
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = e3a7d0398c
-# Tag = cd33c07edb22bfa8
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = ffaa76d3b4
-# Tag = 4e8ed9f8558b1b601875beef864dba5a
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 7b435a8251
-# Tag = fcb8bfa5453300d4e64f1403ddd97be699272fbaf19f881c
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = d57e780867
-# Tag = e73166263e5f9b7c95c3d472e31fd31a6b2ad397e38e68214ef7b4229bd6bd93
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 1f62118cd1e59bdb0c59686a
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 6d7c7eff2ee805f33dd0493a
-# Tag = ed24ef9f792bbd40
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = db1356f596cd85a42daf1ec5
-# Tag = 9679967c6afe6f87bcc0d8e095b2e8a8
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 4e19a5ee9e59b7c5f2a1f968
-# Tag = cf38955f445a63d9694a3c06444f5205982b0ba364dbdf47
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = d71807db6faef5ffedb28c41
-# Tag = 53c1e29d9a503fb3d3f75892995ae059f77d1209b7d0514cad4a8e26f000e408
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 2ef0bd4dc2cf0d921147eab0f7b51a34a6d66637e5c668
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 97597a47a1e842fa9d69f4bbd8bb8712ce39673fd42e0b
-# Tag = ffd26f78fac38d42
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 307bcade071efc9221f2f5912be2b873382889fd6b2567
-# Tag = 69102a8b42571dd546b382571fa084be
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 2f04ad5c3f9f925d81e4c44b2015cd5cf463c385401db0
-# Tag = 3f1967bfccb97415d00d74b8d4db1d0141c66238f4a32b66
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = ba079a481d7eea617df29f9efaaab7a774080f8ec2d193
-# Tag = 2a2410638232cd139fe919e37c9ce64dce266c096dd410be1b61a4de9b7404b6
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 9174cb244933bc2f09c50412b2a6403f572db35457b012e32f858d189d71579e9f14c68dd93eca
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 457d27b7feb85c63d953aafe4a26faac5ed9e02534d91432aec7924b68f9f1406cad86f5a55942
-# Tag = 77d43d83c3cec12a
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = 3b522d5e6e4dbb90eaf76bbd9a6b276743e77cbb38b6d0fe5a2b3d10d91b22d2df5c91fba84fd5
-# Tag = a148fc8faf3a51594872e565c68489ef
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = ea725d8b7958cbfc658158e8ede8535a359607cf79ceebac60701d07a9f37cbad6d8f7bc20c8c9
-# Tag = af0978d87a378b66aef36e3c9f94c326685e07ea759dd3df
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 1e4a9f9b7cc538553bd42dd7042882c7eeff4699507fb14567bfd35018c327f498bbaa27aef99a
-# Tag = 28d977d8654bb12da4d74a6dd4eb8bdb0d3b6d6c8c10ee931e7ff60308b63ad1
-#
-# AAD = a233c455e67708
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = aa3bcc5dee7f10
-# Plaintext =
-# Ciphertext =
-# Tag = f90c87de0d543d40
-#
-# AAD = b243d465f68718
-# Plaintext =
-# Ciphertext =
-# Tag = 17ddd9745b5fd571a81638e582894076
-#
-# AAD = ba4bdc6dfe8f20
-# Plaintext =
-# Ciphertext =
-# Tag = a0c0978081ec69074c9086d3d87640c8a5986d3d27c38ac8
-#
-# AAD = c253e475069728
-# Plaintext =
-# Ciphertext =
-# Tag = c2d42fb8e84f792d874877fb83f5c132be41c3c22205b09100c8108f2e43d343
-#
-# AAD = b445d667f8891a
-# Plaintext = b0d15172f21393b43455d5f676971738b8d9
-# Ciphertext = f80e74e87750e238b94bde879698b2187270
-# Tag =
-#
-# AAD = bc4dde6f009122
-# Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
-# Ciphertext = 14ef2cffee0f16f29aac6668815503142001
-# Tag = 9eaf6899776974db
-#
-# AAD = c455e67708992a
-# Plaintext = c0e161820223a3c44465e50686a72748c8e9
-# Ciphertext = bad8ef823b389b44b9c00f7a29adde71bb10
-# Tag = 0fcca02b00a7671b7cb7e215d595af1e
-#
-# AAD = cc5dee7f10a132
-# Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
-# Ciphertext = f2eaa464d4f30695c528841c6c9d90beb027
-# Tag = a5b5dc3353b7243a95a80760f67b519c996a2a4f22e04b8c
-#
-# AAD = d465f68718a93a
-# Plaintext = d0f171921233b3d45475f51696b73758d8f9
-# Ciphertext = c2b40b6f60f63091541b3c8d855cac85f684
-# Tag = cb6b8bf587e74dd5354b064b78229a73b09fa6c68c17c4ae6c371239db3b4a72
-#
-# AAD = cf60f18213a435
-# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
-# Ciphertext = 34f4510460b498153c453625197c2c6be661a5034ece280d9aa86396c8232c90f96b3ec0a22362e498cdc6fee6
-# Tag =
-#
-# AAD = d768f98a1bac3d
-# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
-# Ciphertext = 33a8de7a8986ed342752ce638403fee65e14bdc8f7b9aba78316d4af0c9f571002b5d422db517a0af27431ca33
-# Tag = 07700ed8f4eb9055
-#
-# AAD = df70019223b445
-# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
-# Ciphertext = c68524d72f9a6014045b7d7daa72d79b20e1070d0873b124212e2a475d0acfc209c78006814ce10f6ee218d1a5
-# Tag = 76cd628cfce6c2b5fb97205371f61ad3
-#
-# AAD = e778099a2bbc4d
-# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
-# Ciphertext = a5b0d7b338682ea60557633c3c13cae60a86fd596043aabbfb14701eb630a7df965fba08cbeda8a549dd4b124e
-# Tag = 867527bc34f52ae0c13ba9a10656cf4cf8c67288c80a8f18
-#
-# AAD = ef8011a233c455
-# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
-# Ciphertext = 79d558204fd131936d04e273b9e73c0c9e5b9a972dfe5af25355e3e4ceef5b380a6c98a9764e95264b437f6c7e
-# Tag = 928659327a01f659bfa0261e7d95247b42c2708e6fd838cd1fb8812c7dbb93d1
-#
-# AAD = 54e576079829ba4bdc6dfe8f20b142d3
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 5ced7e0fa031c253e475069728b94adb
-# Plaintext =
-# Ciphertext =
-# Tag = 00a2ebcdfd191fb8
-#
-# AAD = 64f58617a839ca5bec7d0e9f30c152e3
-# Plaintext =
-# Ciphertext =
-# Tag = 9723758f610ae3d063f73f3d79e1dc4a
-#
-# AAD = 6cfd8e1fb041d263f48516a738c95aeb
-# Plaintext =
-# Ciphertext =
-# Tag = 53f8af4a900697c65fa5e3a4b8e78420d5ad85f2c0c33bfa
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3
-# Plaintext =
-# Ciphertext =
-# Tag = c9fb6ac839933498cb593a1c1b9bd6c46f47d23187b1236346a3aedc94316a8e
-#
-# AAD = 6f009122b344d566f78819aa3bcc5dee
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
-# Ciphertext = bbe038028e324873131513f4aa886462c3a55cc1ceffa0eb5f1bbd
-# Tag =
-#
-# AAD = 7708992abb4cdd6eff9021b243d465f6
-# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
-# Ciphertext = b3b42c2f0dcbfa9f9f3f3c8852304dde32558cac7386a3cf644a0b
-# Tag = 2a5d1dd723d76bb4
-#
-# AAD = 7f10a132c354e576079829ba4bdc6dfe
-# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
-# Ciphertext = d6e59078153e2ba5a30f1f2f9df8e167b4c175baa32ce56612043b
-# Tag = c0194d6d410196244d648bb7d804d607
-#
-# AAD = 8718a93acb5ced7e0fa031c253e47506
-# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
-# Ciphertext = ae465a34df4ab0b31a4984aedc06f66edd479aabadf5a3ef781016
-# Tag = 3b6ed456110dfad12f7206effc3cf1358bbf7ee3c830aa80
-#
-# AAD = 8f20b142d364f58617a839ca5bec7d0e
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
-# Ciphertext = f06a7c85ac848f04201e17204854d2bd640b61b24fbb77e0e533c8
-# Tag = b976315e97c909c01dbd9c2303d64403d9f8f797ca5bd19d40d7fec0d44662f4
-#
-# AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
-# Plaintext =
-# Ciphertext =
-# Tag = 0bc91e932c45edd5
-#
-# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
-# Plaintext =
-# Ciphertext =
-# Tag = 0f2b51d9844b2ed7b6f590b8d5f502d3
-#
-# AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
-# Plaintext =
-# Ciphertext =
-# Tag = 939a3b8e4c16ca5b1cbc33957c304f47c11cdf21857ae2de
-#
-# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
-# Plaintext =
-# Ciphertext =
-# Tag = 89e4c348638fc0965961a3c3eda499de18f9cae991bb544cf5876e8d9ed12ba1
-#
-# AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
-# Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
-# Ciphertext = e92fe469af09d257301e93c2238911776c893d8f489ea132576b97a626fb3b048b04ba7a0315fe
-# Tag =
-#
-# AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
-# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
-# Ciphertext = ceea2417e251da8e541678bb182202829c82aa512c346d2b2165279d2174180543fe86fcc82eca
-# Tag = adcfc2487722e85c
-#
-# AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
-# Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
-# Ciphertext = b0273d1e48d8a1d103a5e171ead75d2c54697a564b46a0c138c0d71d46280d7b6e615746d149dd
-# Tag = 0d46608f7480bb40b2fe8a014e994754
-#
-# AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
-# Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
-# Ciphertext = dd3c259c99122913a8d840ce484487873eefbab4549ab6a9063e26ce2b8b87b1c92f3ebf25e562
-# Tag = 6a4368b5e4f36d3c76630cfee14ed4b661dbfb5f7e83dcda
-#
-# AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
-# Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
-# Ciphertext = 807f10a7d69d537598dd2d8b3ca82a428143fe5cbfa4221a4a761d18d95bf1671c2407715e3858
-# Tag = e47a2e652112fc2e24a05df85b38a59ed5324a3cad95f545f6a08acf1430f20b
-#
-# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
-# Plaintext =
-# Ciphertext =
-# Tag = b9039ac45e59cc6c
-#
-# AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
-# Plaintext =
-# Ciphertext =
-# Tag = 49967e25a36daff826cc4d1fa65819a8
-#
-# AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
-# Plaintext =
-# Ciphertext =
-# Tag = d76227b5947ffa4a32681f907d9e35f3db043a0626c9d1d8
-#
-# AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
-# Plaintext =
-# Ciphertext =
-# Tag = 7a7bedab5b97491926d9e2e431a24be84863bbab368a3f72a59c8cb6104938ad
-#
-# # initialize with key of 128 bits, nonce of 640 bits:
-# Key = 821bb44de67f18b14ae37c15ae47e079
-# Nonce = d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2beb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d9eff602081e2430364c526e647a809c92a8becac0d6ecf
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = c9b14deb7210854b
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 4418f5c95ac6ac3a16244705ddd0cfc6
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 52d024b501d6de0eb9073906f913fc59e6c9efd4ffbe3c5a
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = afd68d0db1c19969e11af020720f40046a543fae0c20367140a0f9f530498fd9
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 9f527652c9
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 109dc06045
-# Tag = b8268fbd7d84c451
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 807dd2a69e
-# Tag = 885254742822c9587803fc1ccaa4e2f8
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 08245d6a04
-# Tag = 6e36c5e3d109e05adb7abd82ed66e58d11ced695f1fef392
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = e638f11fda
-# Tag = 3162d25b1a549628d55aa00b58817a1e27ec6ad5b5f4790ea9019bcb091c8195
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 3bcc58bd1d27674aa349933d
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = abcaa3ab35cf533965adf6af
-# Tag = ccd56641984bf845
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 6ff7906e752f7cca92c0b602
-# Tag = ab71b502e59b3db482a6efe3c89e8224
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = b43d2d23820f5debcbb8c3a8
-# Tag = 872338634528b8b5a03f0d3c47c18a58a10feb32b4e7a525
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = dafd906ac47f129713647493
-# Tag = f1565eaaaba8891af7a68f6fa1307887648ca7cd9358c95393a15c28d9c7c85c
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 149a0721a3eb46d7fe1d9a38d50a741f69478902fa3cc9
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 55d51d2f173afbfaf62539cce15d874a5c428ece3050ac
-# Tag = 5a96c688d1e692e8
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 85d32004535aa4d595f4659128359ec313054d078b238f
-# Tag = d812a331c9a8e23fe160c57d087c17be
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = d32bed8926ca9ae7a490c20927ef925b49c6eb3676db3e
-# Tag = 826642fbf26dd76f0ca5ad2d0ad5a830eca50726f2834943
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = 71eba47090e3cd484dd172feddea2b6ca6e4f36f4690fd
-# Tag = 6357c6f26d21ec8f2122a7685a2bb1d43920e173bd4aba6975dc9de7bc2d40ae
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = e73faab21a7a787bfe88843724aaea70baebc7682fbcf588460dd0c868d9282caf6f8404aa3124
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = e52c35e251cd3e40e20e48387dbaba964d02340d5a18c0fbfe02bcf92be6ec0cb656a5abe76ece
-# Tag = e8497d00b38893dd
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = c885e15513a1c4a644fbd62968041ec6dfd091e379bb938cf90b206be6b11e758d2c36c619f261
-# Tag = 8ea855f0707acc3f9536c5999d328b19
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = a6d79ad809c7e98215edb9b512f5222dd1dadf579a95c39b98349ad52a4cf0af238c670ffbeb9e
-# Tag = aa6f2cb55a1abd8e3da6449ff654428843a50c4113caedaa
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 99eedd546ce7b40b3679586f6f3a51eb3e7d7cc031ab1bd730244b4f0da8c1b2b05eef98d355ea
-# Tag = 408bf7d6f7376d593256a77e355727f5e712e26cd46f5b35ffe8291bc3b5056d
-#
-# AAD = a233c455e67708
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = aa3bcc5dee7f10
-# Plaintext =
-# Ciphertext =
-# Tag = c5e3601f70555194
-#
-# AAD = b243d465f68718
-# Plaintext =
-# Ciphertext =
-# Tag = 5681d2203ecd8817043b892b2cbcb936
-#
-# AAD = ba4bdc6dfe8f20
-# Plaintext =
-# Ciphertext =
-# Tag = f7d6e1fcfa8e255805f1910a732bd43cbfa06b1292c97d3d
-#
-# AAD = c253e475069728
-# Plaintext =
-# Ciphertext =
-# Tag = 31574046ebd65ded2ceddf0b0f29a993e906bbdc7add2907ab6038e8be3d93b2
-#
-# AAD = b445d667f8891a
-# Plaintext = b0d15172f21393b43455d5f676971738b8d9
-# Ciphertext = 60fb8939903545646a89f2332e8be6055ff7
-# Tag =
-#
-# AAD = bc4dde6f009122
-# Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
-# Ciphertext = b2b4cf0583362c5fec453c415c23a3232644
-# Tag = 95ce17ecad7a905f
-#
-# AAD = c455e67708992a
-# Plaintext = c0e161820223a3c44465e50686a72748c8e9
-# Ciphertext = 3d8af7230484c891dd35dc3d8254f3fbc35d
-# Tag = cf74293f44b72ada93c52aa31deb004a
-#
-# AAD = cc5dee7f10a132
-# Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
-# Ciphertext = 705d5dacc198312de028b6162c0bd7242703
-# Tag = 2e7fd009c84d02dc86518b49417e3425e2c95c92d35727e5
-#
-# AAD = d465f68718a93a
-# Plaintext = d0f171921233b3d45475f51696b73758d8f9
-# Ciphertext = a8f0a941c6e08c26c7eab75aa5183f944631
-# Tag = 181c0b882995b2ea5fdd5d53b7a753cca65e9a0ce50e8e10bfd6fec3d21839f6
-#
-# AAD = cf60f18213a435
-# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
-# Ciphertext = 528e3a35f4249b7de29d8894d6b3cd07c7af5048d55c548a97a789e41db0043335413ea3840369f623c8bc99c5
-# Tag =
-#
-# AAD = d768f98a1bac3d
-# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
-# Ciphertext = 2f8f49fd8dbfa2fbaa4655f3cb9ffc55b8635a9b5d1d1cf4a19e1898db76f08d44b2df5e8fc1c61c462a15b731
-# Tag = ee49265028af20b3
-#
-# AAD = df70019223b445
-# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
-# Ciphertext = b0503f549a781e4a29d64c910a8b3e18a046399faeb33543f4da10ac26f6514e1ebce49c3cc8695f7ddd6f5976
-# Tag = 62b1af8b77164e92e215c73a766ec468
-#
-# AAD = e778099a2bbc4d
-# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
-# Ciphertext = e14a75ee5b24b51e13143dc678c18b9ceab72f8c9416e50653f3759c473ffb2f2bbc45ffe005a10dc1adfedb1e
-# Tag = d6095aabf3803d8cb91b55cf20196737e92c8f86c1319fc1
-#
-# AAD = ef8011a233c455
-# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
-# Ciphertext = c51853146b416c2873965404bf3b509c0aaa857749d7362b0109850642699e4226053788581868eec0b1c58ebf
-# Tag = 30f3314091eba609d7dfaffa370e2e32f5a53f064e10d6510707466444ed9f06
-#
-# AAD = 54e576079829ba4bdc6dfe8f20b142d3
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 5ced7e0fa031c253e475069728b94adb
-# Plaintext =
-# Ciphertext =
-# Tag = 137d652dee2b3890
-#
-# AAD = 64f58617a839ca5bec7d0e9f30c152e3
-# Plaintext =
-# Ciphertext =
-# Tag = 252f1a3033311f6c7c2169a87fcf6d60
-#
-# AAD = 6cfd8e1fb041d263f48516a738c95aeb
-# Plaintext =
-# Ciphertext =
-# Tag = 572a2bd5ff12ae5387721a6142a4ffe2f91a1e330d80ec2f
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3
-# Plaintext =
-# Ciphertext =
-# Tag = 98eac818e123e7ffcfdc76a6ab46a3a5121aff12b917014262056c2376e31e48
-#
-# AAD = 6f009122b344d566f78819aa3bcc5dee
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
-# Ciphertext = 2f9170d1bc1ebb38220790a741c3ca3a62e514f861dd407807bb72
-# Tag =
-#
-# AAD = 7708992abb4cdd6eff9021b243d465f6
-# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
-# Ciphertext = 29e5dcfeeb6b2b18393ab1630c461abe7e63f98cdd1fce05952526
-# Tag = 8e013ec9a218ba07
-#
-# AAD = 7f10a132c354e576079829ba4bdc6dfe
-# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
-# Ciphertext = 69dda85a6eac0e36c4d2639a37f2fddb0fd158fc2b4272f9beb313
-# Tag = 7d186118c662ae7a4700fb1c56a8d13d
-#
-# AAD = 8718a93acb5ced7e0fa031c253e47506
-# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
-# Ciphertext = ef052db258506a93b6cc9ac99dc456a00a122d196391b001bb1af2
-# Tag = 14bc2f070bef543d6fab1ae82cfc96257386c303c97f8794
-#
-# AAD = 8f20b142d364f58617a839ca5bec7d0e
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
-# Ciphertext = e7fb119c6e51cc3675e6599259e9aea6f6bed2123086f35d2b1796
-# Tag = 48f54e4a89d2597c58e4b0528cc9e27d1f2c2912803fc85cfdd211bc40d18b5f
-#
-# AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
-# Plaintext =
-# Ciphertext =
-# Tag = 4177758b2c96a15d
-#
-# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
-# Plaintext =
-# Ciphertext =
-# Tag = 0106f4adffb2206e93cae6af52fb4f24
-#
-# AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
-# Plaintext =
-# Ciphertext =
-# Tag = 976132981df0a7c259ff62a8a9b13fd0b8d3c4cf86f19c11
-#
-# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
-# Plaintext =
-# Ciphertext =
-# Tag = e4219ef913039ff02f6e0672e24eaf85cb8c58dabe6ab8ad1862e7237f2641fc
-#
-# AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
-# Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
-# Ciphertext = 43068574ad814e660bcafd4e832efe1552d5eb090d5935704f8934ede3b1929612c9b134dcceb0
-# Tag =
-#
-# AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
-# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
-# Ciphertext = 60dd30ca650886ecda1252fba10d9dbca4dbb32f3b9a41b166a139f294c010520fd00ed054410f
-# Tag = b5620ff3561f2a13
-#
-# AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
-# Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
-# Ciphertext = e2e28c21e1064a5ef6478497988e8d1599b524a9a0f54e4647510dc69352f1765a2e2530239036
-# Tag = adcd89918c9c3c041461981f93ddabeb
-#
-# AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
-# Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
-# Ciphertext = ceb2341faea9958276c6b40180871dad7988f42c33a34767e65ebd336526efa3b346cc12574d05
-# Tag = bb0885e2959f513f1c2d158702560dda758676fb283a5e97
-#
-# AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
-# Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
-# Ciphertext = 2c05aac1e69aca316290c89e0574bdb448407895cfa81fadacc71fa059e6cc1842ae9b0f9e220d
-# Tag = 6afedec4d9a766c3363706ce055f08bca2f60bde083383e935f58b3dabf8aa66
-#
-# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
-# Plaintext =
-# Ciphertext =
-# Tag = 6e91e63feccc2bd1
-#
-# AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
-# Plaintext =
-# Ciphertext =
-# Tag = 7396f158fed2057ae76c7ce5a7f7174d
-#
-# AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
-# Plaintext =
-# Ciphertext =
-# Tag = 5fda1b4b38b662d2d3ad1fe4f29ac1c18dd68f7dd07dd100
-#
-# AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
-# Plaintext =
-# Ciphertext =
-# Tag = bbaee3d2412409fb7a02bc894962d041d3cd3b51c016ed60047ce3d90a9020a0
-#
-# # initialize with key of 128 bits, nonce of 704 bits:
-# Key = 8a23bc55ee8720b952eb841db64fe881
-# Nonce = e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da3bfb5cbd1ede3fa001c12283e4a40566c787e849aa6acb2c8d4dae0f703091f2531374d536f657b819d93a9bfcbc1d7edf9f0061c282e344a5
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 534cd0a431735501
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 53cbd422fd55c34ee32a8a4eb22487a6
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 1ed0b2c5549b3f64a74f8f6035cee2738e08cf6045cdaeb7
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 9b7135be2dfc49f443d3da0e4ea9f56390bd27c609e72e11ab49d11fd29e33b3
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 77ff879847
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 946cb16c6b
-# Tag = 2f0312a5a3efc44c
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = f7cfc2c756
-# Tag = 7233cc66b56478282a5e7eb5b73f4839
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = f408b47b8a
-# Tag = ed7c05f56147746ba72475daca6a2cd39720fbbdfcaad4d0
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = aca8ad7c9a
-# Tag = 5d37d98532f298aebe897ba2a6eac54f40706982fa1173a4d601b39cd286971a
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = fc8c32ca4cd340e2fd492a02
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = a23926c8356894079ba04f05
-# Tag = aaa0b7dd666a843f
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 9bbd39ed5673695debdf968c
-# Tag = 592894700f2beb726450375bcc8ec70f
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 285fc4f10cafb17710e1f920
-# Tag = 8f721021a532b7176b9ad65427bbfbf10997c8921dcf084a
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 55471f3a72834ba325561d94
-# Tag = 942476dfe4f0d4588eeee440801df51622b58ff5e6f8047ac301cd91698e768f
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 28b9011636b5f4958ac1cd3b92ffb554c526b8d7d20da2
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = dbbcbed166f56ae785e85e18197b3518b787cc4ef01917
-# Tag = a9adaed644ad8300
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 5b7800a0b402d5c0c4428719537be9503941121f239f57
-# Tag = 3c5e16a5078a4bda7eb7e7d4c7ae1d4e
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 651aa0196d9ceb173144682ceeab55551517e199d90705
-# Tag = 80f701f0d6d1c7361239859012a4af810352c110032eb9af
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = bec349401bedd3c1f18f75679c7a59c9c8c8138efc1a89
-# Tag = 074c3426f6855b27798d174bbdef6d98b8c6abea86804a052b457a5b3c38b0ac
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 8558033b63d6c6781ea0da1f3bec1d7dbd75882bbe6d7edb017be04120a9db103543ae55946e8d
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 2b1d01629db1b79107369ad9d130ce0b649cf9148fa4756bc388f0fda263b3ab39c2035a0eb766
-# Tag = f4daf0457710b339
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = 1ebfc7abf4320134d5a7caff805e25bf60b9d325aaa8995772d6d35b64a7ae3a6ec620a7d368ad
-# Tag = ebb1cca3b3d5bfd14d07b8b4b42b75f5
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 96d717cd82b6312a9f0879d224e18cc607c36135198a53479e51b47944157b8f6951a3f0d68d55
-# Tag = 3b20187e3307403e882d8ad25c844f85a31ddf01f8c5b67e
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 25e657a43a0064639f38a87d3dff3106dd3ae15ac31bffe8f2562aa43dc1a20e201d1101c778e7
-# Tag = 6b81c7c7d7446d8e320c8ebd9c1d807ad6c86c1f418007a02d9682c72c3a730b
-#
-# AAD = a233c455e67708
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = aa3bcc5dee7f10
-# Plaintext =
-# Ciphertext =
-# Tag = 48b28fb07f73257a
-#
-# AAD = b243d465f68718
-# Plaintext =
-# Ciphertext =
-# Tag = 01552079c0126f43883a04d56c5f4608
-#
-# AAD = ba4bdc6dfe8f20
-# Plaintext =
-# Ciphertext =
-# Tag = 11606b58521a06880bb3aebb1bf993b1fcbb789b47bdc835
-#
-# AAD = c253e475069728
-# Plaintext =
-# Ciphertext =
-# Tag = 1ba35ffeb9f81053ea9d588e680a6c859d411c24c905bdf4ad23c5f2da409dbb
-#
-# AAD = b445d667f8891a
-# Plaintext = b0d15172f21393b43455d5f676971738b8d9
-# Ciphertext = 22e04fb197058dacab29f25383a8cd73d5e6
-# Tag =
-#
-# AAD = bc4dde6f009122
-# Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
-# Ciphertext = af1080469382333ec831ff93cf025774d642
-# Tag = dd62fb616a47d366
-#
-# AAD = c455e67708992a
-# Plaintext = c0e161820223a3c44465e50686a72748c8e9
-# Ciphertext = 5221c8807bffbf9ca501516fcc619931497b
-# Tag = 46a00541e4bc2a96978833f853b3aefb
-#
-# AAD = cc5dee7f10a132
-# Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
-# Ciphertext = 27e083c554288379b7e67036d265619d2dfe
-# Tag = 4e4528bc1c84405967c57d98a57001bfe05e66b8ef5ff9af
-#
-# AAD = d465f68718a93a
-# Plaintext = d0f171921233b3d45475f51696b73758d8f9
-# Ciphertext = d4bd94ae157ae498e07ee85e241a6e324d68
-# Tag = 641c18defcca6aec5f7c18907bd99b5834e77f0f76a7ca770d2b698918f9a85c
-#
-# AAD = cf60f18213a435
-# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
-# Ciphertext = d4346d0114eea95d0518ed851acf70fbb85654d207a2ed5dda94586db55172455dedc4b2b3f8d06b8abd73a8d6
-# Tag =
-#
-# AAD = d768f98a1bac3d
-# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
-# Ciphertext = b68f350c0082dd859d0358ce0aeb2f08172579d2ff701c51ea9ba12723ec3b19d8715dfedd392e464921a6fef3
-# Tag = 3e2225025f50f0fb
-#
-# AAD = df70019223b445
-# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
-# Ciphertext = a2106a71b6fb28914a4e706f577c837a07f053694a9546e0ac02075cbd0e9d6976f217e2bdfb83673081403e9d
-# Tag = 926c8bccf757eb1fef8531660478de69
-#
-# AAD = e778099a2bbc4d
-# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
-# Ciphertext = 71a784f2cddd2bcdeff53b4b1166c1fea1d805177b66a109e74df8b95eee5577bf0740c868ffb61d7fc92206d3
-# Tag = da8e645646f083d20f4577e2e151b2b1d399cea95ac04b93
-#
-# AAD = ef8011a233c455
-# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
-# Ciphertext = b2a62822d837e8e4ca21a4ff770abeef3804ec7bec68637bcb3bac4ddfcb2ce06f0542f328963372a717cd2ef2
-# Tag = c124a16deac6543ca980db251487b4dc4da5486f712bf7a18fc5fdea423b4a58
-#
-# AAD = 54e576079829ba4bdc6dfe8f20b142d3
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 5ced7e0fa031c253e475069728b94adb
-# Plaintext =
-# Ciphertext =
-# Tag = fa8afe5e1c671936
-#
-# AAD = 64f58617a839ca5bec7d0e9f30c152e3
-# Plaintext =
-# Ciphertext =
-# Tag = 6d38fef0f13f1f2746c78104bb8740b2
-#
-# AAD = 6cfd8e1fb041d263f48516a738c95aeb
-# Plaintext =
-# Ciphertext =
-# Tag = a0709994c90c33c66a226eaff4198473db2e5fc774ea7ad1
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3
-# Plaintext =
-# Ciphertext =
-# Tag = c716d647e6929e8b59eb44c356bdcad3652083c4d888b184cad21b1f2eb7761e
-#
-# AAD = 6f009122b344d566f78819aa3bcc5dee
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
-# Ciphertext = e4e907850afa2e02f3b70476d762cdfdfa39681aedd373331ad762
-# Tag =
-#
-# AAD = 7708992abb4cdd6eff9021b243d465f6
-# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
-# Ciphertext = f90670cd80216596424ada1d38a8d5aa5663e66c2b85692dd1d01c
-# Tag = a883aaff925387c4
-#
-# AAD = 7f10a132c354e576079829ba4bdc6dfe
-# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
-# Ciphertext = 62b18341977bec6c409604ca2c3c04a7d50e146864639fba6b7053
-# Tag = 7de0ded769b5ec6347b186146430931e
-#
-# AAD = 8718a93acb5ced7e0fa031c253e47506
-# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
-# Ciphertext = 227efbbdfe1fb41c97b91fc76e752559d3fd2910a5e05cba073cc5
-# Tag = f52ea0a597e16500ba4bec37e57b34dd50739df84dd0e7a0
-#
-# AAD = 8f20b142d364f58617a839ca5bec7d0e
-# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
-# Ciphertext = b796d09658de20fdcad2b43c679c24bbc2224655150ed670748f1f
-# Tag = 08280257c4401f07daf5c423cee144df5ee398991d1745242521457e49da66a2
-#
-# AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
-# Plaintext =
-# Ciphertext =
-# Tag = d4bc9fdd1de9550b
-#
-# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
-# Plaintext =
-# Ciphertext =
-# Tag = 37c1db7477587c88f5b00eb96a6994b0
-#
-# AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
-# Plaintext =
-# Ciphertext =
-# Tag = 4084671b700efdf3f543de5a994185581384f37e5fa25efe
-#
-# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
-# Plaintext =
-# Ciphertext =
-# Tag = 6c557930eb46c4a57eea09e05d9740b7237f9bebb236bcc0845a824758645d0d
-#
-# AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
-# Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
-# Ciphertext = 91803cef593dd5bc83eac04a256d031c85955fd1359d40b257c1017e766431b8bccb49c8abe288
-# Tag =
-#
-# AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
-# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
-# Ciphertext = 703939868321a0bbe37a6b38c355307727dd4d6a280daeedd595cc14514a0c070e1ae5d0511bea
-# Tag = 9243b0e1de1fc542
-#
-# AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
-# Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
-# Ciphertext = d7b68b5dfed8bf0558d3ae70ff1962c956e359dd3b9bff9344840ee5e7090dc9aa096744a5435e
-# Tag = 3dde51abd657710fb1339672b757eedc
-#
-# AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
-# Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
-# Ciphertext = 7ce32f34015faa206644e4cf8601c67fb5d7a12bf2551607a98b204ee16c50d4ae487b7611a1eb
-# Tag = e630e260300b0f4d6844de8a9880a4c8c7b15771fc833de3
-#
-# AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
-# Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
-# Ciphertext = 3b3754b7dcd8e31130ce7150a551ac5a8b1baa4bee134fcf59a2850b0111ad3bea4153f72b5a29
-# Tag = 21f7ae500494ace6f9d050e337704db7255943ef902da5c140c5345f46bfd9da
-#
-# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
-# Plaintext =
-# Ciphertext =
-# Tag = 9a561ea80a3c0290
-#
-# AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
-# Plaintext =
-# Ciphertext =
-# Tag = 1a6774cfb3ca2fb0306bc86a5204d734
-#
-# AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
-# Plaintext =
-# Ciphertext =
-# Tag = 914f4d81596d69b66002c4efe55bbe5669058efa1793da19
-#
-# AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
-# Plaintext =
-# Ciphertext =
-# Tag = 41ee138ce6803aa4dc9fb83248e3d0abae6e390673bf7fd2e8fcfeafd709388c
-#
-# # initialize with key of 128 bits, nonce of 768 bits:
-# Key = 922bc45df68f28c15af38c25be57f089
-# Nonce = f354b516d63798f9b91a7bdc9cfd5ebf7fe041a262c3248545a607682889ea4b0b6ccd2eee4fb011d13293f4b41576d797f859ba7adb3c9d5dbe1f8040a102632384e5460667c829e94aab0ccc2d8eefaf1071d292f354b575d6379858b91a7b
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 257090f77c284721
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = ae4182f0ae6103790cb070ed89d8b6ab
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 61a17f87158587fc9d9636be02a564aa7ea310bd86398fda
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 649cacf048be9188800feef25f67938ca7cf863fb9ed7a82a358bb8490323f22
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 7f64c78f4d
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = e390ecf887
-# Tag = 92223d8412a9c5f1
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 60367f1974
-# Tag = 21242d3a33923517ed487da47f50bd7d
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 435ea8c725
-# Tag = 2fec061d9d160fcc4978d7d865d0dc221711e61d7f9cc32c
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = f7eca14a65
-# Tag = 59418e8009259740db63a999f8d5514249075ae6c4efe4f97eea73eb30c1c6aa
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 32dfd0771d966277171684c2
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 0adf98a1870658a9baf0f7b6
-# Tag = d3d4b74316b6b7c7
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 9f0277d612635cb319aaf319
-# Tag = 44098061b86fbd8724f7078d8906267d
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 49b641289558a2d285cf3a9f
-# Tag = 6e7fb1e8a588b36356de6abfd552f87b814255a874b34c01
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = c45bfad0f25f5743050cbd56
-# Tag = 255c746ba88784bb0f4e430a982e6a801bef1d147ef2d981203e634105dcf3d1
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 0f1aee7616b9ba6a5fd73c0614f211baabffe69abfc17d
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 1243dc105852ba4939d5d077dba6988fb8e81f1a299042
-# Tag = 42847fcf7aad5563
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = cf46073fe38d3f85feb11bee5f9ae4146ff6945ef82059
-# Tag = 247606c9fa41b36e5d1b35dbc441faed
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 2e48b18f7d21b3ce5239cc6a8508fbb07febd6716a48c3
-# Tag = da76a61b9a209edbcf89dde0eb07233cdf72c770db7440d0
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = d218f5628a7e645ff6efd7d0e85c2c330c55a74427b509
-# Tag = 8a68c502a1042c88e9fe4727f4dcc2d385166104fe60f4d0def8b6a587e1f14f
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 1f45e463a640a6a0e2c6b0cf90795f05fd36537c69e36ace6c24515f7c42d56e4d284d72b3f347
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 222dae017d51212bd081b220b4ba4e313aa65d5417a5d1060464ea1dcce34157a023cb338c259a
-# Tag = eca4688b8637d88a
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = 77b551a03c8800a3c47d183db7820d3138f35e8d90503ea98d9097145ef1520c925f20dc5a76bf
-# Tag = 0ea7f02c84cc13b0addcf20b42a015c0
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = f1bed7f09b521c2dbf09620bd36374698fe7b71755962eef3d60f8f52c8c1879cb8fb1ae68fab7
-# Tag = 9b8f23688791c3e3413e7fa9b9188abab8cfbce456fbfb8e
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = dc87bc8ec601d2af568e8860115c33edaca2c170b19a7d98f131196767796892635224cb4acdab
-# Tag = 3f4c02431bbce6d6c216401ff2727c91ccaa8eb308e42a1dc39eee4a0ca56370
-#
-# AAD = 44d566f78819aa3b
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 4cdd6eff9021b243
-# Plaintext =
-# Ciphertext =
-# Tag = f5a8094c723476f5
-#
-# AAD = 54e576079829ba4b
-# Plaintext =
-# Ciphertext =
-# Tag = f95dd7da308d5690f7cb9b869bbe54f4
-#
-# AAD = 5ced7e0fa031c253
-# Plaintext =
-# Ciphertext =
-# Tag = a473d14f917b577964205c9b804db1e270a2f74fa8eb2f1c
-#
-# AAD = 64f58617a839ca5b
-# Plaintext =
-# Ciphertext =
-# Tag = cca440f6d035c6cf273c8cfe00031cf8a5fcafc563e9ea984b78c9dcc787c2cd
-#
-# AAD = 58e97a0b9c2dbe4f
-# Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
-# Ciphertext = 94c61a477cae6bb988adb58bc54c0bcbcd207fc4
-# Tag =
-#
-# AAD = 60f18213a435c657
-# Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
-# Ciphertext = c1d8e53f19720cc4070bf1a08bce88e2c9309233
-# Tag = 9d841625faad2244
-#
-# AAD = 68f98a1bac3dce5f
-# Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
-# Ciphertext = 58ad1430735ebc990f9d1e9d7da8d8ce0e870717
-# Tag = cd7501206caafb399ff5653b1cebaa64
-#
-# AAD = 70019223b445d667
-# Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
-# Ciphertext = c7d4d94c7d51d8ae6c0062b49bae3c5ff9c2936f
-# Tag = cde54ef5f5f4fd1461a6bf8a1ae6cbb7d324ef62da9155aa
-#
-# AAD = 78099a2bbc4dde6f
-# Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
-# Ciphertext = f9ef6e5197ed99435d374abf12ca9e63a9db2362
-# Tag = 239e70b9de81c122baa7ec8d31221d3066c7699d61fd6fe08b708cd8ce02a288
-#
-# AAD = 76079829ba4bdc6d
-# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
-# Ciphertext = b7c713271bbe5051a0c1c99ab1b5abec05af1a6ebd8ccab79a23e1555fbb17588773764ee856096b1de168a4f6356a2f36ec
-# Tag =
-#
-# AAD = 7e0fa031c253e475
-# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
-# Ciphertext = 881f2e6eb36827225032996158df75ed7b11910e6c94d7f515482b92bbd29c28b51d89aade616c1fbe8c3dce318599e2cd8b
-# Tag = 6a311f6a94d3e9d6
-#
-# AAD = 8617a839ca5bec7d
-# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
-# Ciphertext = 26d8c2d3af698f01f6a2303c6ba19b73520f7d67b75541948ebb122ffc1e96b881dd9662d4315f5c89c0fd87db4308d636ff
-# Tag = 4c24ad19a0d9c1bfa56ef3593cbeca78
-#
-# AAD = 8e1fb041d263f485
-# Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
-# Ciphertext = c522468d5579b4da65e76d586534f9f5413394b465c76b2444bb52f8805b760126eeefd73539095777c9bb82cdc5cfffcc7a
-# Tag = 60e038d453325551b2aed60bb79b6238f5fbd6649fd132e7
-#
-# AAD = 9627b849da6bfc8d
-# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
-# Ciphertext = f0115819b3cb61f334e05f07ed71472f409f83d4420e11f64dfb5c395f492261c0cc6da0ece4482fff590357ae32da5a0a12
-# Tag = 0862b4e4df0618b347b0d92e700b07b63ea6b33ba9f4605219fc5f244ff58c71
-#
-# AAD = 9829ba4bdc6dfe8f20b142d364f586170798
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa0
-# Plaintext =
-# Ciphertext =
-# Tag = ea24ec1a2662524e
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a8
-# Plaintext =
-# Ciphertext =
-# Tag = d5aa8fcb4b47fad9f74894192d52ff42
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
-# Plaintext =
-# Ciphertext =
-# Tag = 624bcbe68351b128ddcdcf384065b6b3ddb75ae0c26e6d77
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b8
-# Plaintext =
-# Ciphertext =
-# Tag = 96607c892b3a15fda8b1e1d7ab78811beac62cfaeb6f59fc383a2a43f4c071d3
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b6
-# Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
-# Ciphertext = 6545148db611e243a9f41b6dbb8141d1b899c760c3862dac472d87e24ff6
-# Tag =
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe
-# Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
-# Ciphertext = f81d9117ba585443e156fa0d8ac7fa149ddee3ae3a9c2ad47319c8616c25
-# Tag = 4fbe7f26413c6566
-#
-# AAD = c657e8790a9b2cbd4edf70019223b44535c6
-# Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
-# Ciphertext = c255b9d727cb54ed034f889fb7fa710d9d187bf0c5ac3ca8c127269718fa
-# Tag = 1ca7ea5a292a3537db047f049d15921f
-#
-# AAD = ce5ff08112a334c556e778099a2bbc4d3dce
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
-# Ciphertext = 973d3eb7bc52ed3686c727d9adc6c02037b008422fd682bff1dd869d3e12
-# Tag = 7f3de5054fc77601c5dbd87abe2da5ad61620841c1a56b84
-#
-# AAD = d667f8891aab3ccd5eef8011a233c45545d6
-# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
-# Ciphertext = 02b7186d3933eae5a9cab9d7e2daf9e0d2b7046b2323d55130cd6471b720
-# Tag = b4ea6bbf1c6d025d0e08d8bd21b6bcd8ac65053733d98dc87c602bca89fbb34c
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
-# Plaintext =
-# Ciphertext =
-# Tag = a4c2b9a93517eb8c
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
-# Plaintext =
-# Ciphertext =
-# Tag = e0f0305c463829ac1721b596070a0f5e
-#
-# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
-# Plaintext =
-# Ciphertext =
-# Tag = 49c6a456f025add55f4a0e677f63283d7309905fdbe91bea
-#
-# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
-# Plaintext =
-# Ciphertext =
-# Tag = f624bf7756ac159585a97875bec41f371eaab26ebd6071077142a51f12add791
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
-# Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
-# Ciphertext = 22f39a03bd5ee90fda71c94fe22f79fb1f0e4f7df33111b84153ee20e185ca0c2164d08c7eaba108c2844e8d
-# Tag =
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
-# Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
-# Ciphertext = 83e008bd30d27d77699d6214a11e0823f321a3018d5f4b3056f27bf73716e63c2ba219238b815078fad77f86
-# Tag = db57d743b18b34f2
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
-# Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
-# Ciphertext = b6944ea67c13f2afa92515d7e09273aa910501d211ada0cecd50ad1212cfed0f1f45fb8d504d87f72a7bb7c4
-# Tag = 1cd0684de66d1e0998998812fba1ddf2
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
-# Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
-# Ciphertext = aeca5368ff55a0a97da1597902ac444dd53fdd2f74b600c5ab794a6ee8b2c0d33b3f06b849a9398f2910ed9d
-# Tag = 9b9d339431b60be22703aec6a7d292c8e2bf195745e22360
-#
-# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
-# Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
-# Ciphertext = 23055bcdca8fdc0451c5169d0188407a27705e37a9933773f56d30a82d04fb5f8c3067ff655d01330e9b65d1
-# Tag = f8bfdc4166741bd099aac315c35a385c6b379633309dad9d0639d09c86ee185c
-#
-# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
-# Plaintext =
-# Ciphertext =
-# Tag = 2c2ced637c2879b0
-#
-# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
-# Plaintext =
-# Ciphertext =
-# Tag = 646f5a0536c3b3099a44daf25ba8e3bb
-#
-# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
-# Plaintext =
-# Ciphertext =
-# Tag = 69ca1124e84d1accb9830c71bdc8c0e18e6dd244eefb9e01
-#
-# AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
-# Plaintext =
-# Ciphertext =
-# Tag = 0982618e762ef15c5987d4b0db50063bc1cbdf0080867e770c0ed962dea50f21
-#
-# # initialize with key of 128 bits, nonce of 832 bits:
-# Key = 9a33cc65fe9730c962fb942dc65ff891
-# Nonce = 0364c526e647a809c92a8becac0d6ecf8ff051b272d3349555b617783899fa5b1b7cdd3efe5fc021e142a304c42586e7a70869ca8aeb4cad6dce2f9050b112733394f5561677d839f95abb1cdc3d9effbf2081e2a20364c585e647a868c92a8b4bac0d6e2e8ff051
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 3f646cac3a0e1651
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 65b23d8c219efa8bf68560b3172de0f3
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = dab5b83342bd6cc9b6995e05d552570da342fd910eba12cd
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = cd92250d86dfdf5052556b5eec04f984ce0899e86e31885a7ac9cf9a9b7af778
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 2ef9dded14
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 4d0d16be4b
-# Tag = 6c689d66783946cd
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = f827769ac3
-# Tag = c46de0399191398dda9d13b1150d9a97
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 80af0f3c9b
-# Tag = b59ed5061508509a3d0a67286c9efe04adf03996ef6c5192
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = f5211c90d6
-# Tag = 21a6771dfba0187b6f058bff9f0f1333156d9f32aa7d136efc6908212be3ef6a
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 16d43411e768fb563cfd8555
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = b66db058cc700d2bb30b1575
-# Tag = da252e676839a63e
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 4faceb7f465d903bb2e59a6e
-# Tag = 85d330723ae4fcf4a286ef98ca7f1091
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = b5f7043dbc578788b6d31054
-# Tag = 52403d1f747e6d95d17ecb573f655f2fb0152d137817727a
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 0e8267d12e9207e8982968bd
-# Tag = 208f53174bd2f1576ca4877cf6b70bcbfbb62871ffb5b493b167095fa270ef2d
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = b0ecffed5fb7999a8118b4b13f384cf7c339f9a4190e6f
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 4b7acf9436a0f4cbad29627dbd0efd12854bac94ae34e0
-# Tag = 8ee6b8626a90bbfd
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 08e9d69325b3f48cedb6c3faa1c4d2b25f1870e1e6ba41
-# Tag = 3abb337fdb097a7c061014020eac8d32
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = b29dfbb5057d3f0d9748c4202432a8ba81d3140bd53ce8
-# Tag = 421116dcc81675d135153e2689d2091b5721dd1e23ec0d7a
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = 2d0a9868896e1ef0e891a695e760f2616ac37b99563920
-# Tag = 6b9299fd2f98c0ea7f311dd863e7ed15808e1d96dd82a08a270641c47bfb6b5f
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = adfabd8a0748414180979fd50ff9baa34479040d0544252832db595cd9caec9ed82f24ac94a115
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 0c6a58c292196e697066b1d9e4f6997334a4bfdac9d146c69622f810e4e6b8d8456c9d4fbf0a13
-# Tag = b646fe49f40a086c
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = 2e5c51069d4c1872eb4cc139426a4a85ad880531b93dd2b01fbaa043f8167f38596e95d90b621c
-# Tag = a70f57d015bc8be61a567d4427210b56
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = cd76b1fe0c561fedfbf214bcca1fea188136320253071ce2056292d8ad2d309c7517d10f063faf
-# Tag = 6f833fad638a3e94e2d1e62a40350954f4d665513b7f2508
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 9e1d19de588faa447fc02f19e1ec1595a3aa121966e741bb68a57839c98bd3cf38e9bc368b58a8
-# Tag = 3a85d04228b0ef1a34aa284eb8ad5ca3d9602f71ee232d3e7be4955bbcff7ec6
-#
-# AAD = 44d566f78819aa3b
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 4cdd6eff9021b243
-# Plaintext =
-# Ciphertext =
-# Tag = 062c4dd9ab2dfccb
-#
-# AAD = 54e576079829ba4b
-# Plaintext =
-# Ciphertext =
-# Tag = d173d05933f76688911cad099cd8c15f
-#
-# AAD = 5ced7e0fa031c253
-# Plaintext =
-# Ciphertext =
-# Tag = 3d9d99a18db85d2209b2ce485a73a6e032d58db4d7fd71b3
-#
-# AAD = 64f58617a839ca5b
-# Plaintext =
-# Ciphertext =
-# Tag = cfb868bf8a2c41ded07cc4d93225ebdfe17d10e6fed105fe447ec9795a31fc14
-#
-# AAD = 58e97a0b9c2dbe4f
-# Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
-# Ciphertext = 45d5f5373296deadf267cbd4ca73d4fc4aa1ebbf
-# Tag =
-#
-# AAD = 60f18213a435c657
-# Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
-# Ciphertext = ca0ae0885e9e77a6049936db208441e28a6a36a4
-# Tag = 2f12e384ea59d310
-#
-# AAD = 68f98a1bac3dce5f
-# Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
-# Ciphertext = 476fed2cf9a180ef23bd49e2709a6b1275e4b996
-# Tag = eacfc69d5637df836fb013df48c64a4e
-#
-# AAD = 70019223b445d667
-# Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
-# Ciphertext = 47d0d6fc8c91061174c6f899b104c330a95480f3
-# Tag = 480a478bf2067293a9c797527800458d3734334b4fbc6a3f
-#
-# AAD = 78099a2bbc4dde6f
-# Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
-# Ciphertext = f03187e7074057770c3c4bab6790ccb0dc782b38
-# Tag = 317461fd42cbbf1e1d79a9feb320fa0adddca3b8884a663d3348fd7c82e8b0f8
-#
-# AAD = 76079829ba4bdc6d
-# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
-# Ciphertext = 0fc535f9aa3afe956298a99c9045ca34dee7fb9271b7ee9a69f378ec0ca8c6f111dc3b81ec937b608efb8bd44f2fa5c5506b
-# Tag =
-#
-# AAD = 7e0fa031c253e475
-# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
-# Ciphertext = 0514bc86f4468f8955c44cd3660f903aa67b04256bd00d09e2cfdb2db4803665a069a501127c61faf4806a39587f86f77614
-# Tag = 15887cc389f6bf34
-#
-# AAD = 8617a839ca5bec7d
-# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
-# Ciphertext = 71376828dbf354c4f240bda3b134364c7b38a6ba1d8f4641c093d43f65ada2d404e061f8ff0fcfbb558512d69a5dfb807e9f
-# Tag = 2376ff06eb4e6c89e6c508d3a7f97bd1
-#
-# AAD = 8e1fb041d263f485
-# Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
-# Ciphertext = 5a24ba4f1e6f6714e4252d990a3ac98d2741431ff2866cc7e210f8dfe967e5d4d64821fcde0df9a2d5f47e999f013f9493bc
-# Tag = 2d6f431606a78403c6158833845f8be1c5168f5c8bc43ad8
-#
-# AAD = 9627b849da6bfc8d
-# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
-# Ciphertext = 1eb64568609870c566654ef684cba33c69b47d4d31d3a88bfb60b02e06a413cf743e957cb43e24090924f4a8c521f0794d78
-# Tag = 69a5188333b59a94199bc67a34b5100b396e1eed057f373e4257a8eeda6437d6
-#
-# AAD = 9829ba4bdc6dfe8f20b142d364f586170798
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa0
-# Plaintext =
-# Ciphertext =
-# Tag = 05d90ca8d9fcbc1d
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a8
-# Plaintext =
-# Ciphertext =
-# Tag = 72fc7f594a911df2b23c88803256d67a
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
-# Plaintext =
-# Ciphertext =
-# Tag = 7dc8786259c0620d370a89b2dbfb1479e09d2c78e721cb18
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b8
-# Plaintext =
-# Ciphertext =
-# Tag = a8c5cc1302ff465d72fa3eeb3f5c3c3b35b8c360e17980cddfff79750ba367f1
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b6
-# Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
-# Ciphertext = c6a90c2c72cd38579093abe75a7bf7c87f3f50c954a4b736ed12051e5ce1
-# Tag =
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe
-# Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
-# Ciphertext = cc904c5afb2791bd80d36b5bee0f2a3b445c3ffba6dfd68493588b71b7f1
-# Tag = cd346c1a579fc58e
-#
-# AAD = c657e8790a9b2cbd4edf70019223b44535c6
-# Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
-# Ciphertext = 749cef1b1461a026b02958d9cdde1767ef042439ec552c758b8b22238197
-# Tag = eddb7d04c5c0c990e41e71fefba58aae
-#
-# AAD = ce5ff08112a334c556e778099a2bbc4d3dce
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
-# Ciphertext = df038280ef8c7569ac2ab3fb75b8466c983fb17e1a2d1eb11383224e5e73
-# Tag = a209ed6d032508a1488a0497fe820f1a732ff8203ce55eb1
-#
-# AAD = d667f8891aab3ccd5eef8011a233c45545d6
-# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
-# Ciphertext = ca2f3e57c048a61a6d0f11d8068ddaae364b449a6c38f4d78f4e8c05e2da
-# Tag = a4b7b2e4dead77b8c4c2d2c4a1a041b878303664da7da9b478ab61727e3b0bbe
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
-# Plaintext =
-# Ciphertext =
-# Tag = e99479703dccc08e
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
-# Plaintext =
-# Ciphertext =
-# Tag = 2cae19e94e1cbaa73d417b0302f54220
-#
-# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
-# Plaintext =
-# Ciphertext =
-# Tag = c92c4bfd6b65861599feb15fa8b8fa643d262f0e2c3efcbb
-#
-# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
-# Plaintext =
-# Ciphertext =
-# Tag = 4c54434c1defcef17c035f1b4a5003b9b2ff88ad32ffd2489cc4026715a8892b
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
-# Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
-# Ciphertext = d49dc019aa268da9791fde2d841b7203a843f8a79fbf035bdc7e959fb9dfd522a3b103e13ced4bc00ab46649
-# Tag =
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
-# Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
-# Ciphertext = 3f281bf42d9e55fef322b332c9adfbb249bbb6f200ff21afa4f675a3fdd46c7f5f5e7efaab66c77bd7055a52
-# Tag = bfab283a60155584
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
-# Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
-# Ciphertext = 01186f43b52ff617aeb1050082ec620977e440675421f1ce8e28885317b750ddb4b0ebae443b39a072489cac
-# Tag = 96ef908dbfce2d3ac0107e100ee57a0e
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
-# Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
-# Ciphertext = 6a5c03ab563f78bf1ff87c648fc059ad147e28b2c3169f43e048f614c92a410fd859609fc91d5c48a1b83ecd
-# Tag = c61e08a3a33ef763ca6f44a2de62691835b2cf875bed8ee5
-#
-# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
-# Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
-# Ciphertext = de6db0e7a85625a9893a48b2de428e510ddeec1b42c8dd6f3993bdc32f312f2c42b59818979b07b43218916e
-# Tag = f14b9405611da03ccd7fd1dd632c61f207abd0f468531757f2b026220c74194b
-#
-# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
-# Plaintext =
-# Ciphertext =
-# Tag = 78db4b23706e5b82
-#
-# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
-# Plaintext =
-# Ciphertext =
-# Tag = 638e1f6afaed3c5fd73b67d9a6e6c851
-#
-# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
-# Plaintext =
-# Ciphertext =
-# Tag = c2e15647c05896411fb1885c45d4323de3fd120363d051fa
-#
-# AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
-# Plaintext =
-# Ciphertext =
-# Tag = 52bcb73dd85f95f3b609d6fda83be04dcf1b1cad89403d16df3e11daf5c62b6b
-#
-# # initialize with key of 128 bits, nonce of 896 bits:
-# Key = a23bd46d069f38d16a039c35ce670099
-# Nonce = 1374d536f657b819d93a9bfcbc1d7edf9f0061c282e344a565c6278848a90a6b2b8ced4e0e6fd031f152b314d43596f7b71879da9afb5cbd7dde3fa060c1228343a405662687e849096acb2cec4dae0fcf3091f2b21374d595f657b878d93a9b5bbc1d7e3e9f00612182e3440465c627
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 5a686e0c6d62a6e5
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = ef3fce120647313b9b7f135c357ff192
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 7144cad512b3fbf3c32fa6596ad03576fe7226fbd8fe97bf
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 52bd36047d30e8b19e1fb9ccbf4dbef9b3d68692cc15622c95700a7c95106a12
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 13acef3cc3
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 03731b76cf
-# Tag = d5830dbe7266f0fa
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 763eeeb32a
-# Tag = 7ee7f976fb42848bf44a9e476122da60
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = c3792fa2ae
-# Tag = 96eda6b1e9a33173dc1303b89ca1f93436cd33847415a2c4
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 5e1da00f75
-# Tag = dbc8e96b3f4d447e62c8d1343aeaec5fda69a10f75178c623b6abda4808e8ab3
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 27de5f4193b9ec0318b87eec
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = dc9daa2951f46f303d178b54
-# Tag = e1212580731c99f1
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 09f669a01ae6263da77a5d81
-# Tag = 4e2a9fe20cd8f7ce58bc47233bd1f2f9
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 132693bc7c3ffd2db5d610b8
-# Tag = 753c9be86fb7654bec9fb8b7f9c1319e8408d3e9d8699448
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 3df09231ff759dd2d01fde5d
-# Tag = 11c9ff0b46d33791e2a768243c32ac4762fb3bd59ac19994048d7bee2d9fc80b
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = a3bd685d6e05be37b64c8454556323149f2ce336012f9b
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 4b403bcc05b7c968caa9609b0283b9414ddcfd33ca2528
-# Tag = 42510b3f172f2529
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = a0fc56210aa2f048059433430f9d362c559830755d21aa
-# Tag = bc01f2aca02ebf17d093af82f8f032c4
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = b831a340f30d627c0f28d4af24bf72aa9c95a839feffd6
-# Tag = 25867e752db96bd2ad4879dcf5bfa0415ba7af4fe4cf8c1a
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = be99946ac3b80df2fe19deca88effcc772c7579b6f5655
-# Tag = b7ee7201f0f2dc6d2b155385c6db65425dcddb15cde4b8730ec148444f9ec114
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 9cf9633d61095c2754734e70ab9914c01444a8af7ade7daa7a94ada840ed0bdf813a08ea51250e
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 596bbb4e1638bf2efb4f01473c79bf6fbd565dddeb796be30984b997ff9ecb7550a87b7dd94e81
-# Tag = c792bf8e50b7070d
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = b1b95d3ad101302fe47453c5ff0067cfe69b446076619cbcefe53e06b377a94f710528b0946703
-# Tag = 01d2c64eac873c447c4a939e53460179
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = bbcbaa5bc4cc6017146155ac65ec28e48a3d20e80955466ff79b3a2913ddfc7ccd27edf34e9177
-# Tag = c185c1f847262fd7ac77a60f7a83093431e7d8fa13c0e641
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 6ad082e3f8309ce4d10999e0bdbc3504471e2f1b0a0acab78d0cc43cc057fa2dee70febc2c2965
-# Tag = e0b48ad39b64b09748eeb3da6bdd94a0fd960b6d302f58fe4366701866f96a59
-#
-# AAD = 44d566f78819aa3b
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 4cdd6eff9021b243
-# Plaintext =
-# Ciphertext =
-# Tag = 80fc0e11b2776964
-#
-# AAD = 54e576079829ba4b
-# Plaintext =
-# Ciphertext =
-# Tag = 4885d30c0460ca7ef0453e5ff3884151
-#
-# AAD = 5ced7e0fa031c253
-# Plaintext =
-# Ciphertext =
-# Tag = 218849fc9366d54aff8ba1251f06a8c33ae3aefa0745ce54
-#
-# AAD = 64f58617a839ca5b
-# Plaintext =
-# Ciphertext =
-# Tag = 4231903e6e8650a76ded60d09b6bffa9feffbe6c4053bbc6b6375866b78ab672
-#
-# AAD = 58e97a0b9c2dbe4f
-# Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
-# Ciphertext = 498fb6f1bee9c08a84719af14b28ddd322566aea
-# Tag =
-#
-# AAD = 60f18213a435c657
-# Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
-# Ciphertext = 00204e48f3d2e85db90a8a6633ef55afbd377dfb
-# Tag = 1cfb09d2e898fa3a
-#
-# AAD = 68f98a1bac3dce5f
-# Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
-# Ciphertext = c476472809e760507d38815110670cbffd1405da
-# Tag = 0248e50e5ae0e426c02866898212f970
-#
-# AAD = 70019223b445d667
-# Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
-# Ciphertext = ff3d8a261c9e10832c33a3ed62458312760dc6d8
-# Tag = 29543461655d7fed421fdfa41773ad67c694659ed8e01d3c
-#
-# AAD = 78099a2bbc4dde6f
-# Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
-# Ciphertext = 8ef90037ce43475cd51804c307f216075931eb54
-# Tag = c4c51d4dd00a732b126169d64837f7bd6adde499abb9578730da2f504a1b9f1a
-#
-# AAD = 76079829ba4bdc6d
-# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
-# Ciphertext = b8f2e3e900bf0253b9d2750c927ca39fd879d2976b75077ff4995cd5a9b456978f636f5bfd31a24895b5c2d406a5a4bf2e41
-# Tag =
-#
-# AAD = 7e0fa031c253e475
-# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
-# Ciphertext = 965ab4502e55aaa100c9e0a1030b2730725acd86887a0a3da811a4479a2357c12733d7b17767286ce7a77c6e96fd572df4b8
-# Tag = ae48a38e53be9300
-#
-# AAD = 8617a839ca5bec7d
-# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
-# Ciphertext = 1a72a53b185e476d43cfd3d97efc8c67af3b4531a04ab559019390f76018970febbaa94d954083182646eeda066902236b9e
-# Tag = c8de95f46e34a55ac9b4d886b65a942d
-#
-# AAD = 8e1fb041d263f485
-# Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
-# Ciphertext = 882d6d5f37b1a2fa2fe8233d4a0ec85b7adec94c6ac6c2ff5d7b9af35980f9af4398e4ad357ff1706efe527d7025b51aa617
-# Tag = 77db3999f5fa495358fe99849e9ad85e3cace7d857fe7dae
-#
-# AAD = 9627b849da6bfc8d
-# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
-# Ciphertext = 8f505ab334d6e5ba42f2ec1376355dd90e082a5032be63bcb67d01f81ccee0278b8ba8dcbc4a4bfbd70154180d27b64d2b01
-# Tag = 2ec3a5c12112ea337d3bcb0a53e11315bf8189a3b5ad20e47c1f2bfb5a86bc6d
-#
-# AAD = 9829ba4bdc6dfe8f20b142d364f586170798
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa0
-# Plaintext =
-# Ciphertext =
-# Tag = 3257e78b715a0fbd
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a8
-# Plaintext =
-# Ciphertext =
-# Tag = 1ce2c4b79bff9b12c288cab366b28d5e
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
-# Plaintext =
-# Ciphertext =
-# Tag = 788f36e74953ed889b78054f232a02d550a1f06b0ab5a222
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b8
-# Plaintext =
-# Ciphertext =
-# Tag = 466fb87db92c9090946bdc041d5d216094149e92fef6dc7996baff8e4d2c66b3
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b6
-# Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
-# Ciphertext = c7a8ef6a58b50706ca9ff27de41a466edc893e130482170dd3679ed1c288
-# Tag =
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe
-# Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
-# Ciphertext = ccd182779e21be688c6ca494662bc47702dd6d121f6eba59e0721ed2c07f
-# Tag = 58b2f95edc12ae53
-#
-# AAD = c657e8790a9b2cbd4edf70019223b44535c6
-# Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
-# Ciphertext = dafcc5c02f8b201ee0a24a6d63cc8a0a30dd6ac7ac332f3ad0d97e3df939
-# Tag = b583f42120d13ba8608204fe22a9ea01
-#
-# AAD = ce5ff08112a334c556e778099a2bbc4d3dce
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
-# Ciphertext = c7ff666fc51e3d89ad4dc213f59f65b9127116d10b72baade3c9e51606d5
-# Tag = 74cc26879e1e3cce63a49f4c9b4aea59b9d5850f29bd100c
-#
-# AAD = d667f8891aab3ccd5eef8011a233c45545d6
-# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
-# Ciphertext = eead6cb784e8f0cd925f1a832db3944e407a0d7064fb6c7adce79f751475
-# Tag = 0d1a4a6edf67916e38fa1037c6350be65e4534ff362c5ad60ac9c6c504797552
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
-# Plaintext =
-# Ciphertext =
-# Tag = e2191197b77804c9
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
-# Plaintext =
-# Ciphertext =
-# Tag = c7f2c1c66e94c86640dd5ed6283f834c
-#
-# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
-# Plaintext =
-# Ciphertext =
-# Tag = 28f2ed85c415d3ccc2e08412fa6779df620329cbcaf850b6
-#
-# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
-# Plaintext =
-# Ciphertext =
-# Tag = d09104ffd899ceda208c44b471a3ac79d65398302ff23a53f6c39897532afb55
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
-# Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
-# Ciphertext = 874cc6e6546a9be48cd043e70508a6d1070cf892fcc815b15dbc90ba0b48599e557b0563815de9af468ef58f
-# Tag =
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
-# Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
-# Ciphertext = 74e5981636e65c03a592381b4366d029e0816d6347c61597ef1258a8ebd061ccca2bcddba42b6d20ef0e90ee
-# Tag = 80486d47f1c71ddb
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
-# Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
-# Ciphertext = 72a9efa0a78cceda3c65f07f985835b950b8d2565a030d54cde7631ff5c5cd20aac5448004f8645e8e454fd5
-# Tag = e473b2e785dfa779d64ee31021ca4e30
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
-# Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
-# Ciphertext = 6b2943f4b2186fe699221b09ca1e0b1f27db409697c86eb0d976f8a5c58c405da08d5ba966e53d578dad53f3
-# Tag = 0513216ccdc09d8aa4bca65fde363e8433193431fb1f7f75
-#
-# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
-# Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
-# Ciphertext = db9f993fde1dd01739ff3dc133f3a01780dcf4d4c0edbc8f442aaa2f4db231c5a8a96b19336f3d779e75aae1
-# Tag = 7e63ea3793977273f9fdbcc4ed1a97a26549d7f0b128cdbb40763f017ac45cbe
-#
-# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
-# Plaintext =
-# Ciphertext =
-# Tag = 3e451771ccfcce92
-#
-# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
-# Plaintext =
-# Ciphertext =
-# Tag = a82f02467a9af70481c45185aeb88b3b
-#
-# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
-# Plaintext =
-# Ciphertext =
-# Tag = d6b9b76a977b979da4af99d3adaa384fd57911b16c200713
-#
-# AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
-# Plaintext =
-# Ciphertext =
-# Tag = e690f4696bd48cd5392910ba74b4f6ddfca118695021e08042cd6bea949cd692
-#
-# # initialize with key of 128 bits, nonce of 960 bits:
-# Key = aa43dc750ea740d9720ba43dd66f08a1
-# Nonce = 2384e5460667c829e94aab0ccc2d8eefaf1071d292f354b575d6379858b91a7b3b9cfd5e1e7fe0410162c324e445a607c72889eaaa0b6ccd8dee4fb070d1329353b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667c888e94aab6bcc2d8e4eaf10713192f3541475d637f758b91ada3b9cfd
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 8cbb835a1d67acd0
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = eeee5454ab5614bf502f1cd892b163e6
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = d3c77fbe9fa9a99feaac1e5ffe92f04fc7f3a951e53f32e1
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = fe69c22bcf4147c946e0da5e2346802eaa364b76f816fb5bbf4422e82eab1b12
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 7760b50efd
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = b0dc1a1c4d
-# Tag = bc08a919a13fbf54
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = e590478583
-# Tag = a3a2718748d51ef0899c54e41cd14ebd
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = cad2acc9c7
-# Tag = 35887022c618ef898b3023382f4b4c4ce85179e1f8ccf508
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 5f4362000c
-# Tag = a8527b7ceabe3b75756e5c3e9fb282cbc5219855320fe95f4bcd72d1890b9f8b
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = f46b821b52c8d3ea709db1a5
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 6d7c1b63118266cbb9e1b9e8
-# Tag = 65abcd602d0a6cf3
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 4779ea92d6a0b8feb071520e
-# Tag = 8f293749ce9bd7823730f8704700e5fd
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 6fe91761006a2220d0f269d9
-# Tag = c2475297af1963a073c5c0bb62902d9682eb5ceebdc045ac
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 7cbf00e4df2d558941d7c3db
-# Tag = dc6a39e56d3a7f03d1b73fb421645d5803bb6e8444c134ada494f5bbc5448b49
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = d543bbe88c028a1c1b3d062845240ec827409c0cac4608
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 5a986f73e8ce418df4603e1589a4a9ea229e51ce4b98e6
-# Tag = 3f32efbea1aa50db
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = f913bc1c8e89f93943bebe9a4d5bb1611354a683fade69
-# Tag = cae40ad9f7c75cd954cba88290340e52
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = a51c59673a8680f216d1f42a27133149580121aa7a5fb1
-# Tag = 988accdd465c765577e75ff2260c3e49f284167fd69c5186
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = a1b1c3ffd499c254a5bee4a76cbaf97704313416f65ae2
-# Tag = 7afaf111746e780b506d44b33add8a751e12b98014a7a435cfea6f177f948090
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 34683ae09324615ef0906383f0d16e92bf1cb014cd20b6b89aaf08eb7baf8ed6d3bc2c652f0d76
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 1380cf8b141c4d963ef828e78408175b2d953cdcbd516bc0041ea72cc84b4bcc0e5872740fd109
-# Tag = ffe1556d350320c8
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = d939d5d3480fee44af7820f191672ba35a511337bc35803ec4d90614a03f43b04444f390e5386d
-# Tag = bef4c1380e02d5c5753341aa8d8f6503
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 03aa9d6f2281c3b20dd65971e1adeac9585c3773d01ffedefa6287b8ce2f52c942d3a93802cc04
-# Tag = 3c1b3d5590e5a3c33a6b3bc0d091326e8e88019ed7d5c6ad
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 49ac6419f4ef6b26f5cff2dbf11406e6858e7011fcc70699aa1940a32fcbfe6a8313ac60f967b8
-# Tag = 756382a6e872816b0f295cc158b46fd45ac866ab6d5c37c660f7dfcad6837b8f
-#
-# AAD = 44d566f78819aa3b
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 4cdd6eff9021b243
-# Plaintext =
-# Ciphertext =
-# Tag = d4cbc9de27a6154c
-#
-# AAD = 54e576079829ba4b
-# Plaintext =
-# Ciphertext =
-# Tag = 98d045e1554034b3a620dfe161b0aeda
-#
-# AAD = 5ced7e0fa031c253
-# Plaintext =
-# Ciphertext =
-# Tag = e4fb2e680f9100f5aa3d1e21539455b88e2ad764dfd193d2
-#
-# AAD = 64f58617a839ca5b
-# Plaintext =
-# Ciphertext =
-# Tag = 853fabde6e03c789c34220a1db5e6a1ede37a288ebf9f7e5cb1f30a6787fbb01
-#
-# AAD = 58e97a0b9c2dbe4f
-# Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
-# Ciphertext = d7c105c648c7404455565dc70a152fce178df003
-# Tag =
-#
-# AAD = 60f18213a435c657
-# Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
-# Ciphertext = 4d242dc2c9906b5a9eba26e52c6fc5bd1b672e59
-# Tag = 8e09d34b6a43ddf6
-#
-# AAD = 68f98a1bac3dce5f
-# Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
-# Ciphertext = d70715db40b4fd2b9f7a83a0282494c800eced32
-# Tag = 038d52118bc684845ad1d4b85a58c5b0
-#
-# AAD = 70019223b445d667
-# Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
-# Ciphertext = b320a8716e319e1e1926358bc21a45309672d855
-# Tag = aac3ad393ae9d07f501f4f5aca0ab241229ab23a05abe192
-#
-# AAD = 78099a2bbc4dde6f
-# Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
-# Ciphertext = 99241490f501912a1c0dbdad235a79c44be4be6a
-# Tag = 59d5bf769cf478f73403131df332c0306d2097b44e6378ba9ebf8538e6063e42
-#
-# AAD = 76079829ba4bdc6d
-# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
-# Ciphertext = f3c20d15ef7e567d57f752eb5200ce03e8129bb48eb2ef86977202aa93a13521e38a125a7bceb44ecb917c0d0514d9b41606
-# Tag =
-#
-# AAD = 7e0fa031c253e475
-# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
-# Ciphertext = 8cd40273030403c0dafc16aaf0b0fdbbe102e7daf2f45a6724c15da2a2fd7edc63a33c9d2385a92fd8d2ea44a5cc6f1b72e4
-# Tag = 80eafad1d8d511c8
-#
-# AAD = 8617a839ca5bec7d
-# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
-# Ciphertext = 7a33848c68719ab9c53836ab563d02dfe189659b0256ea2780b7e99ce9cf6796b664e793a62c48e22ee4ac12d708564df19c
-# Tag = 6870d98201dd8b56b0f664ee6654e7e4
-#
-# AAD = 8e1fb041d263f485
-# Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
-# Ciphertext = 019dc26ab6b3eae9ec11c27bdd31e3d5b360020ba8d757736172255e2be3ad1570b3727e4df72ddff734195288a1937b9af2
-# Tag = bdfce6e6a3a490045631e968568dfdde1f3338ab451a0bd7
-#
-# AAD = 9627b849da6bfc8d
-# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
-# Ciphertext = c84992d6c75ecd6fee704dfd979cd2da9bc6abfb9072a95abe7838a581f31b877fa51ecd4ef9bc3a4deb905cfeed235ee16d
-# Tag = a3c89806315c72e98f9334a4ee2c6fce15d34f63be8c5bad3aee667c71664c28
-#
-# AAD = 9829ba4bdc6dfe8f20b142d364f586170798
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa0
-# Plaintext =
-# Ciphertext =
-# Tag = a050ed631a89113a
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a8
-# Plaintext =
-# Ciphertext =
-# Tag = f96c121333e8fc4f335ab8a314f96728
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
-# Plaintext =
-# Ciphertext =
-# Tag = 89a522680aa3bbdff515cdf93579022524dd2080bc8aa3db
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b8
-# Plaintext =
-# Ciphertext =
-# Tag = c864688687dad46b9b99a5d5f0b2135084626b2f05dcb71d2c6f56d509389c62
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b6
-# Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
-# Ciphertext = d44658a4a2cd6366ecb1c4e04924e84a49bd8b8d0b26056e7540f4f7d6f1
-# Tag =
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe
-# Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
-# Ciphertext = 16818be085451184f92f36b0d114f9111fd62a8d11f19d008b2de739d821
-# Tag = 8ddfff945931ecdf
-#
-# AAD = c657e8790a9b2cbd4edf70019223b44535c6
-# Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
-# Ciphertext = 544a70ddad580d60775f28ad8222aac9f58dbe8756639e0a59a7bab71eb8
-# Tag = 8a0e5231c54177cbff7989a5872267d5
-#
-# AAD = ce5ff08112a334c556e778099a2bbc4d3dce
-# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
-# Ciphertext = d7191eec553563a315c5363bc2363b2e0aa7160ee1294c4e7c1178cce2e9
-# Tag = ce7e1520f9b8df4502ccfcf4f7f53c13334730449c67188e
-#
-# AAD = d667f8891aab3ccd5eef8011a233c45545d6
-# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
-# Ciphertext = f10fbb509106acbb6ea55312321d637a7925b4e79835c19051fb65b74f40
-# Tag = 2e65b558be2522d8135be4ff5efb1d1976ac53cb9abfcb9b21ac9b74a287f7cd
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
-# Plaintext =
-# Ciphertext =
-# Tag = 137dfe109d6521fb
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
-# Plaintext =
-# Ciphertext =
-# Tag = cb4dc877ede36c141507e54a5ebcc047
-#
-# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
-# Plaintext =
-# Ciphertext =
-# Tag = 76611c16527fad7ec998d73eded502eee0e5507778d5247c
-#
-# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
-# Plaintext =
-# Ciphertext =
-# Tag = c96faa794fb616f847f1acd2ba64d44896141bdec8c56f21ee318442d9e1c13a
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
-# Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
-# Ciphertext = fec3f18d0b6cfd45224f34eeb9527098600fb86eafff33e3070b446e8b387855a4dfd09a69c7bd7120daa485
-# Tag =
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
-# Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
-# Ciphertext = a87f405dc5e3fe873c4b6538553c039229f7a9b0f84d3a7b693328a1e9bbff0358f65da28bb8c98a76bb7ab5
-# Tag = c309df12f27d26e8
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
-# Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
-# Ciphertext = 395aa1723397da50e450b4fd58ab6fdebb1155bb07e70c1cae823ca07b5e048200dca29049131313329cbbc6
-# Tag = 4958058cffc9277fa3a52bcf2781ef45
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
-# Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
-# Ciphertext = 7dd3cf99686d7e2683724d94abaf82acda420e8ba67d574043d4811e908884beb6b977ae6eab035615d9a94b
-# Tag = b9a4c65390873f8ba320d10f88552164c4d18bea7c4410cd
-#
-# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
-# Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
-# Ciphertext = 0b27077bf9064bf7f0520c626d67138afaf95c57738bfd698adb189274550adce43ab44fb674e98139e5b815
-# Tag = b5eae367c79ea867419282a8855a830e034f1f23b07d6aa7ceebf5b1da05016b
-#
-# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
-# Plaintext =
-# Ciphertext =
-# Tag = 222b0ea9432f7bad
-#
-# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
-# Plaintext =
-# Ciphertext =
-# Tag = a25dfabe677eff1d92a5e646b1b0c458
-#
-# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
-# Plaintext =
-# Ciphertext =
-# Tag = 6ad8cc9f8f9a9cb666654d1d6bef0d63002eed997e8c4f78
-#
-# AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
-# Plaintext =
-# Ciphertext =
-# Tag = 538b3bea41ea3f75fd7bdd6a68bfb76ce1d625ee536a73b7625078e6924cac5a
-#
-# # initialize with key of 128 bits, nonce of 24 bits:
-# Key = b24be47d16af48e17a13ac45de7710a9
-# Nonce = 3394f5561677d839f95abb1cdc3d9effbf2081e2a20364c585e647a868c92a8b4bac0d6e2e8ff0511172d334f455b617d73899faba1b7cdd9dfe5fc080e142a363c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d3
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = bdbce20db9fe79a8
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = c7f1baa2405cc76169ab747062d3dd52
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 743d337e170c68cf27246cbfbd53943a29273496ddf0cfcb
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 7b10a954a16a25b93508964ac028870c634ebed9ba9eca39edf9e3378dd4e0a0
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = e01d5bd189
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 6074a98c57
-# Tag = d1ff44ac6d477915
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = f7e8f19c62
-# Tag = 734dd473d536cccff76e8dfc1e9e3766
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 12a1fa7a14
-# Tag = 96960af729c81b2c7a1546bf349e3b66b2aa5916b9d2f2fe
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 84e36030bc
-# Tag = 6b9d78cca4b76ec7fa5f6f0eb09bf89d20ba33caae45e6d50afcd8814830049b
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 2c88621a3ac28f956e22830a
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 47cd485c13fa0ea09a942534
-# Tag = f766d1395124e695
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 2cb1d13b97f79810b9a7f227
-# Tag = 950553e726684b100f8238a569626fe0
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 88915058c7daaa04db6726d4
-# Tag = e1d37ec52e061970f03817185a9cc4d402703151b4c8ca36
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 6e0d7f25249c2715793b6aed
-# Tag = cc1a053bebff9d6d91c828fd27224ddb718d64e6c42d34fdeb23c290a1a3388c
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = ae82aea99f30f3dabeeaec752971e746b6ba1d35160ab0
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 531d1e030b3f29148aa2b41acac16d3b1449782bb4ebe6
-# Tag = 0df035115e562537
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 136512db5a7d854652afb993ad1237c1b5adc7b83c5337
-# Tag = 28066c90cc3ebfa316716c22709fe78b
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = afb90feda3f1ff98b9ced13c683590fe14701e7be3de40
-# Tag = e85b82eeb5c2d752be6e7451469df2826e4a468717d1586d
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = d8c4ad37ffe7daf4854408c4d2c39774b7b11b453f007c
-# Tag = 550a785575c57eec8207a11d29a90d6042173877db27eaafccf334794bd88af0
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 39d88312d19d07958127daebeb10bd2d8f4164b3dd2462fa321131061156bb6c67b0cecc5ae8d1
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 92a2cef0b6221953303776d81788869f6e5bf2a4c442b42540c2adef715fec68c5730666e35fcc
-# Tag = 1ee32242ffd6cdba
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = f9cd7bcdc5e83d2a296064b1d9ff9c3f6bc8fb59aa7c096edbfdc6cff89d38e6f7d478b08a6234
-# Tag = 16b5735a3cba93ee2ca816b72f9f47f4
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 8e6a7626d99704015fbb61f36245eda1034a786f37f620cecd883139e65492035e2a08ebc790a0
-# Tag = ed81fd3de45fef135bc05c92856d4c2125172dce71d06c71
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 557379c1555a0a0915a6f64fc9327bfea7f5a4bbbd5c893a1d53d2dbdfe31157c4cfbdfbedd3c9
-# Tag = ef77368c65d0d73f0d6d4a98050a874c6286d5337e40ac29f1d05c75412050f5
-#
-# AAD = e67708992abb4cdd6e
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = ee7f10a132c354e576
-# Plaintext =
-# Ciphertext =
-# Tag = 4beb07036c1070fc
-#
-# AAD = f68718a93acb5ced7e
-# Plaintext =
-# Ciphertext =
-# Tag = 60705c79629b4341b7ec756efcc09b48
-#
-# AAD = fe8f20b142d364f586
-# Plaintext =
-# Ciphertext =
-# Tag = be5b3fa772986bce240f73e2fb0d0eabf0ad1c17fa66a300
-#
-# AAD = 069728b94adb6cfd8e
-# Plaintext =
-# Ciphertext =
-# Tag = 33ffd04548cf5dcff995921df46bc3537a78f8bdcd00562951e18a84dfe28cd2
-#
-# AAD = fc8d1eaf40d162f384
-# Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
-# Ciphertext = c64f502a9058dc5ffe1e9cf6249c1bb45c4a9dd3f042
-# Tag =
-#
-# AAD = 049526b748d96afb8c
-# Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
-# Ciphertext = faf271a278aec77e12c24e0b2a98309c204e4dbb2084
-# Tag = 79f8c81ec8956b18
-#
-# AAD = 0c9d2ebf50e1720394
-# Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
-# Ciphertext = aef22a36547824a0663730c2f55380b2a861e643e5d3
-# Tag = 39f653c362aaa546fb38452e48f1a628
-#
-# AAD = 14a536c758e97a0b9c
-# Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
-# Ciphertext = e61af45db7132c9e38f2b37c8027d69f004317bde39f
-# Tag = 7e66ff46cdc4e75528c47dc842a886e24faa15327ad553c4
-#
-# AAD = 1cad3ecf60f18213a4
-# Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
-# Ciphertext = e102a8fc25a8a399baa6d2b1af052ac079a998b0ac00
-# Tag = 267514b85221bcda642fc26ccaaa8d43a92992bf9fca9e10630f20fae6007ef7
-#
-# AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
-# Plaintext =
-# Ciphertext =
-# Tag = f2c6d2e0cfcf89ee
-#
-# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
-# Plaintext =
-# Ciphertext =
-# Tag = 138bd6a251f432a424df778759eb11d4
-#
-# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
-# Plaintext =
-# Ciphertext =
-# Tag = e2e1c97b1b77849c1bef54172d2c4e5be11a38c6c8a4c6e4
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
-# Plaintext =
-# Ciphertext =
-# Tag = 85ad61699473787bfa4035fb57da783cf7cae00aac873729047a1147e2a91057
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
-# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
-# Ciphertext = 2ca7106cc0c15a64c7d1722d4b9c37d5a12514abef3c389aaab699d1805223152829
-# Tag =
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
-# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
-# Ciphertext = 2a99e10c4fc0367bbcfaf0dcf6c476f19cbc587d4edd51f1cefc6e9f2aef335f0dde
-# Tag = 2bf57212d307c0e1
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
-# Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
-# Ciphertext = 05dcd8d5dac17a99ee9376627805e294ebda5560b7889a62b3cd1c7c0b8bd8f7545e
-# Tag = 01f0578f966d45052fcb37685e02dda5
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
-# Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
-# Ciphertext = 5997890a7da21ecf3a63312aa0e37a5d5be515c13f3ef117b323d76107b97ee8c1b2
-# Tag = 348a8c138d1471fa31489fb0fa68f63bcbdcdde5612e21dc
-#
-# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
-# Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
-# Ciphertext = f8be750fbee8c0eb5717463bebdd241d307377d243c2f592e48a3b97fb8b94bcd709
-# Tag = 15799d0c81a2f265693704e06dca53b0a4bff1a4d6a1c571c55381bb35ca27af
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
-# Plaintext =
-# Ciphertext =
-# Tag = a21749f034c39f75
-#
-# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
-# Plaintext =
-# Ciphertext =
-# Tag = db2f973194f73b96ec8a1c37ad94b161
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
-# Plaintext =
-# Ciphertext =
-# Tag = 90a3dbcc7ba07e13bd5d43143bc3c42bd6022a853965c8ee
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
-# Plaintext =
-# Ciphertext =
-# Tag = 4dc660eb6667d5a7d32f91253c05bc3c8c20e120905c1aa1ac9a4e05ec4e23ff
-#
-# AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
-# Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
-# Ciphertext = e0e011fc88919158bc5ba297d2d69e30d35ca7533afd4fecee86c06ef80797205eafec7398652cb0cf721136645a03c159be
-# Tag =
-#
-# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
-# Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
-# Ciphertext = 7ea2af78b36c8d36bce0a75cc7941a807d165b6b4cbf0a0c5524969dc4dec71aaadc846d9e4ab97565176727bbe68eb07978
-# Tag = 1a169dc37b4052ca
-#
-# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
-# Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
-# Ciphertext = f3307f681f22d6530e62a92632509e008bc9bb59d771792e02785550366bb32ed173bbd348831d6239a198c8a65bc6508464
-# Tag = c03b862ba790674d2cf3bcf71db8ee0d
-#
-# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
-# Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
-# Ciphertext = a89c2578c38f7a5e2bae8100c4bfa3f09f20b8a846326505cd2f0c41efe5335a5bf87e4b106bd391f0c41ee93b7c162414ec
-# Tag = 3866d89ad71141f60f6546326ccf83d77924f55ed33b058b
-#
-# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
-# Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
-# Ciphertext = 8834f3a02194ed0689b3bfe23e72c02eab4a28e076b56cb81915e3b312edb3b357a3823fbe5ed0628705e97b6ea529310c8a
-# Tag = 672db0d83ef3d5cc0529ca8b8a69dcf6d2cbe55991c0d620bb6f8df4cdc50de4
-#
-# # initialize with key of 128 bits, nonce of 88 bits:
-# Key = ba53ec851eb750e9821bb44de67f18b1
-# Nonce = 43a405662687e849096acb2cec4dae0fcf3091f2b21374d595f657b878d93a9b5bbc1d7e3e9f00612182e3440465c627e748a90aca2b8cedad0e6fd090f152b373d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a9
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 5bbe3056efe78b59
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = ed7da3d5ffd6868f7d9a3cad5c3b6b55
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = a94245bc152a147026b8eb7bf5066af7e1e409fcf6c22def
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = b8164d98bab7b47b09298e8a8633cb1cb13f2cd6fb57fe8454a11da2db6178e2
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 07a580412d
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = e793ce0085
-# Tag = bcbec78e33261609
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 9e9c6bc8d5
-# Tag = 216140c258aba5d8e0bd72eb9beec13e
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 2d7683521e
-# Tag = 2f2af547d8a19e09fbd51a985767762dc7bce29215be4d1b
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = a5f2661398
-# Tag = dd13b57e10d0e98856f364f2dc30c0a2327285255ede29a303f48652b31e8267
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 269743ac4cf7f0d1aa4f93a2
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = a0799d6e77db87e10658a786
-# Tag = 72dc49e879329f62
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = bfda08ab5dd7d14c5163d470
-# Tag = 0d9a8763ac660bf9de839dff7b9d3398
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = c8847fc0a34aa04a103217e6
-# Tag = c681993c0d49730137336345b1ac2dd4d58bdcc1a5bf12d7
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = cd97b35faca4f1daad4f6896
-# Tag = ea17eb1c1eb5a2a5da513ac7602631c97dbf6b23d756f93a496709d3044fa40e
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 0bb56c27b5c8d32ca0036b7f57bbf2957fd9f01e22a9f5
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 688bba1a6d69232d81bc1e9fc992a4a55150eec153bada
-# Tag = ee467925b566d73e
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = f30ef0c0616a1d81c1608a6873bac0243eb2663a38c1c5
-# Tag = ab6af91057e62599839ce4d36b334baf
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = c00a848cd7cea2c0fabee782024c34638e835fb6a3eed0
-# Tag = ea321116285549481a2303ced86324c8a184467e824d6ab3
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = a87561ac9f6aa6ea791534ef539c26fdcd22dc4b1f91f7
-# Tag = d715b1ccc20839453234d457612b7d087b7f2ac07ae18c171a060bf8a48d2625
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = a56636080ced6a50b0b915efc4d0ca64b9254124df777c369f086751ac2aba3bb0dae2728023ed
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = bbdf44719865d90c05be25c1877677c79bba171318dbcaf8f1b15b48e5360be53ebc90b35ea1b5
-# Tag = ef1f34dc2b68f29c
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = d8692ad92b2785e8d36823d714b8fad20aed565fc0b7376b0a6a7513caed0f76bdf0ebed6f7593
-# Tag = 0f55c7239cd881080c6db1e612c65e6e
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = a043abe2d7ccbf7681fea974973a37aa3f9c6e3c3511f9f3686dd4133d241fd2403df63024cd19
-# Tag = 74dcd4e892b0c494c951469b0b42c354c1843c2ce3a66751
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = d7d3dfa9268f8d52cffc767b2e9a78e5bd7e748da40a8d7b16557cd068aabfbcb00d60bca11548
-# Tag = d902359213d8d8ceeca677c6cb357e97904c7657f1c6ca5155a7c44ec6b0a149
-#
-# AAD = e67708992abb4cdd6e
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = ee7f10a132c354e576
-# Plaintext =
-# Ciphertext =
-# Tag = 62fcb1d60a5dbaa5
-#
-# AAD = f68718a93acb5ced7e
-# Plaintext =
-# Ciphertext =
-# Tag = 7b069886bee6e7c81cbcff423dcb7e13
-#
-# AAD = fe8f20b142d364f586
-# Plaintext =
-# Ciphertext =
-# Tag = 2e3e1e4291edc62170ab007d49f68bc43204a11bb2948d2f
-#
-# AAD = 069728b94adb6cfd8e
-# Plaintext =
-# Ciphertext =
-# Tag = eb845cde9358d437940946696a61e7a576424ec98a09e64f7985a2b3964fb89c
-#
-# AAD = fc8d1eaf40d162f384
-# Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
-# Ciphertext = ed50d186af626a4288611de1acf231ba0232ec228d8c
-# Tag =
-#
-# AAD = 049526b748d96afb8c
-# Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
-# Ciphertext = 2e332dbd08e1b4de6c55eef7553318c3f0e4f755d15c
-# Tag = 933749bbc1d83999
-#
-# AAD = 0c9d2ebf50e1720394
-# Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
-# Ciphertext = 725f172a062767ff798fe159116dfd303d4eb12c8ec0
-# Tag = 2df742b6eacbe6b27d177540897e5f54
-#
-# AAD = 14a536c758e97a0b9c
-# Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
-# Ciphertext = f957546d247f21669c0db13b57c7d44443455b5b1032
-# Tag = cfe7ecadaaf689f0666bda2389c32983da2facbdb1760e42
-#
-# AAD = 1cad3ecf60f18213a4
-# Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
-# Ciphertext = 0643058ece0d14584f26051441883d0c7e3fd970a501
-# Tag = ecf55c6d2c4417e44e50ab925f9b3fdd253d69f593d2047278a10a1a23639185
-#
-# AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
-# Plaintext =
-# Ciphertext =
-# Tag = a3f593c9d2a3b91f
-#
-# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
-# Plaintext =
-# Ciphertext =
-# Tag = dd5e060ba931c23e309801a3bca036b4
-#
-# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
-# Plaintext =
-# Ciphertext =
-# Tag = 7508eb13a3a94d73c5898c3361a7ae4c273617e38dd11043
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
-# Plaintext =
-# Ciphertext =
-# Tag = 07aaa7a8f84fdc883a250c76eb82e150f521c85ff0edd12e640373ec0f0242e6
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
-# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
-# Ciphertext = 47928f22b49a1554a20f4318d3b45207ac0ee00d39d25eb52ff57053ee5b000f3581
-# Tag =
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
-# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
-# Ciphertext = 57792857a74446fa6a38064a457e18b045b535728b6be44208652de434b33e3d94a9
-# Tag = cdec92c126180a28
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
-# Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
-# Ciphertext = 7c5552d22338e0dbf677027f011a3a4b5ca1bc67753c4bf0f1914e7c7bd39f5639da
-# Tag = 5aa60294d511f088a80beb51d0c91f33
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
-# Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
-# Ciphertext = 5c8c3cf39b0ca57368dc7556b97bf705b89588007d0e183f7ef81266e23b9aa8b182
-# Tag = 5c873087ec32d8d4099dd7ae862bdfdcb2e188c673ae94d1
-#
-# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
-# Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
-# Ciphertext = 2a92e33b4930951081d812808c7e583ed7efa3fad0d141000cdea6994f504099f644
-# Tag = 915ba59578f73b3c27aa15b513dd304323d9b81a677e070c0ce8b1683199b55e
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
-# Plaintext =
-# Ciphertext =
-# Tag = 85132ebdb8bdea65
-#
-# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
-# Plaintext =
-# Ciphertext =
-# Tag = 5d7affbceb3a6581169e25281e611e0b
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
-# Plaintext =
-# Ciphertext =
-# Tag = 3966b563ef3ddf934e720cd7805f6c7a55d1d7892b428339
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
-# Plaintext =
-# Ciphertext =
-# Tag = d15476bb9718f32a3973b7a42823ef927bb0f6df6ca8b6bf7d0779ca4f0b19f4
-#
-# AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
-# Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
-# Ciphertext = 9f1ef776f07a9385566e60d077c5a2e5d6021a274eb5742c409cf5e6ee954c8d6e7ff6b86ff3a40963d7f0903737b1209ea7
-# Tag =
-#
-# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
-# Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
-# Ciphertext = 7a37ced5c11949c21bfa00d538baaa564be45eaebc36ee5e3715f20e92de7c68146cf8a28a2774bfdadb584bfe0c8882dc66
-# Tag = bb588f119584c10c
-#
-# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
-# Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
-# Ciphertext = ab941f07a782b76db1a95bbf23dddaa6a1e3173d6710a816416ac1060afe9b76f20f644b7cf331076bd8ff6b499a24d83bc9
-# Tag = bb595cd2c7d12087961d2ede496f9aa0
-#
-# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
-# Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
-# Ciphertext = db101d928228e17d2c05fb665a870b0bfa1e8979915909982198ce735b4d3cfd01dcc4518919e27b299ba13948152303dcac
-# Tag = 4b91278ae197b6dd7cca31e6b472966f18d85a1ffee5cb3a
-#
-# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
-# Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
-# Ciphertext = 074816336911211a675a6d3c8ee33e920326ca0c8d8133ea7a39e5c0a488c783967ef4240266559e9ae05f1ddca21c402278
-# Tag = 68600a63c443e63f31e81620a26f45b550d96b1e16715edfa36620f015df38a5
-#
-# # initialize with key of 128 bits, nonce of 52 bits:
-# Key = c25bf48d26bf58f18a23bc55ee8720b9
-# Nonce = 53b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667c888e94aab6bcc2d8e4eaf10713192f3541475d637f758b91ada3b9cfdbd1e7fe0a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = c9a77131beff6ea7
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 9235945ffab4e4030ff097e5b7960b98
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 55d6d886a9baf3b9cd2f65d3dc9ff7acb9274ecf08a3c83f
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 4b53f16c4456450a9cf7450b12ca82053331877d0ad3e7c624054c2bd45cf5b6
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 222709e208
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 3ba37b69ee
-# Tag = 87defada8cb651cc
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = b5002b428f
-# Tag = db97c666231642eb6be759fbc27a9814
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = f95e5aa38e
-# Tag = bae6356f3fda549e737876dd31094f263d2d7b1e7c8a2e68
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 9148a865ee
-# Tag = a14f5efbb50dc9f253fcd127ab90b1ae1e098b1543cf77b5592a5091b5e6c755
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = b879eab819bcfc92e8608df2
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 57ca5bbea4c3aa923a609ac9
-# Tag = 27a3373e39618d4a
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 4a1d241d295976b22e24614d
-# Tag = 8e2a78933156c3e3cd843496311989a2
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 4622f684646c6a8453702837
-# Tag = 300d6c8315511e2be3730faf8ecc69fe1dc18280b29870b5
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = c0816f3687e8ad56ea95797d
-# Tag = 4a48951f37e87f8b530ecb926148a6fff0142dd0442aaf92599eb44e3c9ecd7a
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 873eac1a9cfab77ece9e43d51c694829e09da4c20caf4f
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 9d377d7bced80845f9a14bd4260e18c2f01f2f0dc211ad
-# Tag = b451f4acc3bffd14
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = ae1df422e36779cc059e422151bfb28f8d03ae717386c2
-# Tag = c5861f19540a191c889720a800d26d68
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = b8107dc9ec704d9974f85219bec7c0fa896c01003f3c6f
-# Tag = 54f8e8f8f0fc17350b6525531588901d3151bf8a13298372
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = cdf15ad1b8160a13591f6259e7c4ee0e6cd188fe6bb103
-# Tag = f9fef1835eac3a788b4569213110a5ebc1aa1e87421b67ca3340d5c71b577250
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 5748248becbd75c146f0c1bb1af11dd56ba5a93225c9be3e34b8a97680b345e5914bef37cd1818
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = af34fd3b0caf844f90d40c8037c8f8e562bdd564e7d9f2bf94c1c4b1ddb11cfe0b346a811ea8b9
-# Tag = 174c21811c38a679
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = f79e39c562ee1dfd145d5b3bda18e8d858e6c9c2a63a7f880162671f751351fb77b4ac54eb4e5c
-# Tag = 9c93f5a15f8bb51d2d7fae0a4f1d3302
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 4d3083b3a6e04c71636c14c6f5ca90d9a3c86cbfda560c9ecf685c6126388c5b18ae8e65aab1da
-# Tag = 4a06586df0e039c966179425e83618f0413c069887642985
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = e30281295f04cdc45237f4e93da99e8285994dfcbdbbc0f3e5fbae14a598a60e89036b5d7462d7
-# Tag = 27ed3ef9a0c80cf0e5080df20f15a25e8de17bfed05f3d6f43e2e462da0b145d
-#
-# AAD = e67708992abb4cdd6e
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = ee7f10a132c354e576
-# Plaintext =
-# Ciphertext =
-# Tag = 74a5d9cc59bb17ee
-#
-# AAD = f68718a93acb5ced7e
-# Plaintext =
-# Ciphertext =
-# Tag = 3975be9d7123ea8dd17b09f50f4d0d62
-#
-# AAD = fe8f20b142d364f586
-# Plaintext =
-# Ciphertext =
-# Tag = 722b9ae37a84d94ad3dfd416b28e8a78c675d5b251ae1833
-#
-# AAD = 069728b94adb6cfd8e
-# Plaintext =
-# Ciphertext =
-# Tag = 8c884c7633c8d662d099509820a4b09a2b6e506da14a8b27c41587dc1b70185d
-#
-# AAD = fc8d1eaf40d162f384
-# Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
-# Ciphertext = 23957669f2d84da158e015d6e7f3e7c7ee6e049c489f
-# Tag =
-#
-# AAD = 049526b748d96afb8c
-# Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
-# Ciphertext = e0d8bd2afca001c0944812bfb68e7ea0b3af9b2c4a64
-# Tag = b4a614c46f6e115e
-#
-# AAD = 0c9d2ebf50e1720394
-# Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
-# Ciphertext = 0c50d4090d15e45ad328314e68164ae21c0cfae97655
-# Tag = 0543e9fe561c7d52414c8d315a30cdd2
-#
-# AAD = 14a536c758e97a0b9c
-# Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
-# Ciphertext = 393d855318676fc5e77574c3216e76cacbd404b8894b
-# Tag = 52b3bdedc69d5f77a2209ab85afd486b4c229fa329519718
-#
-# AAD = 1cad3ecf60f18213a4
-# Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
-# Ciphertext = 9d0e41199c3d4157a1482467032be52685704b594ffe
-# Tag = 8499312b60d67a702f4759a54545520a4de912183eb557f71e7ce141227c4905
-#
-# AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
-# Plaintext =
-# Ciphertext =
-# Tag = 68b9e8d52661950a
-#
-# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
-# Plaintext =
-# Ciphertext =
-# Tag = e5c611444a6e35e0560bf2871f3d3fb9
-#
-# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
-# Plaintext =
-# Ciphertext =
-# Tag = d87ca71c9f321cc153a45d5c9a7f70dca7b0af7e841a8223
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
-# Plaintext =
-# Ciphertext =
-# Tag = 9411cce7aea1ff835cbd1c9e6285fd3273b96c2d6d364900718211d17205ee33
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
-# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
-# Ciphertext = 0a325a9febf9404fb77721d17555711235ec6291f5ffdb4fb820b3666ad385070165
-# Tag =
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
-# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
-# Ciphertext = 9bcb7ad754e25334906f43d59b1f72f0b21a1aa995234e2732f79435236c08358a24
-# Tag = be8ca69bff1e8910
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
-# Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
-# Ciphertext = 6cddc150af6c838bb729e026a52b145a6980bea5fc9b8d6d4599e6ade94ce9ce1e4a
-# Tag = 3db9ec1add8ae7a4c0fee46723a1cf41
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
-# Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
-# Ciphertext = af5083b8298ace4b7ac0f8859ce9d57699c70c2bec9a11573f048e1e6b9bfe7e68c3
-# Tag = c724d993f596bb70ac0c8939c9e29b9ebf846c431c57c32d
-#
-# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
-# Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
-# Ciphertext = 3c615844cce28a3f7877918ee72527cd6396c4b3eae7928f5c92aec0499c18eb4cdc
-# Tag = 615ff0b9443cfeeb0cd498b721e5033d000a1531f08de1ab8cb03005832250cd
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
-# Plaintext =
-# Ciphertext =
-# Tag = eed1b155e68437a0
-#
-# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
-# Plaintext =
-# Ciphertext =
-# Tag = 67a5d4b9bec0540bbe8a3720c6024ab5
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
-# Plaintext =
-# Ciphertext =
-# Tag = a9e072fb57e305b1a211b0a5101dfeea4a56169de658c354
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
-# Plaintext =
-# Ciphertext =
-# Tag = 1c90e975764944b8cba925e5bc58de0581147b0aafc1548d08313684103fc680
-#
-# AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
-# Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
-# Ciphertext = 534438da447e2067c10340725bdc1e2e773e6e0b487c1e0ac5852d1c3a2df02687901d60bdfbf4983430be2fa1fc85dcd6b3
-# Tag =
-#
-# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
-# Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
-# Ciphertext = 5cede84d7c78573f236e504e0a38ffb033ea79c7c76c1229eb1fb26cfb29f70a35c32484841761818cb27cf37a73d78f619a
-# Tag = f0d49d5c236bdf4d
-#
-# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
-# Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
-# Ciphertext = 58f46a195008e8e657b53a13506f77a2c2be03932e7a461445fba5e24bc4ab36465732984c050d39315c678cba25bf7e4ada
-# Tag = 9831743efc823d4d119bdee88bdd6bf4
-#
-# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
-# Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
-# Ciphertext = 12cb6d3c66cdf9dbb87c1e0fcb89920b2950250904cc6ce187bb34be2f64fdd3549a4ec5bdd12d9c6e73e87d1538aa77ff3b
-# Tag = ddbd7755bdc22506cf64289dbeea8945c1d210b5f1df8315
-#
-# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
-# Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
-# Ciphertext = 2bd818fddb47a0d60451f549ce2a36bac008fe540f7a7186e5442e844a31489c45734517cf9df09e68558e2a407a80b908d5
-# Tag = dd63d9aad646d28a3834ab612fdf1fc7775c106c356b553edd620a4d107d53b4
-#
-# # initialize with key of 128 bits, nonce of 16 bits:
-# Key = ca63fc952ec760f9922bc45df68f28c1
-# Nonce = 63c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f455
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 517bb6750ce74e15
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 59312e6b1ac7bab102f8975afb25c813
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = d113d78cd4ad33a9987db82d8dd242fa87fc8079c96327fd
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = a1adf0802c5742f0b7b38d90d684999803eaae0a987872f0bc1db05fb5a6008b
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = 406a50ec18
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = c1ec06af92
-# Tag = 77241593b9e227ef
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 055a7d510b
-# Tag = 922579428985e00056bbcd27aa3012ea
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = d3e978f92c
-# Tag = b00142b26b25d9065665d6371e4bff62e0cde518eb06c57e
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 69fe677600
-# Tag = 5b564585d25890205d043ec60162df08e366034af08c3be85cf050bfb1f6d593
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = c2e64d2ee371edf2c8d6fc47
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 79dbe5c178fa67f678e4bf12
-# Tag = 100ac8ed1f77d7b9
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 002cb53f326513a7ac61373a
-# Tag = f48fc9b6b2192827b91c87495bcbfede
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = f7b84c6c90475491295eafbf
-# Tag = 867e6638940ee876766fa0947fcab5fc99f14265e90bd219
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 5d474b2604b76a5e34015aa3
-# Tag = 6f8fc2fde9d151cd9527690702544e8a9788369e96c107a4218668f066acc469
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 9c28aadfd9331ce6a532090710853008fd21c2d1c402d7
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 703d1e5f851b5071806f0420dac7f1424b872f047695bf
-# Tag = f23cb900812a070d
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 9ceb2b3c8e3678c7ebe4a24e7c24e1a0170739d6005e3f
-# Tag = 22fc398d90276fe1fc361107718e821f
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 1bfad283fb9446d812502e18e3e900407476767fdd5e1a
-# Tag = 58bbac8653ba83689cd384b5f6eaeca7cd99b8add19638cc
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = f05d75bbda5ccb9400713542632c0e55d4c3f9834f1b35
-# Tag = 2b688af20f0959a56827c71cfa79fc91637a8685527bd0fe457d29dbed10fc3e
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 9745ca96e4ed5903c05b777cd9ed7d3a044d223e5fd6d41db1e48e58e777b9777e8815b082fabb
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 2a08e9d06d24c2db032bc5e23c0859a8a952d2029bb4ef53580fc77eebad3d0df45f4df42dbc17
-# Tag = 6c58ec36d9d3bbe5
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = f126ff4a2d42b416cc5824b6c96b0e2f0b901f1b7b4045c34454b2d22228e7faa97eeb82c29f19
-# Tag = 914b37985c69622c0a75ffcf0dcba59b
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 74df1108ad8fb37da0858e5ab4bc5752fd06fc9304c1491bb3a04de9a71df622b491a09311f776
-# Tag = c6466f39cb8007570423fbebb6e31676cbd947093acd188f
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 61e1a6d20ed860d8bd787240a2622e974f8a0f003dd09357eb31f29730a6237f5e6dc0fd56785d
-# Tag = 4a2f704dab65a3640eee4efaba60072e22ab71288c422acc303b6612871b52c5
-#
-# AAD = e67708992abb4cdd6e
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = ee7f10a132c354e576
-# Plaintext =
-# Ciphertext =
-# Tag = 963b8f1b4c4ba956
-#
-# AAD = f68718a93acb5ced7e
-# Plaintext =
-# Ciphertext =
-# Tag = baab6945f8dee5d1a1cb7ecc5a5bfc3a
-#
-# AAD = fe8f20b142d364f586
-# Plaintext =
-# Ciphertext =
-# Tag = 742256032689966c732d2ec45ad8ccfddf084c34c3cef054
-#
-# AAD = 069728b94adb6cfd8e
-# Plaintext =
-# Ciphertext =
-# Tag = ec775512b21ceafdad402a3b5c9732638980619db646e2835dacfc9e0d6ceb2f
-#
-# AAD = fc8d1eaf40d162f384
-# Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
-# Ciphertext = e17f35268a34b8e50c1dcfda886029fa3a8397f0c3c7
-# Tag =
-#
-# AAD = 049526b748d96afb8c
-# Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
-# Ciphertext = bbd17ae6e0d41c834c4de236c13d2394b8dabfa41ec3
-# Tag = 8600622d3de66540
-#
-# AAD = 0c9d2ebf50e1720394
-# Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
-# Ciphertext = fc747f1599c77bda5e74af50b59bded41be03fa6b69c
-# Tag = b0c89839cfec87c769f4bf169f73775e
-#
-# AAD = 14a536c758e97a0b9c
-# Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
-# Ciphertext = 3e9d2b5188e6c6a53cf5030bd4599500a5cf9f1c0f10
-# Tag = fabd0e88bc4b0e2891f09b54119023abf2057e895b18d493
-#
-# AAD = 1cad3ecf60f18213a4
-# Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
-# Ciphertext = 3995d624d0d05fb8c6ea74b995e38c465602f40fc729
-# Tag = cc072eee5121dc677d3f7bfb29379f6975e039e77b90019f94cb38634e2f0634
-#
-# AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
-# Plaintext =
-# Ciphertext =
-# Tag = fbb13ac80f048f48
-#
-# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
-# Plaintext =
-# Ciphertext =
-# Tag = 76bf4a86ea75f629a24647c3497948f5
-#
-# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
-# Plaintext =
-# Ciphertext =
-# Tag = c36d79a4352e1699da77f652122dc4fcd78f8f59abf2dc31
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
-# Plaintext =
-# Ciphertext =
-# Tag = 77518f95ea372df15246efdd7ebd4f72f9c12b415d7d3c74d92d733de206d3c6
-#
-# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
-# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
-# Ciphertext = 40f38fb1935b5438565f70da9e439d6f4b7caeb36c9d0da73b367f1b14865d9967e3
-# Tag =
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
-# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
-# Ciphertext = 212d19f557fc1505a18e97ffa8ad0dd71ab89892e27102670405c7ef0701b6d82615
-# Tag = b15f1f1c8f4d35c7
-#
-# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
-# Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
-# Ciphertext = 2529d74b424dfdc48fd1ddd1760d54c631062ec7a71d6dbda0d8cd91c11992999572
-# Tag = ecd800a8bdc405a972a84a086bc37fa6
-#
-# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
-# Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
-# Ciphertext = a1a2311172efcc9e1fc53665b277aa861379ff3213c04956d2c540c30a0f6aa800bd
-# Tag = d12ed3f47b7e66c256dd36794ce4c0a40d4db611c97ef76f
-#
-# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
-# Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
-# Ciphertext = 23c5cd8fc4903829747479915261b78654bc8631075be35ba3b689332d97a5a9ccd2
-# Tag = 7f9dd289816dbd8748ac743354716292ec81c399d616c53af0f8a59ef04c108a
-#
-# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
-# Plaintext =
-# Ciphertext =
-# Tag = 9b7e4fe8414cdf53
-#
-# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
-# Plaintext =
-# Ciphertext =
-# Tag = 73891d2096fe95e113b8c96c10fdcf1a
-#
-# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
-# Plaintext =
-# Ciphertext =
-# Tag = 6eb6c8913e152b5af68175c1ff4c461c71c83f89a2416bba
-#
-# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
-# Plaintext =
-# Ciphertext =
-# Tag = 71decb11965b05e8d0861934a570140da494797aab7eeacad26f9d9ff71574d7
-#
-# AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
-# Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
-# Ciphertext = f76abc53e591ed31a1efa1249d91dfa253a7e27bdd072ae2a8e7e9e940ac8dd32a4ac5cc1fc267fab44980e99b258f003787
-# Tag =
-#
-# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
-# Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
-# Ciphertext = 04ec8c07eef82836373eb69b41826d1ad21c6924e4aba77209df4df96329bf25c9555a42e3048550b95251487d2a4eb735a0
-# Tag = bf817ca8213c66f2
-#
-# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
-# Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
-# Ciphertext = 9620151e271f710df5a4e6deb14c910ccb0361a20ffed79d1eb8b65e257692f7bb101f7641f463ca030c670c8b934361edb3
-# Tag = 0853d4e7a6276f8ddf1f471319ead5dc
-#
-# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
-# Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
-# Ciphertext = 3c171ed0c7189c9492d91528f901fdb1fe920762a4a3eb86a313884238c1584aa9916322caa75336aa52bbb9a831bcb74c3c
-# Tag = 6562ff882423bb89667f2dbc84b162161887bc4f7298c5ee
-#
-# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
-# Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
-# Ciphertext = 6ea079d914b0b91a55114cecbe1b7adabc303fb036ec1211a7a5249434563b9a4c2e56a32c00dbc8d8bd60d4db99efe79d51
-# Tag = 26c586c8208740240fa4bb2db0897132c27e3c70874ac5af42544d2ce684da30
-#
-# # initialize with key of 128 bits, nonce of 80 bits:
-# Key = d26b049d36cf68019a33cc65fe9730c9
-# Nonce = 73d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2b
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 5f4111619cd1553a
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = bc8eeae299416a4727255804f374f84c
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = bd49129b54cfb1e21b2d7042a307c36ac75ade06e18b4d2f
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 7ea1c20e889eef9b5e04ae3b5338f02ae7c9c80d07cdcd0ad37339e9aaefb6d5
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = fd2a0e4b4b
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 7d8d262e7c
-# Tag = 82ff04794b500947
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = 456912ba11
-# Tag = d0bfc7cacf4efbdd0f941f92151589ec
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 1931e10759
-# Tag = 95fa9610eb80b602e43ae14a1e7fc3d1088c4ab8de74167e
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 8b32fdbcd2
-# Tag = 43225a535245272277691b4153c7ca55d26becc3425bc307f0a65dae7c58b30f
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 6f481310526b8a8b0844c9b9
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 7a3ca34f2c32248adeb4fa85
-# Tag = 418427ea6c383b2c
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = f2fb50ae65eb6dc13813d6c8
-# Tag = 4a844571c94a8a11c9696b6bc7df0ae0
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 82dcbe96870843940f820bbd
-# Tag = 4a0c143ceb09c4a7cdea711eca573e6765a31f1f57cb1f39
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 2fdc92457a855ad1c2ce0e4e
-# Tag = e0f236d3d5a0cce6a0b2058ab1c30a900e1da65e1bfc3c95d754cb8253c650ed
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 3125449a4fa3c7ebe156651accc579b4f31f9556a2ad45
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 82ab7550857efd719899ce14637ebe9989e816f2d6e26b
-# Tag = bb63bd63af0a05ff
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = ec5ae11ead411fa769de8661c5fd5ba5890f190c57930f
-# Tag = 98173050b6ce8da73b1b727a9f04e592
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = fdc75307b6614af182bf9656c7021b945a128ea28b5c9a
-# Tag = cbdb90120887aec18f58743b8612738c649ccd07d6fb1710
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = 75a6340d90880909ed9b8c694a5ba1890996c3d5cc8897
-# Tag = 1f55584b10481541f3026b94dd9dd1585903ee432ade24bb30d2614e4c24e16e
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 758d378bb49b7a21e424d85661f69318b887ac9b098834d78ad2b14d6cc177670eb1720f24f851
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 4275d4fbc28b33ed2bc3f6ba65a9bd19334ddbe12f82633dc58478f0fb153620ec8fdc814cbfdd
-# Tag = 67d6971dec8b79c6
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = 21da8369e61305f240369f1a1e85574f0109b390500111c600abd3c572febca24e90c5b21d79f1
-# Tag = 8e1ae3f1138a7bc53702ae4aceb8f840
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = 6a9ced69bce3e60f20c35f88c62fc7d10c8cfcc39810d16304a2e8ded8c168d701c38c222ccb25
-# Tag = 8ab10e43b188ecfda5ed9f4053029a233842ee1bb52c82e0
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 49678c911ada7cc99f06c755b2a7febb4d132548623731b77bf87788fd12f65145274a46aaa3e0
-# Tag = c3ed2118f7328be094583aa8ff2b759bce5d259d715e5278816439b17c101cc4
-#
-# AAD = 8819aa3bcc5dee7f10a1
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 9021b243d465f68718a9
-# Plaintext =
-# Ciphertext =
-# Tag = a71cf06c88cbc973
-#
-# AAD = 9829ba4bdc6dfe8f20b1
-# Plaintext =
-# Ciphertext =
-# Tag = 9368317d41aab2269e7d94708d843a07
-#
-# AAD = a031c253e475069728b9
-# Plaintext =
-# Ciphertext =
-# Tag = 80bdff5e3dc01cc2b13e6357f684df7a485bb73290d18f88
-#
-# AAD = a839ca5bec7d0e9f30c1
-# Plaintext =
-# Ciphertext =
-# Tag = 687f2b8e8918b80788355b7de8ac8c344c2912d11b046355b604bdba9e77766c
-#
-# AAD = a031c253e475069728b9
-# Plaintext = 7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b
-# Ciphertext = 82aa30d01b72ca9baeb9707e43875abc1b84f57e7b23afc1
-# Tag =
-#
-# AAD = a839ca5bec7d0e9f30c1
-# Plaintext = 87a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
-# Ciphertext = 556fcc8185b12bc0167a879e744dc89804fafa6b01631c61
-# Tag = de6740d406c53256
-#
-# AAD = b041d263f48516a738c9
-# Plaintext = 8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
-# Ciphertext = f65d15bbc66527bc8ec309df5987772ee31db91d0c7bc172
-# Tag = 1a0899f3d1b4265acb5b7580bc4cebb5
-#
-# AAD = b849da6bfc8d1eaf40d1
-# Plaintext = 97b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
-# Ciphertext = 9cdba140217e734901c8414901a019e25f9ff4b138ff4954
-# Tag = efc70c3485600a3b438791e9f0c245629a4419cdd09d8d36
-#
-# AAD = c051e273049526b748d9
-# Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e90a8aab
-# Ciphertext = 203123fd38519bba35c7425c0e16b406dde4f4a04e15ed64
-# Tag = f39f261a3efbd147e2b2bc4555dc469825006792cb9ff4f004505133740d5a58
-#
-# AAD = c253e475069728b94adb6cfd8e1fb04131c253e4750697
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = ca5bec7d0e9f30c152e374059627b84939ca5bec7d0e9f
-# Plaintext =
-# Ciphertext =
-# Tag = 2468fe3d48670c94
-#
-# AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
-# Plaintext =
-# Ciphertext =
-# Tag = b1081f4cec1ab6cd646be0ddc8d6aa92
-#
-# AAD = da6bfc8d1eaf40d162f38415a637c85949da6bfc8d1eaf
-# Plaintext =
-# Ciphertext =
-# Tag = 1fed174acbe536ee21a4a269d551f0755a0ec5ac25a5f784
-#
-# AAD = e273049526b748d96afb8c1dae3fd06151e273049526b7
-# Plaintext =
-# Ciphertext =
-# Tag = f7fa367b7196c77c78b791b6c288c02a96b625b846e33705643deff9dd4161e1
-#
-# AAD = e778099a2bbc4dde6f009122b344d56656e778099a2bbc
-# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
-# Ciphertext = 69c0bf63df493c8130a29dddad9980fff7cb2166aa09361a4f190c73969142cb10100ca842
-# Tag =
-#
-# AAD = ef8011a233c455e67708992abb4cdd6e5eef8011a233c4
-# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa020
-# Ciphertext = be83d961ee14147e3cd6214d7e1e676fdc19a8ca7dad8331781baab147b604aa08f3f40927
-# Tag = f463f98f6630f854
-#
-# AAD = f78819aa3bcc5dee7f10a132c354e57666f78819aa3bcc
-# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a828
-# Ciphertext = 2801ce757e376d9a0152177c8496553949385f627bf95cb996e168333fd33993d080e44955
-# Tag = ce8fe44c491d87383f5a7d53d0451937
-#
-# AAD = ff9021b243d465f68718a93acb5ced7e6eff9021b243d4
-# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb030
-# Ciphertext = 4f23d5c00d433f82794bc66e4ab2d1f3c01125a9bac1f99d831472882e481d19af9dad0ad3
-# Tag = 9ef415ed96e0ac73ecc3d6d30a019c933bc7becb1c8ec1d7
-#
-# AAD = 079829ba4bdc6dfe8f20b142d364f58676079829ba4bdc
-# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b838
-# Ciphertext = 8dff6699a2607abf4051044e452f81620d64599eeded02351afb06cbd08a379a6209168dc3
-# Tag = 249b371536e4061f78305c7d9689690dba5dff4101360461c910ba5ae99f462e
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e17262f38415a637c859
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a6afb8c1dae3fd061
-# Plaintext =
-# Ciphertext =
-# Tag = 1e7d8c0ed3f00911
-#
-# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
-# Plaintext =
-# Ciphertext =
-# Tag = cc8862820230c5aaeaa5426ad1ece4a4
-#
-# AAD = 9c2dbe4fe071029324b546d768f98a1b0b9c2dbe4fe071029324b546d768f98a7a0b9c2dbe4fe071
-# Plaintext =
-# Ciphertext =
-# Tag = c4fbbfdd62e0da97bc83f9ba603fceaf7b00e7a9eda51bed
-#
-# AAD = a435c657e8790a9b2cbd4edf7001922313a435c657e8790a9b2cbd4edf7001928213a435c657e879
-# Plaintext =
-# Ciphertext =
-# Tag = 26db49a2f83ddfaf1966bccc08ee29a0ef5a80fc06f9c253c75f463e07a5a1ab
-#
-# # initialize with key of 128 bits, nonce of 44 bits:
-# Key = da730ca53ed77009a23bd46d069f38d1
-# Nonce = 83e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da3bfb5cbd1ede3fa001
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 72fc2aa9dfec5626
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = cb5671ddb1e46a714030d049bac4e3e6
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 111337b2df5d4a0c20a472ef9e49ebaf275a3557008b5cd1
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = efa6b8dd73ec93732de560ba0ac36c7ab17e746b00c6d7ec3dde349f9a64f36e
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = f6e50165c6
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = a324348eea
-# Tag = f764f4650f63e062
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = d692e0b7c2
-# Tag = 55dd98902c7e70e478b74801c9b9e8be
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 035886516d
-# Tag = a74ce36933a9b9884dca69d7329e78e76fd792a3295a8ef1
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = c74ed5f518
-# Tag = 73a1c12b7bbb1da10f808bc57613662948599047fa8a098a63215445c8b0a992
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 35516e2598a48b7639c31a17
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = f04c072676d946ecb4275473
-# Tag = 58caa361fa13d5f7
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = dc48388aae68cd5250061ba0
-# Tag = 310cb30f7b0ac66e70d738fdab7fab0b
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = 719f6f55785fe0dcb563a1f9
-# Tag = cbb4551c2a83df8b33b98744d0314a48ec915fa9e3fdcef8
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 4748b698ada2a06ad9c3ba63
-# Tag = a161d8867f08840a0550d0f91bcc0d9801fcc8941703e0444449be551ef6a51a
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = 09c5084e667b5125461f2332f57bdbcccd56f259e3ccbd
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 5e88d356c6d45f06eec4e079b1c01f7603b44d8a4f6daa
-# Tag = fdad68df4244f781
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 388e885dba0e6a547616edc32daece79308a218286ac57
-# Tag = 7675543738e93034058d3afbac4e65ea
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 824d4a3b91b1a12222024354784a97b744da3bf2af22fa
-# Tag = f7c760411695f920e4f2c4f547df712c2cc26c986b81a75c
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = 93f0c49bc4f8fba2e8f640f11a22568556b6eca2e998c8
-# Tag = 78704f99f4b85a06800c31a4ea37b9ad825fe5ae174eff6d88f7aa9266ec1135
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = 333b2640ea152649d8c10563d7b7d7a4ae519b1872f2d25e8b5fb80124e7c13e14e05077f0f005
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = 7725f24b4cce732e54734fc34ce97630c736a1c3bb337bfb56fa4f2281edc8f884e38b216ca819
-# Tag = 28040c1d64171887
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = 05d87c6ec71b18547d59be266efb8dae30f5d3fcc4a3c3481fee2f0e71b3d3ce6db4561fd582d5
-# Tag = 866aff568d10353e19e1897747adc713
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = d354606ac33d4f950bb95e2a9babd3ab5cfcac3096e530f65d5d4fe17f750a64ebc4574732bd16
-# Tag = c6debd8c79226f17ca9192b959a3698177899cca008cf911
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = 4538042e140b9a616e4756482219cae23721e52e0a4027d0aec4010b116d6620786671fd4c6b8d
-# Tag = 215489fdd7381fa99c0df68727f78081491d496cf68a2cf5a3e474cc480c4737
-#
-# AAD = 8819aa3bcc5dee7f10a1
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 9021b243d465f68718a9
-# Plaintext =
-# Ciphertext =
-# Tag = ee79299bf39b92fc
-#
-# AAD = 9829ba4bdc6dfe8f20b1
-# Plaintext =
-# Ciphertext =
-# Tag = 3bb2275e67c6c4224512649f8faaa476
-#
-# AAD = a031c253e475069728b9
-# Plaintext =
-# Ciphertext =
-# Tag = 43aa46c80187f9598c09bf82941d3144192a004bca97dcc2
-#
-# AAD = a839ca5bec7d0e9f30c1
-# Plaintext =
-# Ciphertext =
-# Tag = 070838eed9ef934e58ac03f99ff6fc9d663814f749ab942df3b86e89614c4384
-#
-# AAD = a031c253e475069728b9
-# Plaintext = 7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b
-# Ciphertext = 9f9cad8fa7c82175a43e395ed26ec70829f7f11d1565c5f8
-# Tag =
-#
-# AAD = a839ca5bec7d0e9f30c1
-# Plaintext = 87a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
-# Ciphertext = d1fa47053572153cd10de80a26e578290cefb8943543447a
-# Tag = 29d1a1adc77bbf9a
-#
-# AAD = b041d263f48516a738c9
-# Plaintext = 8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
-# Ciphertext = f74bd649e89228225563841e7c2641893e9b6cc24dd983d5
-# Tag = 19eb819974feffce116446131ef05b64
-#
-# AAD = b849da6bfc8d1eaf40d1
-# Plaintext = 97b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
-# Ciphertext = 7e18d89cc51af41909900ccb23478936d10dee1a93757702
-# Tag = b5b8d7e93f2fcbe23151a016a264db0b2bde795663fb778b
-#
-# AAD = c051e273049526b748d9
-# Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e90a8aab
-# Ciphertext = 86eac3782da4ae4d7ab2ddc893e9e5a3852ce0e90b07914e
-# Tag = 4b76f11c70a7daeb21a31d5880e4319655cdb310817c7230e8e1a1dd2d82efff
-#
-# AAD = c253e475069728b94adb6cfd8e1fb04131c253e4750697
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = ca5bec7d0e9f30c152e374059627b84939ca5bec7d0e9f
-# Plaintext =
-# Ciphertext =
-# Tag = 146d93d2f5d3e1e6
-#
-# AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
-# Plaintext =
-# Ciphertext =
-# Tag = 094859713e48b019a6a08936d4c56b60
-#
-# AAD = da6bfc8d1eaf40d162f38415a637c85949da6bfc8d1eaf
-# Plaintext =
-# Ciphertext =
-# Tag = 4e1132bca936e934287363b67191000df66a3df3cfd260cf
-#
-# AAD = e273049526b748d96afb8c1dae3fd06151e273049526b7
-# Plaintext =
-# Ciphertext =
-# Tag = 2fdf1e5bf76b087a02c179590f0283c84257ce9605679b9001bd6a7b3d635d18
-#
-# AAD = e778099a2bbc4dde6f009122b344d56656e778099a2bbc
-# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
-# Ciphertext = 251407b4a09952b44aab4249a33d1ca63a799ddb55938b15a6474c8f64dd62fcd7248e22e9
-# Tag =
-#
-# AAD = ef8011a233c455e67708992abb4cdd6e5eef8011a233c4
-# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa020
-# Ciphertext = cb9b42f3327943301fdc528f50489210080591688e391921a807ca98fbedd8f01a4a607496
-# Tag = 6293bf3357d1e53c
-#
-# AAD = f78819aa3bcc5dee7f10a132c354e57666f78819aa3bcc
-# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a828
-# Ciphertext = 9f3e4cea5037aab126783d9fb47d59ff4999678378ad6ee3781166c061f4da5dc53b1829be
-# Tag = afab2eee6f87cb5416bad721a6bcec84
-#
-# AAD = ff9021b243d465f68718a93acb5ced7e6eff9021b243d4
-# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb030
-# Ciphertext = f244c8d8860d5fc4743e140e0d27672a73f9fb99b3da5ccf073d69863455a1b47bcb3f74cd
-# Tag = 9f0fb46999bee79f332f8d440c8dfb474a92c2569408a6a7
-#
-# AAD = 079829ba4bdc6dfe8f20b142d364f58676079829ba4bdc
-# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b838
-# Ciphertext = 46a66a31fd419ff61ad94f1c6fe3854dfdba23f8d3406049104f776d9cb2946505f5b0c83f
-# Tag = 1c9c1e5a93e913c127ebb9c97d54036b249704900f16bfa6b97711e1ba5f36e5
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e17262f38415a637c859
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a6afb8c1dae3fd061
-# Plaintext =
-# Ciphertext =
-# Tag = 94e00b7c57ebfa0c
-#
-# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
-# Plaintext =
-# Ciphertext =
-# Tag = 499ec63e88671215ab71bb78cb993701
-#
-# AAD = 9c2dbe4fe071029324b546d768f98a1b0b9c2dbe4fe071029324b546d768f98a7a0b9c2dbe4fe071
-# Plaintext =
-# Ciphertext =
-# Tag = c55829248014a5527684d51155c1d1d279fc2895590378bc
-#
-# AAD = a435c657e8790a9b2cbd4edf7001922313a435c657e8790a9b2cbd4edf7001928213a435c657e879
-# Plaintext =
-# Ciphertext =
-# Tag = 5011765d32f5907f8324dcfd47c132b07c1f8bb0d3bdc0257ad33001e0c3e123
-#
-# # initialize with key of 128 bits, nonce of 08 bits:
-# Key = e27b14ad46df7811aa43dc750ea740d9
-# Nonce = 93f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9b91a7bdc9cfd5ebf7fe041a262c3248545a607682889ea4b0b6ccd2eee4fb011d13293f4b41576d7
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 4287fc16f83e7758
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = aa49fa00358fd747bca6bb5beea719d4
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 39ad9444737ceabd08ee68fa5f04518d3f0a7822ff67cc32
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = e775bafc8fadb340760eedfe92093741ae96a13086487753b06d2a0872912572
-#
-# AAD =
-# Plaintext = 6f901031b1
-# Ciphertext = cbe9b5814d
-# Tag =
-#
-# AAD =
-# Plaintext = 77981839b9
-# Ciphertext = 08833f527f
-# Tag = 9da8081892c447cb
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = e6696ec916
-# Tag = 3d63ac7e7982de43aeae250835e60976
-#
-# AAD =
-# Plaintext = 87a82849c9
-# Ciphertext = 01b63da71d
-# Tag = 949c2b9f7f15802089ec8f6035e664cb17e897dc0e2b96ed
-#
-# AAD =
-# Plaintext = 8fb03051d1
-# Ciphertext = 43e075fcdb
-# Tag = bc41c4aac0b7e11355b804f7f83c85d350027011faf3b5bc0f78511a550afd0c
-#
-# AAD =
-# Plaintext = ddfe7e9f1f40c0e161820223
-# Ciphertext = 6285efeb06624f723fc2a1e3
-# Tag =
-#
-# AAD =
-# Plaintext = e50686a72748c8e9698a0a2b
-# Ciphertext = 9c8a3fd6573a9c30f00f9307
-# Tag = 868a0d5c2a1bfa3a
-#
-# AAD =
-# Plaintext = ed0e8eaf2f50d0f171921233
-# Ciphertext = 952844009ca95705214e08b2
-# Tag = 75a721d9bead8fc66f59fed89644ce74
-#
-# AAD =
-# Plaintext = f51696b73758d8f9799a1a3b
-# Ciphertext = a746a55f6525954b2cfd99b4
-# Tag = 7f5972b57800cd74f6c9394b61f5247f02b72cff98ec709d
-#
-# AAD =
-# Plaintext = fd1e9ebf3f60e00181a22243
-# Ciphertext = 7937173673d928a71ca7b421
-# Tag = acff90843d5fc6ab0d88f68eca4a0bf7ead77189efd3c2657f3785c3f50c9fde
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
-# Ciphertext = be8febbe2173ba47a0e9784ee33cea39357ee7aa62108e
-# Tag =
-#
-# AAD =
-# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
-# Ciphertext = 5f068487a3d5730f02d9c64b03de9f1b039b599da6ef1c
-# Tag = 38b0610a2c9f6490
-#
-# AAD =
-# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
-# Ciphertext = 5062c8114152834c81ce32196a179ac27049eae4803a9f
-# Tag = 3d5037c9e88ff50657a4c5d6eed26716
-#
-# AAD =
-# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
-# Ciphertext = 4ef64e180d5ba769c4faa851bb1b1bd807da65540bc27b
-# Tag = 237b1c5f0caa59aab5cf2e0455d0f8fc18195a1222677ecd
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
-# Ciphertext = 150fdda3e0f6b6dee4a651cc6a48b01424b85b3a6bd6b4
-# Tag = 9326d003fbe66b5be322ada2c23663a4e0dc67cc05b5e71cbf79387a280164df
-#
-# AAD =
-# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
-# Ciphertext = c9e857458685193dc403b4ccb21464f6fbef41ba0d52b92ba4b262ce04816fdf2d3758072acb0d
-# Tag =
-#
-# AAD =
-# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
-# Ciphertext = ade1a05fc6da6bb56feaf822f0b90901a82f1a6c86d3bd7966f6211cc19ae5ca3960258358584d
-# Tag = 4a0582ab4b646696
-#
-# AAD =
-# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
-# Ciphertext = f97adb42fac458549f62ed513930a2c4b5a64597bb6f21c0997eb96f4fce77176ef555cfd7da75
-# Tag = 04d57b95ddf39adb2f320801ad7325bf
-#
-# AAD =
-# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
-# Ciphertext = ac47ab94e806ebcabbcc451e692cb8dec3b60d6a5dd9aff11fea97c948a5a4b31a56a3ca66fe0e
-# Tag = 600fac3cc91e0d9288ea11087675b696d8664a6dcc3ba763
-#
-# AAD =
-# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
-# Ciphertext = ed7390a2cf24c94779bd044bff3b456098527f73d2488d6ed1706cef9c65e6d82d8f4a7d350182
-# Tag = 86ee26626a83a16d7332e4f48f9108af95711c201e9f483a32a294c6077d0c0a
-#
-# AAD = 8819aa3bcc5dee7f10a1
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 9021b243d465f68718a9
-# Plaintext =
-# Ciphertext =
-# Tag = 604aac50511008d7
-#
-# AAD = 9829ba4bdc6dfe8f20b1
-# Plaintext =
-# Ciphertext =
-# Tag = 310b38a622eeb807f2c57fc725ff6357
-#
-# AAD = a031c253e475069728b9
-# Plaintext =
-# Ciphertext =
-# Tag = 68fadca05b09f8190ff790f8f5bab01904d2c0c39cd8ad10
-#
-# AAD = a839ca5bec7d0e9f30c1
-# Plaintext =
-# Ciphertext =
-# Tag = b3939abad431e80940b01c13349644ebec775661623b7d9ca0bdd94db3d4dc4c
-#
-# AAD = a031c253e475069728b9
-# Plaintext = 7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b
-# Ciphertext = b0bded1ac0271160fdbdaa82f2dc7ed9d2938dffda38f256
-# Tag =
-#
-# AAD = a839ca5bec7d0e9f30c1
-# Plaintext = 87a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
-# Ciphertext = 82cbb73114eda1a91c0cbd4eab2a6ec4f67ffa7ff3bce214
-# Tag = e132cc11e29f9ed3
-#
-# AAD = b041d263f48516a738c9
-# Plaintext = 8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
-# Ciphertext = c04e351401427ac7bdc95cef3ed57ef142c1c43a4777df83
-# Tag = 09d7df32e6967dc20330b9b18441537b
-#
-# AAD = b849da6bfc8d1eaf40d1
-# Plaintext = 97b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
-# Ciphertext = 3e9c5806450fbfef0c910eb97a833e268611060d7c6d149a
-# Tag = b817125f9da3121bed367df944596ec84c5aa2ef97235cff
-#
-# AAD = c051e273049526b748d9
-# Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e90a8aab
-# Ciphertext = 013cd19122273e7f6064f66ddcd0a269018cf198a9c96717
-# Tag = 0a9b6d3fc840de1834f921706388652165bbaa66fed20af57d4ba70a6142eedf
-#
-# AAD = c253e475069728b94adb6cfd8e1fb04131c253e4750697
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = ca5bec7d0e9f30c152e374059627b84939ca5bec7d0e9f
-# Plaintext =
-# Ciphertext =
-# Tag = 87124bcec2990e17
-#
-# AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
-# Plaintext =
-# Ciphertext =
-# Tag = 68310a99bbe5bcb4c71904c80de84a62
-#
-# AAD = da6bfc8d1eaf40d162f38415a637c85949da6bfc8d1eaf
-# Plaintext =
-# Ciphertext =
-# Tag = 0fc952cf56a86d8ee7206debbaf0eb8434fe956662e92203
-#
-# AAD = e273049526b748d96afb8c1dae3fd06151e273049526b7
-# Plaintext =
-# Ciphertext =
-# Tag = 26544c1c8792b6562826bb5ed7eb8981743baa309609919fdc492e1c792db207
-#
-# AAD = e778099a2bbc4dde6f009122b344d56656e778099a2bbc
-# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
-# Ciphertext = 9465ef900f9d28e81418c572bb6aab32858e119a1b855e4c272efa9cce05636308e6f094c1
-# Tag =
-#
-# AAD = ef8011a233c455e67708992abb4cdd6e5eef8011a233c4
-# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa020
-# Ciphertext = 549929005139e7adc21862093a35a0d771fe17106c4f816df74e543127478ff7850d2ba241
-# Tag = 5994e7ea2f8264fe
-#
-# AAD = f78819aa3bcc5dee7f10a132c354e57666f78819aa3bcc
-# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a828
-# Ciphertext = 1942c07aa249ae11baa43b1a5194f15c4bf98ff9ab27fdab650fa55202d5e7798c77594aa6
-# Tag = f9852bfbde1f5effc2d522f118b48ab8
-#
-# AAD = ff9021b243d465f68718a93acb5ced7e6eff9021b243d4
-# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb030
-# Ciphertext = fce5bf3badf6f08d74dfd05fc2ff62a5abee30006d872cc498df19ad7f2fea21aef6ee7b93
-# Tag = 7e7de7f423a89bad791f7d4edd1eaea3856ce140f7994d2c
-#
-# AAD = 079829ba4bdc6dfe8f20b142d364f58676079829ba4bdc
-# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b838
-# Ciphertext = 0690f57ab9fa727f4bb2d8fb91b9f79dad64f832e9ed0a9ed5b86de0856c859cd8878b4eee
-# Tag = 6bdc79bf57b0247e2667bfad87f2176feb2882f4e24fb1eade7f1b63491b38a0
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e17262f38415a637c859
-# Plaintext =
-# Ciphertext =
-# Tag =
-#
-# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a6afb8c1dae3fd061
-# Plaintext =
-# Ciphertext =
-# Tag = 00c11942e0ce5c31
-#
-# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
-# Plaintext =
-# Ciphertext =
-# Tag = c88ca1b82714b5f6941bebc538ce7131
-#
-# AAD = 9c2dbe4fe071029324b546d768f98a1b0b9c2dbe4fe071029324b546d768f98a7a0b9c2dbe4fe071
-# Plaintext =
-# Ciphertext =
-# Tag = b155947eebee4b5cd7494715795daf3017d01a475b126f37
-#
-# AAD = a435c657e8790a9b2cbd4edf7001922313a435c657e8790a9b2cbd4edf7001928213a435c657e879
-# Plaintext =
-# Ciphertext =
-# Tag = d60d4c8448df7f9aa90403b115918cf8da30d868ba96b8dbfd054060a47e37f4
-#
-# # initialize with key of 112 bits, nonce of 64 bits:
-# Key = a53ed77009a23bd46d069f38d16a
-# Nonce = ff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2beb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d9eff602081e2430364c526e647a8
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = e1f65ed4799ce0e96a16fe5686f85e3f
-#
-# AAD =
-# Plaintext = 3b5cdc
-# Ciphertext = 222aef
-# Tag = 392beb4e95684dc5b97683af4c1c00d0
-#
-# AAD =
-# Plaintext = c3e464850526a6
-# Ciphertext = 77b7f5255aa468
-# Tag = d3294efa2735eda5088ed7c06ee13ccb
-#
-# AAD =
-# Plaintext = 8fb03051d1f272931334b4d555
-# Ciphertext = 1a3fd59a68c58288ff2f9c40c3
-# Tag = 3f61cdf406af73f623c1d20eaf6c34ce
-#
-# AAD =
-# Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
-# Ciphertext = fbd3f6e1c23e78b785790b9d655afc06a4735b2e87e2
-# Tag = 981ea58e5bc51f084d72c6ba322b1751
-#
-# AAD =
-# Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef
-# Ciphertext = 4598dcdfeb2d51a78cf272e1c9814895f29b8ea62c0b320945dad6a5671026dd1f5f392e
-# Tag = 5589beefc13695d2ab71d731c7947abc
-#
-# AAD = 54e576079829ba4b
-# Plaintext =
-# Ciphertext =
-# Tag = d9baa1edbd2016587578749dfc38c446
-#
-# AAD = 69fa8b1cad3ecf60
-# Plaintext = a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f1
-# Ciphertext = f9b774839975ea54f4164cb0c0899c95da9f96cd82
-# Tag = ef0eab96785e0c2823edb202a12bf560
-#
-# AAD = a839ca5bec7d0e9f30c152e37405962717a8
-# Plaintext =
-# Ciphertext =
-# Tag = 4d941d757e6097c8eff3bb12025d0ae0
-#
-# AAD = c758e97a0b9c2dbe4fe071029324b54636c7
-# Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191b23253d3f474
-# Ciphertext = a88c79f84d28437697ed846848ac183d7a4a67a0959bab6f2e23428e9c3530
-# Tag = cec47b9f3d5054b5c42bffd66c88d0f6
-#
-# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
-# Plaintext =
-# Ciphertext =
-# Tag = 0743090b18737818ed9e5b200d0f1f5c
-#
-# AAD = b142d364f58617a839ca5bec7d0e9f3020b142d364f58617a839ca5bec7d0e9f
-# Plaintext = ef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5
-# Ciphertext = c006a061d383e200f2ad353819780d2d63620beabed49c77fed295d6bff87fac20dff95c580cf6cc4439d67ba7
-# Tag = 6cb093e95d6ab61af80dc6df1a463b69
-#
-# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
-# Plaintext =
-# Ciphertext =
-# Tag = 43e2f25ad278f48887e86d62a21152a7
-#
-# # initialize with key of 104 bits, nonce of 72 bits:
-# Key = 049d36cf68019a33cc65fe9730
-# Nonce = a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da3bfb5cbd1ede3fa001c12283e4a40566c787e849aa
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 6a90200ceaf49bef422ec10f4b08640f
-#
-# AAD =
-# Plaintext = 99ba
-# Ciphertext = 08bf
-# Tag = 1788ce3ae56024347ee4c389e014fbe5
-#
-# AAD =
-# Plaintext = 7fa02041c1
-# Ciphertext = c0d79c347b
-# Tag = a4537af01d093470639cac46363fe882
-#
-# AAD =
-# Plaintext = 0728a8c9496aea0b8b
-# Ciphertext = ad5cbf19fb7f1d6620
-# Tag = 3f66353cd96a4a0b8ad1780c617a6e53
-#
-# AAD =
-# Plaintext = d3f474951536b6d75778f81999ba3a
-# Ciphertext = 50b505d2da5ce59eafb6371b96400b
-# Tag = 1227fc67b00c6281b08490e8ce6ed714
-#
-# AAD =
-# Plaintext = 85a62647c7e86889092aaacb4b6cec0d8dae2e4fcff07091
-# Ciphertext = b198d0d1ccf782f6275dfef4a5ca0f2533a2890a72638b15
-# Tag = 7c0386d87d936396ff04d40f1a8a34d6
-#
-# AAD =
-# Plaintext = 61820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d4
-# Ciphertext = 74fda61013e7646a8102f62787961d11e2af80c13aaab80be228a8edae9dfd31097e2a0c0bd3
-# Tag = f1fe2b47b41526e89c9c733a456a24f7
-#
-# AAD = b243d465f68718
-# Plaintext =
-# Ciphertext =
-# Tag = e50a8af84f67f9d13e39d96b347c299d
-#
-# AAD = c556e778099a2b
-# Plaintext = 62830324a4c54566e60787a82849c9ea6a8b0b
-# Ciphertext = 8ea4a9aec57fafdd8015323f8cdbb1cbc7e8a3
-# Tag = 480cd3e9c75be25392ec3c9b363cbb5b
-#
-# AAD = e172039425b647
-# Plaintext = 1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191
-# Ciphertext = 8f958b8b5d492b08d90ba7b5d8f54f1b95c7835c2738edb66adfaa71c8b8a2b138c3d9d2b1553dc90faa6e570b5687
-# Tag = 86f4ea9714d2bc10c2ae500ae1dd8a1b
-#
-# AAD = 64f58617a839ca5bec7d0e9f30c152e3
-# Plaintext =
-# Ciphertext =
-# Tag = 9f8764f4ee751f99cdd6ca3a504eff32
-#
-# AAD = 8011a233c455e67708992abb4cdd6eff
-# Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
-# Ciphertext = 65670a5d28946be4fc4019beee5efe818921c3846e69f2a3015e7db0
-# Tag = a486be8700a19b469583e0bb98d39cdc
-#
-# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
-# Plaintext =
-# Ciphertext =
-# Tag = f6f4081122a75f898496b234e2c41ef5
-#
-# AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce
-# Plaintext = c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d5
-# Ciphertext = 81bf6a6746400b66264ba18606956d50d55d077bc2e0c397bf5b20acb7a620d418555b853b40462b
-# Tag = a6b2a85539b769320d6c979764cecab6
-#
-# AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
-# Plaintext =
-# Ciphertext =
-# Tag = ecc433ec167cc9fc16bb58f2bf9192c9
-#
-# # initialize with key of 96 bits, nonce of 80 bits:
-# Key = 63fc952ec760f9922bc45df6
-# Nonce = 41a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9b91a7bdc9cfd5ebf7fe041a262c3248545a607682889ea4b0b
-#
-# AAD =
-# Plaintext =
-# Ciphertext =
-# Tag = 28a524868cfeb34ea90ec7826f337c5b
-#
-# AAD =
-# Plaintext = f7
-# Ciphertext = de
-# Tag = ee4555f7341372103ab71c55535bdf91
-#
-# AAD =
-# Plaintext = 99ba
-# Ciphertext = ff9f
-# Tag = 4bc0ab83549588db26252d140c6094d0
-#
-# AAD =
-# Plaintext = ddfe7e9f
-# Ciphertext = 1f277bb0
-# Tag = 5cdf45253d3c028fd184558810d05846
-#
-# AAD =
-# Plaintext = c3e464850526a6
-# Ciphertext = fae9a85b882b8f
-# Tag = be5e59244750a36f1307beeb3ad0dd5c
-#
-# AAD =
-# Plaintext = 4b6cec0d8dae2e4fcff070
-# Ciphertext = a78ae059f47f0e07719dcd
-# Tag = 711a5cb5c29fd02ef77c3f69b19b3ea8
-#
-# AAD =
-# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
-# Ciphertext = fd03713013c8e04d6cf2f710340fae5869
-# Tag = 0b5b4593a64aef67c0af2e05f6c2fed5
-#
-# AAD =
-# Plaintext = c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
-# Ciphertext = 665834855377354a8862594b83c3268bbab64cd2692943ec1815
-# Tag = 1377aada741f277657edbfb7b8c4ae86
-#
-# AAD =
-# Plaintext = a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9
-# Ciphertext = 958314a613ec7a0f529184d3220df37eb332ad3ed06669b5c6907424dd7d454f07b6486d6cc17a2d
-# Tag = e6d130d4993ee850b2f0a57bcbfff903
-#
-# AAD = 10a132c354e5
-# Plaintext =
-# Ciphertext =
-# Tag = 16c1b00d915be6e35de375ab24047582
-#
-# AAD = 22b344d566f7
-# Plaintext = bfe060810122a2c34364e40585a62647c7e8
-# Ciphertext = 627d8c6ecd1dd9affd6a3e5179f8ba28ec08
-# Tag = 733d8903e514acb20778351e2671bd3b
-#
-# AAD = 3dce5ff08112
-# Plaintext = d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2bab
-# Ciphertext = 53009fca1f7cd34253e5b44507dd34bb80a9a35206d7640033ee589a8ce656d264b81c83485adb17f55dbc159c
-# Tag = 113f22cf20eb5d5c4dbdad32d8f89c49
-#
-# AAD = 20b142d364f58617a839ca5bec7d
-# Plaintext =
-# Ciphertext =
-# Tag = cb4b7d9aff15027753f5acf81e0df0a6
-#
-# AAD = 3acb5ced7e0fa031c253e4750697
-# Plaintext = d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e36384
-# Ciphertext = 1c80b2634d0d7c7beb8c1a5950a1697556d1b28953844e27c94d
-# Tag = d501234924a86688b32ee02699d2e19c
-#
-# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
-# Plaintext =
-# Ciphertext =
-# Tag = 8e2058a292f7d459c92f586f308a5072
-#
-# AAD = 9829ba4bdc6dfe8f20b142d364f58617079829ba4bdc6dfe
-# Plaintext = 3556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e607
-# Ciphertext = 7d9d405ee2daee5ac4214484edfb499e2214d413467e164c7e3158b49c11ae588631d3fe
-# Tag = 78f852770b66d60e7839982c01fe2328
-#
-# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
-# Plaintext =
-# Ciphertext =
-# Tag = 3d519ddb47fbcd09c435f1e3a9c6844f
-#
-# AAD = 8213a435c657e8790a9b2cbd4edf7001f18213a435c657e8790a9b2cbd4edf7060f18213a435
-# Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758
-# Ciphertext = 0d51b1d0b43e70e0a552121c60ae6fcb24da6120ac2604208a4a6a76fc75077c103cdec9a6b4bc62a9e7827156f204b0c397
-# Tag = e58fdde4564e883245bcf9315e1062d0
-#
-# GlobalTag = 1e7c6c56424f8c1fe0bd042d03da3a1e
-#
+# initialize with key of 1376 bits, nonce of200 bits:
+Key = 039c35ce67009932cb64fd962fc861fa932cc55ef79029c25bf48d26bf58f18a821bb44de67f18b14ae37c15ae47e07912ab44dd760fa841da730ca53ed77009019a33cc65fe9730c962fb942dc65ff8912ac35cf58e27c059f28b24bd56ef888019b24be47d16af48e17a13ac45de7710a942db740da63fd8710aa33cd56e07ff9831ca63fc952ec760f9922bc45df68f28c15af38c25be57f08922bb54ed867e17b049e27b14ad46df7811
+Nonce = a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f3
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = bbe5e399a19e2bc46a043f681199c4c1
+
+# initialize with key of 1176 bits, nonce of400 bits:
+Key = 4ae37c15ae47e07912ab44dd760fa841da730ca53ed77009a23bd46d069f38d1c962fb942dc65ff8912ac35cf58e27c059f28b24bd56ef8821ba53ec851eb75048e17a13ac45de7710a942db740da63fd8710aa33cd56e07a039d26b049d36cfc760f9922bc45df68f28c15af38c25be57f08922bb54ed861fb851ea831cb54e46df7811aa43dc750ea740d9720ba43dd66f08
+Nonce = 5abb1c7d3d9eff602081e2430364c526e647a809c92a8becac0d6ecf8ff051b272d3349555b617783899fa5b1b7cdd3efe5f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 84a558f21f3a59a6c682c4590d27a31e
+
+# initialize with key of 976 bits, nonce of600 bits:
+Key = 912ac35cf58e27c059f28b24bd56ef8821ba53ec851eb750e9821bb44de67f1810a942db740da63fd8710aa33cd56e07a039d26b049d36cf68019a33cc65fe978f28c15af38c25be57f08922bb54ed861fb851ea831cb54ee78019b24be47d160ea740d9720ba43dd66f08a13ad36c059e37d069029b34cd66ff
+Nonce = 1374d536f657b819d93a9bfcbc1d7edf9f0061c282e344a565c6278848a90a6b2b8ced4e0e6fd031f152b314d43596f7b71879da9afb5cbd7dde3fa060c1228343a405662687e849096acb
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 0407ae8dbee55b240dd16834a0000da4
+
+# initialize with key of 776 bits, nonce of800 bits:
+Key = d8710aa33cd56e07a039d26b049d36cf68019a33cc65fe9730c962fb942dc65f57f08922bb54ed861fb851ea831cb54ee78019b24be47d16af48e17a13ac45ded66f08a13ad36c059e37d069029b34cd66ff9831ca63fc952ec760f9922bc45d55
+Nonce = cc2d8eefaf1071d292f354b575d6379858b91a7b3b9cfd5e1e7fe0410162c324e445a607c72889eaaa0b6ccd8dee4fb070d1329353b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667c888e94aab6bcc2d8e4eaf10713192f3541475d637
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7f90f9047a5a91d81c6c4d9dc4b9c4a0
+
+# initialize with key of 576 bits, nonce of1000 bits:
+Key = 1fb851ea831cb54ee78019b24be47d16af48e17a13ac45de7710a942db740da69e37d069029b34cd66ff9831ca63fc952ec760f9922bc45df68f28c15af38c251db64fe8811ab34c
+Nonce = 85e647a868c92a8b4bac0d6e2e8ff0511172d334f455b617d73899faba1b7cdd9dfe5fc080e142a363c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e14202
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 62e07ec02db8f7caed806b1e3500cca4
+
+# initialize with key of 376 bits, nonce of1200 bits:
+Key = 66ff9831ca63fc952ec760f9922bc45df68f28c15af38c25be57f08922bb54ede57e17b049e27b14ad46df7811aa43
+Nonce = 3e9f00612182e3440465c627e748a90aca2b8cedad0e6fd090f152b373d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6e
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 8a34b6e167cd342950d4cc8198e3fdb8
+
+AAD =
+Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef
+Ciphertext = 046c887cfdf2062edb84ea63771b7f289e8ac8bad182ebc3bdf2649c97f7aaa2aaf09b5b
+Tag = 8a4bb30e51beb36b62975ba5e101e50b
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
+Plaintext =
+Ciphertext =
+Tag = 34214632bea9ed43d46769058acbdccb
+
+# initialize with key of 336 bits, nonce of1240 bits:
+Key = 41da730ca53ed77009a23bd46d069f38d16a039c35ce67009932cb64fd962fc8c059f28b24bd56ef8821
+Nonce = 63c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 144a990a573dce2d601bafd071507477
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262
+Ciphertext = f6fdaf27e9da2d15aff5b7a17760a47e6ddba120faab6c975989c281b5f6fa
+Tag = 25d555cc575b30d1f1a679b06251ffda
+
+AAD = 6afb8c1dae3fd061f28314a536c758e9d96afb8c1dae3fd061f28314a536c75848d96a
+Plaintext =
+Ciphertext =
+Tag = fbff145373bb5e0189f6fe2b0820e2e9
+
+# initialize with key of 296 bits, nonce of1280 bits:
+Key = 1cb54ee78019b24be47d16af48e17a13ac45de7710a942db740da63fd8710aa39b34cd66ff
+Nonce = 88e94aab6bcc2d8e4eaf10713192f3541475d637f758b91ada3b9cfdbd1e7fe0a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf40
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 80af6610c416327bd88947a1fab735b9
+
+AAD =
+Plaintext = c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 75784025c1aed92ce4b310cbe8de95cde9267c256aedd82a65e6
+Tag = ee83df8556ab8bdf2aaa99a7a32a5285
+
+AAD = e273049526b748d96afb8c1dae3fd06151e273049526b748d96afb8c1dae3f
+Plaintext =
+Ciphertext =
+Tag = c19c142f7da4ce00ed27d169505b0ac1
+
+# initialize with key of 256 bits, nonce of1320 bits:
+Key = f79029c25bf48d26bf58f18a23bc55ee8720b952eb841db64fe8811ab34ce57e
+Nonce = ad0e6fd090f152b373d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e74808
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 0135daca621b16cdf3179e2d401e2f23
+
+AAD =
+Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e9
+Ciphertext = 65ddfd8c4b065178f6a8d44619b7c0a89dfafb75cf
+Tag = e2c6bbbc891f2c00f0433ed1060e6c96
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40
+Plaintext =
+Ciphertext =
+Tag = 687287251aa6a97c58a6c5bc858d40ab
+
+AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70
+Plaintext = cff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
+Ciphertext = 25bddb6f9bd5782537229dd52ef787e8a809209e6abc0190272b0e22d8e10f959f520cbd07fc044eec0e74c0edb845ae
+Tag = cb9605d5693a1e7540f15d9a7f30fa5d
+
+# initialize with key of 216 bits, nonce of1360 bits:
+Key = d26b049d36cf68019a33cc65fe9730c962fb942dc65ff8912ac35c
+Nonce = d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d133938ac5f2f6e2ee1c7a704b4cc156
+
+AAD =
+Plaintext = 75961637b7d85879f91a9abb3b5cdcfd
+Ciphertext = 03de093cdddf6c6c82612e5e3669de10
+Tag = 5490155541fc88a8208f450058061d7c
+
+AAD =
+Plaintext = a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9
+Ciphertext = 0815b63d5ad612100cad9bba77b1f52d667c5c637b4bf0add14726941ba40cf0458a5a2afdbccc43
+Tag = d931d1f617ddd7b7500ab6aa9798e8f0
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+Plaintext =
+Ciphertext =
+Tag = 73b88935e03861da9d222740597cb04f
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869
+Plaintext = badb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce
+Ciphertext = 899e4fe02d6506ae8f67f936ca04e530a942ec6e544ffb87c0a6ae4c62b8418dbb4439674c8f34a0
+Tag = f30f894edcef80ac350eb5adcc1eb389
+
+AAD = 46d768f98a1bac3dce5ff08112a334c5b546d768f98a1bac3dce5ff08112a33424b546d768f98a1bac3dce5ff08112a393
+Plaintext =
+Ciphertext =
+Tag = 9be57f0a67d11df3e8e76802ec8680c9
+
+# initialize with key of 176 bits, nonce of1400 bits:
+Key = ad46df7811aa43dc750ea740d9720ba43dd66f08a13a
+Nonce = f758b91ada3b9cfdbd1e7fe0a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 266848eabdcee983c4ba7a6e41c8f24a
+
+AAD =
+Plaintext = 4b6cec0d8dae2e4fcff070
+Ciphertext = 5f6d0c8404e0813f91ba49
+Tag = 539ca100934ebeebc9b6b1554cd722a5
+
+AAD =
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = 3ff7413bd9e4022790036f32bd4f99a441acb9ad9386e083b8c725
+Tag = af8bf947f279a3f9ef2579a22b8d1b80
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 316290822e5c0995e942e940cc1da6e9
+
+AAD = 8516a738c95aeb7c0d9e2fc051e27304
+Plaintext = 4768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d757
+Ciphertext = 4e457c12057857f965216a524ac3cbb8d6eccedd86d0b66d416d5c8e1ae97a669c
+Tag = e5854765170979069898b9eb65dfc593
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = 4e5fc382485ce1b6e612574bfec5aeec
+
+# initialize with key of 160 bits, nonce of1416 bits:
+Key = 6b049d36cf68019a33cc65fe9730c962fb942dc6
+Nonce = 399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2beb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9c0c0add92fba0080ffb98784a1d134f
+
+AAD =
+Plaintext = 0728a8c9496aea0b8b
+Ciphertext = 126a43acc824c6d2cf
+Tag = 2d9925422842a56ef8af1284efe033b0
+
+AAD =
+Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
+Ciphertext = a4fad825b5e5f132abad990324ab40af8a0f10d6ea64
+Tag = 08af7c227c124d202a1e58ea5ceadba4
+
+AAD =
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e
+Ciphertext = d0178c6e0edfe80a1ed2f6c757e8f89376cc402feda5396c5548cd086a078c6378cfb97cb84b4d2fd29f
+Tag = 8a350ca21a334ba34f6d0644239bfc24
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = 63bc41c7cf9c2211758cdc076cac247f
+
+AAD = 3ecf60f18213a435c657e8790a9b
+Plaintext = 5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4e
+Ciphertext = 92ec93172c15e1f4f0b03c23108c86ce24e5cc7df85160950fd5c620b252
+Tag = 1ce55cf9e62e5cfbc764b79558a98d77
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+Plaintext =
+Ciphertext =
+Tag = ff0900fb38e572ef096969874433ef2a
+
+AAD = b445d667f8891aab3ccd5eef8011a23323b445d667f8891aab3ccd5eef8011a2
+Plaintext = d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6d
+Ciphertext = 0d75d18f23a5277ff28fd2e0d7693dd522b6ea5df905d1db801adb6bb25808b86b7bd664e17d9aa7da69a806ebca4f5e
+Tag = 3c945d5ca3e18f428ef1502acad51ff6
+
+# initialize with key of 144 bits, nonce of1432 bits:
+Key = 29c25bf48d26bf58f18a23bc55ee8720b952
+Nonce = 7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9b91a7bdc9cfd5ebf7fe041
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 8886656aa52038498fdcbedb99273347
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = 385aad6803dca3
+Tag = 84d72a9550c382c2e73a2d065c039241
+
+AAD =
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
+Ciphertext = e05c31a49979e67837c73f91a0a363a8b0
+Tag = 4298b04186f0cfdea42bb2455ca13108
+
+AAD =
+Plaintext = 95b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425
+Ciphertext = e01db73a57bf5e479bca494ed24d9d46d41f7da014ef22347614b70b09b09ef8
+Tag = d3c14904dac4f05ec3e3448abe2a670d
+
+AAD = dc6dfe8f20b142d364f58617
+Plaintext =
+Ciphertext =
+Tag = 41c145336443f9dd02637144b29ab6fb
+
+AAD = f78819aa3bcc5dee7f10a132
+Plaintext = 77981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+Ciphertext = 5d116dda7ff03701b2e1f4691a2bfc422bdea8755c0055d32de288
+Tag = 099287daf4520c19ca15071cfcc8cd62
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = e183b5fb834705ed4a1c19ec7e62b9b5
+
+AAD = 27b849da6bfc8d1eaf40d162f38415a69627b849da6bfc8d1eaf40d1
+Plaintext = a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdc
+Ciphertext = 9f4fb229efc3d383be35c76ff749997b9cd3cb491e71bb5adb76d196163addaa1a5d649b5d6b07795c6fb4
+Tag = bbeb40acbab1b2cb0a7dcc85bcd4fe70
+
+AAD = 46d768f98a1bac3dce5ff08112a334c5b546d768f98a1bac3dce5ff08112a33424b546d768f98a1bac3dce5ff08112a393
+Plaintext =
+Ciphertext =
+Tag = 5dc8f44711df0ebd9b0bb5bf2dc45d13
+
+# initialize with key of 128 bits, nonce of 0 bits:
+Key = 32cb64fd962fc861fa932cc55ef79029
+Nonce =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c257270f5307aead
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a3265d5ead58b8622275267c01a8c375
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = fb9a01210b12b8065ef9ad1868a55b8a844de3f7f4a800ce
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7242ba58fa98cccd789e6562f1c9a6026188f2da49f0bd7d68dea8fd1bcfb2cf
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 1536764dba
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 79dfa059ad
+Tag = 2ae9e002084aef01
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 88d71b45cb
+Tag = 35b9397b21cd90c1f455a7e5099cf370
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 7daedf33ff
+Tag = 8432f093a48b2ae39f7a3f9a3eaefd4d4aa3254a443c9622
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = bcc4e409ee
+Tag = 7d08db19ae102c32342eb0c76d5f9c304484051d796acff11ab108968eeb7fab
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 45deae65e7f59aa351079641
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = f027a40a925f88f55ec7de89
+Tag = 41889fe2629fc818
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 93d4d881359a85248718737d
+Tag = 839412743c1d4edfbd922cb94e922ce5
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = cf5c50b0a059299b9f01062c
+Tag = 6b39b2b3496c7fb1eae353e27c0bc066c1821cc69dc18043
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 9d9bbbbacd607a6ccf8f8006
+Tag = 6c470e7aad8469e7cf6867c186a72b2933b71180dc1a687fb9209017bb533619
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 1ef93fe206d4d2aec70c994706a2d7681a316a28e15e86
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 1dc2988e1acec91adb7eafc50a0532f5ea54316b2e9f09
+Tag = 2a593d89fe00d758
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 71f23b8768f5e0a44902e071d7be1c6db318ee05996914
+Tag = 65d23e307c00e2daab356ef595a90981
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 3e1c59ba869e1a103687cf01795c48f32d7a734fa3101e
+Tag = 5583839d9500aa19073fad2d87279c89dffaabc3dfd50512
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 6ba468e423c5aa880ab0a090f27bba454580bac9e4a426
+Tag = 445d2b3fb29ab6a7d97489cba3c33af8232b61a17849c8bf83e40148edea2de7
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 6b617b841f6e2fce85cc8e637c613ab7a40306991ecb7bf48fed146447308daf80382a34cbba14
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 23a7570c6e8878f932cc8ca5b58b988956afdbf5adf618156660c66ae4ea828b0450694c5fe9e1
+Tag = dc06457af296de87
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = cec732f7a38772d2578ececa7184d4c332652d09f95833ad31774dcc0c8263aae520849b4a883e
+Tag = 0e744f554afa4eafde0741d95e07fb5a
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 3bf74e6bddfd3286993c88bdb2f674c02adcf0e4f237bdbf809dd60319f185277a2c5cb9fcfb48
+Tag = 8f58df391f0561eb9855d4ae0934accbef65fbf79478fff4
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 701f9b30efcfbd0f228f9ec80913a203e31f4775bc5a1f432f974da5b5452fb881dfbcfd3772a3
+Tag = e6f1227113211ed73bcdd78f9878e9471f661d03ffe4c5d636cebf9b121381bd
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 36b2ee5662b1ed45
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 2e5eb96356b14595583a984393e90275
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 23ab68933e746f944f1b197b96b0e2d54e94659e5ebc9f8a
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = a3020de3c9c45233cf88eff8d76100e2fe40173042e454a5f4ceff5fb1214b30
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 3dec13c04189c388c698c25eb5af
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 1bc3b9600705413fd9f748f2d2b7
+Tag = 623a213b4d9271df
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 22d9caf523b4c108c903654a7be5
+Tag = 94149f06dc63e50a40338e6e39ed566f
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = e3cb6adbfd6570d7f1ff844ca397
+Tag = d57e82d84379b160acecac0ffd8abe5cfa5985df1e874408
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = a0901513a06ff02ad24cf8a6d496
+Tag = 6bc348822731af9d854ae4227470e5aa73738115b45ca427d5a43ad13bce7c81
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 4d354307c4ef987fea92981ee5aa989332f5553e8464ea905382259ac422a8fc79ac83
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = b02dada9fe16df8f207673f8f34e172d9af28b43d3bf21145c4db6f55e21d61c5b96a3
+Tag = 77048c08aae8c255
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 2b4a0d10a70f3f3a63c03608b39eefd6851ea5135f68c11b5cc415c7ab3a29aae040db
+Tag = 0e592c4bdc035ee28c7ea27ad173dd59
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 5faa1793ae497f67d881f79cef5faf45db3361e6681a1d55f4e86f7d065d4dcf71b155
+Tag = e288d43e688704f7e216da4eb592c55adaa88a3e51ca0945
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = cff79e4b4481053319300509395f2041ea9cc675638da74da140ab86801f664128a29a
+Tag = dc5f6bfaf5bdf1f39e569b3e8bd2cb6944dc23efa2bb4310f0c771c601599073
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = b3a7bcca57a8c4c6
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 4b70e798c3bfdf8807a093eb8959c5b9
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 52d4192788f4c9224b24ec20f28f4d8d601eeeb56a783da2
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = a540c44e47baaea2ae4fe73c470dfeb707d8aee365459cd8cb7f28c2c0b29c8d
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 0206a65d46bfacfe110455d449ce130aba7540c3
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 3a5cc5bd5078f4c8c980fde2f8daf24689101521
+Tag = deba21df9e6b4228
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = d98224d5b02c1bb56d2328592aee4670a3680da0
+Tag = 127863bac302ea62eed3568a762ee0d3
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = f9f7c256d997ff9b73e123f2780b86f1c816c03d
+Tag = dc36190e64613afd16f4090eb1406ff162b4529340ab4231
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 6ebdd377525d35001b3281fe307984dcd450c9aa
+Tag = dba9770c64d91ae1c6d62db6cdd3ba0b921cc0ef52e6fdfa95ee9deb020986a6
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 9eed607492d06d9c28e52d644b81f4f632497ad8f3dfef67d05560bf68986252b3466d27d2ed5e1a57a729c9458982be6559
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 51689f764341213689791a95f6c6ab93b7bb0572843ae2c5aedeb70ce2e87e06b3f35b1b87f312d61cdd8007d2fd81ba3e88
+Tag = 4a25dcd4435deb42
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = a80908eb657fd52d85ae6c8f65eadfdbe3a2daf3d98b6bea4124e4e7830c0b710dfedb8fc278a0a0a0e72f75fac95b50694d
+Tag = e7eaac443892c88c3dfa714a4409426c
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 81178a81d446ac7744ca63ae8f8e732fe4741d415a3629b038973fad935bad465f241f24191cebcdac890fe75c8894ed4163
+Tag = 840a3ff26cf166840103957502c35542e9b9470b3bd789ac
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 4bd8f6c6c26154c1e4ee257332811f86f8baf78c7d0093ab4372454a50bb05559f694058a4bcb702861c2c82d73029237485
+Tag = 25bf5e634d3d1e30ba3539adde66dfc02f396ab0d41c2a853fcaaaf56e56f50e
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = cab1947792104cb4
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 902b12f2b7c59362296d2f142ddea000
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = e0dee1833900febb7b9fc53f4f3f1f1e8f6622b7e97cacba
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 2680ff11985d5e8f46f92acdbcfbe1cddc0ed470bf8d410daebd89cacf245060
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = a8461f54d39b094ad4f68806548667bdefa2b7722daae773e70279af
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 5f67bacbfc72afe2590c14fc1905f294ad2721ad86764513ad98526f
+Tag = 09b50ccc9da054aa
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = df903ffc4014962e50221b92a1cc72824d9c476cfee7b9844afd3118
+Tag = a7ee3e5e90af86a02d8a54c06ead4231
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = d96b6fe59d9cf286ce5da946a13c3dc2823772abf2428caa42d93b33
+Tag = aa7dd07546aec6e06a91264b0e2e923895679727c0183e15
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 52f1528781a74988b102b86b5c511170d21ea911ed35bfb7ef33aa5d
+Tag = f78d4d64ffda574104581159fdca73b10d8649398d9af0b9b32b6089495da775
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = c9e994c45382f79e
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = dc52c03855ff0a884bd3297659ed1aed
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 96d9aeb87ab14dd390355dddd668a8a1a0d120bc046c8bef
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 66cece3ada2732f3b5929293c173e765720ffc2ec85f46b9310bccf56a322b39
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 8c76dbed0f043fe68284996a146ad66fcd863019f96ac4ae9448faecd63d874a5a9ec511461214
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 20cb5a62d45a52cb5f765b3c9a8cc2a3ec14892ff388c87ef58ecb489e08c78ecc51efef539243
+Tag = c52c81fee99b8a79
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 03cac0b456f7401aa38e13e837d98dbea9f1f3dce9f37eab49c8df431270e2f448afaeff7d916f
+Tag = ce332a2ccdeaa38c1f302ecf74f177f8
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 79bc7d19961d8ddce9bb2ecd0ca78325b3f40a8e4a4145ac02f170aedb85dc411fe65b245baec5
+Tag = 8c7a01ff63a38aaeb305772fd070f4dbb22d951770b0527b
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = e6c82d9f049d85417a81f3a6c1e06f4da68313e87fad40281dc863e3abd3fb6c021cf448e317d5
+Tag = 57fadb6f555e5f5b004801924f61981123e45087b3e1d693cfd1ca268d58dc1b
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = a8043d065e854f8c
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 46f020350801815c3fb636917b1efad4
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = bbadac9f062ef1af3c95d7556a604d2b5570dcd190820d34
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 9edc390a828f46559ccbbdd5ae61af2a6d8504e69a48674dfc9ac3c7795a77ce
+
+# initialize with key of 128 bits, nonce of64 bits:
+Key = 3ad36c059e37d069029b34cd66ff9831
+Nonce = 43a405662687e849
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c573c668db9a2cde
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 49a5804e793672df058c223218eda8a9
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 3e520289e4410dd64bbac098f84373f5a13799a93b4cff8e
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1462f86d48360f0f75aa8116f6dc7e2b9693b5a5acb654413db300c686b12b87
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = bba7129444
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 8391224c52
+Tag = 1f3a848a9ba389df
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = ea22e3836c
+Tag = 1e337624239888f553f66e4b7dff2c40
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 6bbc8aef21
+Tag = 415f8a207858a94e571a2bfda5ed280a035459593d67c036
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = db43029828
+Tag = 4cc94d738799dab1349f6b95c60b3193f35a74295f2ca22bcfda544b224b237c
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 28ce9dec611ddcabebc3238e
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 9ecfb7663894f03ccaf84f0b
+Tag = c8d14b9c946db692
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 12e624e4d147980570b80955
+Tag = 91fbf17455d8984e1549e8691d6ead48
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 71bc91cd08c052d43a8d5bf0
+Tag = 4177b11d3282717652f331b82aeb9156374ca22e05affd2b
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 2b4416219aa4a008af0436d3
+Tag = 84afab4a839306ebe27e5dd8ed28fc160d8c760ff87a58cdf03dafa6a12b2d2e
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 0227b76c1f04d51e0904be270a864fd360d7fa98bc222f
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 94944b7ac542e82368e5fad4147f1cc7c40d28858fd782
+Tag = 08b9648e7eda5c45
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 418b8c74daecb6ff9bff4a4d485ea8f5f3fd3fe69b8974
+Tag = a470da07888f08c96902a88e63e03ea0
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = bd4ae91ddd48102e7554f52416364d89ef00a3fc7f65ab
+Tag = 8a0b8d08f74fd475b183fcf3d0d69ab972e3b17884973972
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = b4e86dbfdf8f55108c46f4bf6e0e7e3e6269f6b886cddb
+Tag = 28feca673322552f8198cf1fc7e8e3e23ab464c2d2a8df62602ddc05e170ad5a
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = ac6a68b52e4abd416b9abeda553ed24563cba6b6f9c3ee38e8183af40224b020822f813dc2ffe9
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 2099370162f199e32c59198619fcf9d03c5f23ca62e9ceae94bcd4564854959de229c9c6fa43d6
+Tag = c897b557338c1ef0
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 07a97204e88c9a9cb9921cf9097930e002a3fc50d364dbea014c4cd74d05ccef1cb4bda48e0254
+Tag = a5e3e29ec24258b8f50127a73b8ba819
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = bf721016121d2c99fe532fd02b2aee9ca993232968d93ea4b83e7f0aca2a18c2e4c8fb48df7377
+Tag = 8b91f0e9f4b454c7a4132e76d6b6d391654bdeb899733f7f
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 743dbf795a4d9898acd236d98df514cbf76fa8a4fd1f28ae8f609a476ee04fd076a2bac09b70c7
+Tag = 054827132710f3649787818ab92c63fd1eea84f086bb4fba0071f35ef15264c5
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = c7015bba4d8e2b0d
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = c3ca67db5a366800128cb16bfcc2d619
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 541a746b262465d66bfd46b11663711c0d0a6d99523ea788
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 4e31633765ad386a57ae21fad661a54445ddc60d62817331477b064f9ce2dcab
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 901199708970911f0b437f72abdb
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 38f83ce83bc0e8df0571dd47dafd
+Tag = 007d040d02599afe
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 0f52b34f45657d31b40ca0d152c2
+Tag = dddc87ebaea140b3b3193f2eae23d3ae
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 94d6c7fb56cf26e1ee3e79b96bb9
+Tag = 09ffa07a977e64007e0088dfb680a5b34768ed04b835d0d6
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 5abc35ee82d84eeec5bd64030d18
+Tag = a668139b031344833b43896d6730379a7c436b85e7abc4988dd4041021d130c7
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 332e7242a34f4d2a3a793ff792371f7f19a1a4b404c98e0b2b79a8b54cc9fff4a5d190
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 8f0cd16b164da3fc37c51fd5ed48e78ad0b663db7266038751d1214e59adb11d9dada3
+Tag = d4e321ab327f6b55
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 5586ac97bfce4eec9389db476d0f7dcb1b963fd863608c062551cd801bb2ad99619003
+Tag = e3a05acabf5929ff98ab62f30cf3a29e
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 9628f3b8273f375f069444b22bb178307d563a9373d40e47129468c0ebdc4ac4630ff6
+Tag = 84674da9be31c6bc75b0d52b34c9d1daaccfd348b42a1a7b
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = f43321d40d605a351789132778ec4ddbfe2eb9f50c426d84b245f5816dfaa87a184873
+Tag = cf54cdd4955d6c6c4896f7892a261d7b7e9dc400dcbd0030f86fd3c5429c5dbe
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 12354cc75633edf0
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 5c77010dab4820d7a7aedacf0015ebe6
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = bf803e85954b76712604c790a45f79e10dd7e9ab0f52c869
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 60a325f3974cd0369f2d3f9befdb313813da5a631e51ef98686513379be67428
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = c1d0707ac5ed5d045196ad51b5b17c87ea3aeeb1
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 17c9e112056f4cbdb4b90ec97122a1afb6273c68
+Tag = 42e3eef1ef27f836
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 7ac94af5965e971d7bce0ade73af17ab9483eb25
+Tag = ea3a52d59ae27c6a8d91ae5756cc0dbf
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = f07a2cb30cf16af25b63327f5b41e790f4ddac61
+Tag = ff1259225b38b5ebc48b5537d3a26bac81b868cc12d79083
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 86a38441e5400bf9247cd79f11f349e014e88dad
+Tag = 9e4490846a0bb8e9833292518408f8c20f8cde6f62b750b6e2ba346aab8e2782
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = edfdb988245eb4ebf5abb9c7476b47076c37ae18559bd3d6a7dba12e99073db363608ea0c2dbfe52a3c2c835cb902ff3e773
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = d4e7b7534bcb39321ca3e1f5d947b5856a54decc03743b2214853e67345170a9543ec279ddf555d5920f43a9ca2b8726d39c
+Tag = 41b4cfa9ee4f4f1e
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 444ef3909e42fc7975423dc913d16258b4571565a16f09fbcaf02660547cf98f633c51a1a48c0b0251481ffc10d0d9c69105
+Tag = c62bfc0ad8d1c17e52b607e106b519d2
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 074cf9d5991a47686f27e964139fc9ed429c65765afcfb92816b09b2397e33cc33eca03b45179be90c4223e2b419cdec81ac
+Tag = 8f159958db825f91c369e0828b98af5791b6ba2b52c8b9f0
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = f72d2c35ee563e3d12116e5e57b012ac0ee9802f8d9b5980fd8a6b83fb1ba476920c5646e029cdff2a32901ae36c6da30b2a
+Tag = 8ab9b32a8bd02e41ecdcdb480495540ef1a98e38188beea71c59f83a5d3fab74
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = fed5f9442eab657f
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = f56dd58f778d3cb827491ee97d778f05
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = b5c3bf1bf8220c4ad5821422c308fcdff09cec9bc32a32cd
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 72527969077c44b56e7f606b8c558c41e997e0e2e94bef92852a78c74f836476
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = aa35d8d1c3c497d160818a7bea345a6fd6b570161d19586567ba9b53
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = c735063fafc2f9182a48d51766e5d55286b245d59772875f68c134f2
+Tag = f19e9e7796343464
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 1dd5fb71639af22b3e95efbe49f4b5f99186618101a4e7a9cb29be5f
+Tag = e627e774ce97b963120a9be4e6cb7094
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 6c542540d2b25b6ec8a5ab8adcc320ef235895caec25f16fae947114
+Tag = 05f5e23aeec52199b2d81569605d8b47d2775de217c99eb9
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = f312506614208f2878b15fcd1877f3109b1cf3115aedd6bf9097fc39
+Tag = 1a0948f718583f284de252043c916e35764223efc7df327a22160c2d7cf09cd1
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = a68fe52f5c9ab1df
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 4b6ad1f60a60b882065c91a6637b907c
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 66bfb808c4ff6bc4c98bebdd10b04dcc8fc57251f39c523d
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = df0c0b6b9dd6ed0d30326d641dfd14c90c51d1cb11fc9cd5d7760eeb541aac3c
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = bf31a38b08ad11ec8b63e5495422d14695556c01303502d0216d6cba2f7051e545db62458467d0
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 088e87b83fa45a11644cc538e5a0e23948b857f6854ff70086de482ba5287524c6a5a529ef7eeb
+Tag = cb0e80bbf1166cd4
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 00d26600fa1a1e7ca99b894c1f346fa7b25b8fdb7dcedde364937461031aec413a02177200b2ac
+Tag = cda56e0d87855622c289ffde95a161a4
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 478e36aade320ffe032a78feea6a8ac395b9133c46685a41dd7b7a30325734c59213ed57ebc50e
+Tag = d8a9e962427494404d2ca13b2c4dd815c378a5c8e1c5b35f
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 799f6fe70703d63674bd1a6313816fbaa699c85286edec43c9c8c733b70efb5d4beef0ec4468d0
+Tag = b31990acf77426d6f722f0a14ded00fdd3c93ec41cb186d47e10de8ad22680ee
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 5894b487dbc95146
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 2ef165935539576aa9f184c02ea17718
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = a23085aac48ec1ecbd1676d468c3bed02237cfb50c5885f5
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = c6bcaf17d8b8678e9d48669beabfbe469f562eec532b2d5b52efa87c449cfb59
+
+# initialize with key of 128 bits, nonce of128 bits:
+Key = 42db740da63fd8710aa33cd56e07a039
+Nonce = 53b415763697f859197adb3cfc5dbe1f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f01de38c5b735fb3
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d5b6c0aa25c2847186a989df1b987ff9
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 87cf1e801dd4f5f338bd878642b209bea5216f16614da576
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a3c9756a3d9fb78f5553575c57c590e4d31e06fbd72e41d27baa4a00f3873c94
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = ccbf98112c
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 6b5a4ec120
+Tag = a99938c40dba7435
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 46907bf76b
+Tag = 627c1d6fcbc266d920f1b0795d115add
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 7c00fcbc92
+Tag = 5d06ac15c8d823b2b7eb26f98659916d0121bbe97a1a1fd1
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 2e3f9db491
+Tag = cdbdcbf2863dd35d3c43b1c50a49b52d3ee11edf0aae210ae3cb560b0866dd4e
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = abcde4c398c3b761bbed9d1b
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = fecbc4ed172e789940af03f6
+Tag = 16406b3367485c7e
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = a0ce9342721a70a90c667dc3
+Tag = 58508c833afd4e01e0afa87223c80ea8
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 1fd541a0482e7ebd512f9440
+Tag = 21a1c3f4d06a58a51a1a442162646c192d345e85a6d04a1c
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 98f2b52d6be9232ab8575818
+Tag = 0207a1a039bd4e4384d12117e60536707ac9ffa1fa582e314614372ce2583f1a
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 49fb9cad51c7e92d859b674557a75c88c3d1fd7572cc7c
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = b96460ac9cb4595f14443d79acd0ef181c1abe6cb0f658
+Tag = 0786d352a10a1b25
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 42c458451f12c3709d44e36d2c8d8b7fe5e637be526fbb
+Tag = 170469b41bca1dcf15db479e66f7c915
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 5b1eb8c37d0a9cd5113b02a87417d9b5ddb4238dcce56f
+Tag = b8e6965d7635a2fad3bb97aa51b038c9adce7963106cf2d9
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 36e11f9cb68e3da538619ba973885101c7979d669c8d68
+Tag = a46925acdcde5b8545e18512fd23d2003449415eebefb84edc370ef0a08d9f7e
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 6f4625c1878c6cb2dfd60a082a37f220af0521f1c6ece37bd67862f7ada6e603b4fa51fedadffa
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 20e9bcc0c8d4fdcf66682d61e9694a63d9bccf552220b9290c2269c4af57172598ca9a0b37ec6c
+Tag = c59997244f2438ce
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 402db5fee89ba59384bb57d6ce01ab12eb562a95b40d5ad86ae7cc7a0aa597202c6d5588eb1b8b
+Tag = 130920a0597ef972058c8a1370f99d06
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = e3c0a4e28e9837d6946770c3fd0bcf0fcb30b4d49bd61a4aa4416b88a83cfd764198a3931c7bb7
+Tag = ad335b876bb7766036c7597a785e60cd50bf830ce5150d65
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 4152ef9317983bdc31e51e1948362ae1b66451c68934f29c988e73ba96512222ad85b011f401c4
+Tag = 3aab47470d3f4196fe0b912c4bb97858ddf594405aac5ee04438d5b0f9608ed0
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 864465e910bb6f22
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 7e5b3ac40ffa3c1c9226056cf0774bbd
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = ad5fc9751493a28e886073b4c4bc988c545d86a6ffc70db7
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 70f25d2ede47f2cf4df63d62842427f7a6a92a8d30419df49a39c5737a35707f
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 81fde86151462a3cb478af8e47ee
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 941178eb365991c5a91d1978f1f4
+Tag = 5911a8888f045974
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 4fdad42e51078f251690f0d25ed6
+Tag = e8b20f223a33623f9f1250ab17b471bd
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 0e6f03a74dd33b8cc2d90a181ed2
+Tag = a21685b3c127deb18d7e07ce8bc4a04f5ca2fd8bf0ee365c
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 06fa46a34e5b68bb5842dd2f550b
+Tag = 39e1303de8938846aed77273936940831610363e82228c11ef3e6f60fe9bf201
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 54190c5e51edf97feb6ae02cd8a58bd81273222f302f8ca00fac16cb6db7355b6aa0fd
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 28cd29dfea7a6c47b3a581a127d71f5319c650d0ba151e667a9a61646a7fbf8fadde84
+Tag = 5c7f2445eb156621
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 305e20e4bb35794b4d70507a9be23c4bc1be0b9ae0f4766a1d8c726b5e9d9b7e9d8cb4
+Tag = 5726dcbe930b1a75accdf44ace9d7819
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = d7aa36133b0e1ba190fa42993093173e256db61aa124e0057633231c707b936d9b3296
+Tag = 6158f65704de932fa093cf1c0bf57f4c242582a6ee0a5d09
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 8e7898a8d3575c019307d4efe609ce0717b8a1bc68507d0f5b5ab65fddbd67e37f6e87
+Tag = ba3edc080c91cc234c0beda88a257ad96de0af3fea4e51e67a917efd896c5069
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 4e570238bd11eaa2
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 64587fb1293fb8e146a67c1badae7fcd
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 8a3f1852ed0e4de2d4959208bc5a57b5e871139f292efa79
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 9d5c83a916f935c1c11429080a6b2cca5166f5ba13dea1715a6878651bbc197b
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 67fd9c22f8041a49c45995f438c5510f07b88b06
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 0cf6566aa858d796c394db94d61f86f31c12ad33
+Tag = 07e011ce81326d87
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 879ed7c06fb02397cb533ef2d245f63d28cad418
+Tag = cfa761ef76f4e3e6287930308e78fa0b
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 6b55228d76dffbe0fc89856a5853afb7df77e302
+Tag = 7a241bad2f9ffc92715956a4385d8c03a3c57f06773faadb
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 1e6910aa6187a4414226798d065fcab8dcc48c74
+Tag = c854d5356604a0cf3f5dbdb06cd640b99ae235544c3bd19aa6173265aa64fe97
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 975ebbae0a4366225cc784ed34160f3892fb43cdb80b372b4c29a9b858e274e0208647a07cc4e7f82f0b88f426ba2591761b
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = e07e4e961713de115d537a739aa4d4da0295c351be19da34c585c4dadc2db3a53f902f03a3d4668f5723850346de2bec035c
+Tag = ea5c28ab883369a2
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = d2b045f1bc359baf02d762470663c4c642dc4d5e5655215a1cc57e57b9c29877fc153ef77865f5b70acf52f1d2adea99da7b
+Tag = 096604780770de73b6ac9b42c3f68fe5
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 7a80e3335667fa4ec2ed850780998bcb33c53dd35677a7960535f912ceda869a053c3c29c92e2c706b62314ef0cef5ff559c
+Tag = 6b78fe154d77f7e20ad8a880ffae3a268e5615fd187da453
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 945c9830513f2de1802a4223479653e74022dd6ec359a6cb9e2f8fd6b3f4ef30078757d7c90838b9408837f093d496e075f0
+Tag = 99e28c7a09caf792bb6197b2f8e59a0650a1b64c8894dbedf9f23a8851a6c64e
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = d85536be6605a09b
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = d7f56fd8a18a907a248ee32e16c69d6d
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 2aa6b125e018c070f923fcaa28882ce96b7f11fc4dd9efa7
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 1c7c7563f0ff06f27ee1c557796026a7fb8ed2eff502988411df3f70e61a862e
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 579e2338f901bd405e4becbfb02c2087ea8174b32145fafa189d0452
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = abc014e2583feb0cc5ff795364b05b5d9e07eecd76d367a6e6aff318
+Tag = 36d475d41adaa0f8
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = ed529e35862473f0c289d4446974139e093f183573de2206553bb05b
+Tag = ea9c440235433adf412051041eecd2bf
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 4a749c17d277e8e183ae670ea2d9758715f57d1d57625e8e570a7fd2
+Tag = b1bc4d70e3ab206e55fcb90c26a6e6f6f00615e4c638d337
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 41dd6b31cdfa6b9614c183a6a1b85a689b0ce954cb621fd13b5a321f
+Tag = f4e1f035025c91934bf8937f2f5ae76a6fcf40f9023b37cf4a7668059b55f5d3
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 36cc5d3c9ac3964a
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 278a3a8d8192209243de0a30a1439433
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = f12aaa04ad45b5d4be440a15cabaadc02a30c2b29709a0dc
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = b88321c856864a79dbb2c3064e85040da9a90284766533bb755cf89d6d7ec45e
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = f6d7e5117119345049edde892207f49c492cde9f7ab06e22870ddaf20798abc71c121c9296b917
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = bdc067759d881b19cb7a355a2ea5b3860fb020496473437cf9db9d997d7c19161d054234ded319
+Tag = f9270b4596c4e115
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = b0b86b4d85ccc9248573df04d880df9a9fb9f9ea47efe3fe58eb627f80759fcad1b2b1edcbaba8
+Tag = c641c221e317a40d4378151741f15b0b
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 43ac00b42ff5a94902f8b7ca0a18e359d4c6d597880d12fac2050da367e69b6bb42df7b5a976d4
+Tag = b20d55ed33bee294e8781c97170e087ef5172face14802bc
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = d0903161726608dde2ad445f3ac017fee13c6b894f8fe2b8b743d43468cbc50063702430efd4d1
+Tag = 1b442200c295a02a64b1a31f9eb6644aac518d243de096fa1dc5f200b604750f
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 00dedfeb15275248
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = e4fa7e13aafcf199af09df9c0d6524bc
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 6c6eb3f9222cd98e89eadc5aaf685c980f15eb0036c0a5b7
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 2a69d16663196738753f42de5bb4f082038bdc4a9e4f72e366488ee92e1e209a
+
+# initialize with key of 128 bits, nonce of192 bits:
+Key = 4ae37c15ae47e07912ab44dd760fa841
+Nonce = 63c4258646a70869298aeb4c0c6dce2fef50b112d23394f5
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 5d9cf1a04120cd48
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 3a3f256e7e6b754299de8dfceca4b0d6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 891b7bd6878ab1bbe707740d415aaa3e1b8363d942441c26
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 365bd8e6490d578e204c93a0088cfe47e0b38cc56882773cba1e742dfe21b77c
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = f9b7e0c2ba
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 5856d3f8e8
+Tag = be4a85f723669be9
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 09a411660c
+Tag = b2d2b0fb22829e9e4fca1a1618ff9971
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 57fdc06bbb
+Tag = c273bce1a25df2d0920c99bd786483f1c94ce8e8ffe49716
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 7a60cd1fe0
+Tag = 898642dbacc36fc1b52167f23fd59fd9cb38c025d7fbfee6758633601bd989ea
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 7a8e03245262f46872980346
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = a5db2340dba9063d4034388a
+Tag = abe584316f8724a6
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = e219fe7b037461490e52f256
+Tag = a852afd69dc636c7c50ff440b277c701
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 7bd14f10746d87c296b31703
+Tag = 6648cceba2be7d7ae8270e4428b590513b6eabec4edce28b
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = f093e30763727722ec97bf22
+Tag = e4dcfe0def1895a263aed90a5ff926a132d8f97aa85ac7070f1472c57a454aca
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = c2ccbd6f42bddb9435fe2c4a97bfb679a8c898da1187c2
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = b82c070ad8c00df0de3a801bd8a7b8f35afedc4ea99dc2
+Tag = 7613e9db87e4b839
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = e42305dc5ac4314a548d1eff9e78b20b631a90890234a0
+Tag = 4c78b5c1cc208c02fda9688692f46064
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 91b418b493600d02f4ab3ddf0dd9e834395ecde84c3963
+Tag = a517d3017015ef74c6990954eb8dd38a1cd02d20646555e2
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = e50db89aeec8e83477a210c94042869a5ac3d959f3d0f4
+Tag = ec08938e92ccab6b633ba276c665d3000d1241ee41d4969785f9f12ae1a32a44
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = e879c0344953db3f51756fa819ce33a94d8f32b2762f000c024fa141ac9494dee249845fae3b07
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 7d8bd79cab9fae137f32669df7792d1f4e0fd173888499b1ee7527b9a1b31fc691fe8b026e0847
+Tag = 1afb1ac8277ff6f5
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = dad47b79240216a136c2a2f939872d4a8902a6d5f7e45afe1e0c681f7f4af3f7ce55fea0e23e88
+Tag = 56efdb0d526bcbd43bc3dd64d96c3ad5
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 4251a236cd83c7331ed29e962d7c276b764f6aa0036c4d92240f38bbbd9a81da98d8a23a01518e
+Tag = 367eb7a2082f45ce7e843e810fca6fda00fdbad6db0f2c4f
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 4694c0285290fd545a4a585b9d8965434612ab8c2b48e30214631b9dfa71879883fd2df69372d6
+Tag = 08cb6a7a2fca7cf59803a3d446e19dc8ef876496771ffd6fbb480095a11d0b2a
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 3c3d4f47164fc01b
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 991b19e728c79b4526a87ca97fac9fb3
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 6430d665d34e2d62719d6e41be67236115e7bdf02a311250
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = e2d514ff12117f9dce6cae7ee77e557ec1d8a0a2ca08d43cd5065a574726f515
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 9be1fb814b18d9ab1058fd70842e
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 37d38c41a86514b70612d54d965d
+Tag = 6c3f47cc571ccee7
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 4949cafdb36d48b2ba21d9607939
+Tag = 9909096fe46c52262bfe70cdbeb619b6
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 28736e5d21e81dd91af7cab41d57
+Tag = 1873ec3a7a7bfbed18cfad957297f2ad5a8ff4cc13fdf298
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 9091e155a60f5df82886c75ac714
+Tag = d8f719d5f8bfd062771de1b6daa540a0ab8662a48104274b81b797256b20728c
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = a822beacafa73ca8ba0dfb3c6ceb6a62451bdd6ddcbeeddcabd1164a61300f212836f9
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 1ef03fccd83aeb58765898fa93ffc7b8dfe1f434610a381c14bca46d6a4283a3e7731d
+Tag = 6695c68c1a8d2393
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 2cb00b41814ad79b83105d7cda712d15af16d6eee2af9ef38b817ba1edca8c1724bc98
+Tag = a0d91236f9382be295d806aaae062b74
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = c7af492b410b4209f40cdd1a7e341be6d2d621c41ed257c3e165ba1bd5afe9b6e0c11b
+Tag = eeb66a917f3ba8ec5d8a4db217bb77945a7fd712aa1f10dd
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 51f215e0079bc38a2da9a9ec76059ce1e7b46300c08517af37f457599981cdf3cb51a4
+Tag = b3780aa11e8a3394435eccff3d0f69887aa88816f33fd766c56f740935b21a72
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = b16a5ee2f7ca6eec
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 12ae71447494005aebbb5c5b5a80d1f8
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = fff6b46274083e16e4b04c2fc4470b52c8d8c4d043153edf
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = be9d80d82a45ff7e77e9535f9b08a5516d5222c001d2437b8906bc48a76fd026
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 67d178a120fb450da7c99717e062e0f346f30609
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 64fcd0b67205358381464830a8c039b4755b6b4b
+Tag = d037acb17ae8cfb0
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 5cdead6540223a0bd34c23d8a09458fe4dcb90f8
+Tag = a78223ea699aff53a370d2fc83928e48
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = d1789cac538ff960254a6ee8fb64768aaa1f8a73
+Tag = 585acfb1452b3a11184876b3cef13d5b4062c3f480e07353
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 357918e31730ab2524abb8b40b28d3b7aaa8b2c5
+Tag = 3f2aa72ba4b245b36fd761f4fcefb4652d527795e650558fec9e92b111d546e7
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = fa8fa69e7b126eef5cde5b9c2c709a3b4c71732343564d9078694fcfbdff4b6f89882053dc9e652d510ebbf95e8367c2e5ec
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = b8b0d0e53afa91f36711ae9a50e7f58565c5a3ac7ff6cd3086610aea7f31241883d5a454665ebd2dd485beca76d4d1c4e1ce
+Tag = b5d533f11a905cd9
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = ec865ef9555cd6e157c16ce50f371bc4d46bb57e63df480634c17fd4fb092c982eec5560f75d9e17350ecba8af24aca795c4
+Tag = 057835dbe4a9d36796a671a53ba4d636
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 8cb49c33bb3a7912503737c7a99c35242852e5e69b4b28b901b20ce5b83f4446aa18da3d90df5bcd313f49f5daa42d07f8a4
+Tag = b25b450f0d1c291c70bcd980467524ba0f4c4914b4ac8101
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 3c9cd1dc604701a1034e89d01b6ed741eaea2791dfd3e3ac7eec51cbf8e782ff33e83b822a27f062ac1065f2060a56ba737a
+Tag = 10b96effc8c6df792443f24d7a3020a8fd929f59672abbffd9af6acad752f4a9
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = dcdb07a03cce06c0
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = cb16261513f0c66d38c858a43f36a404
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 94221a06f04750141f3e3fa92c85394c196998ff3aefcbfc
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = afa0e7bfb1ef40107c368c341c2e1d6441b6f8b73405155d6827cee309cba5ea
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 835268370835c02cf7d0aff668deb992da3e1b4053127bc7e8a85c06
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 5f131583ac0902eee3d7a1fc6547d89c6c47689de66a77281ea0c1d8
+Tag = b71ead7e40538487
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = d4cdb4ea88a33482a535631a52f8eeb1067b1386da02e90b96363632
+Tag = 2c58522f1c4cbe65975a766dac36580d
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = d9c7bfcbc34d2dafdbf28bdff08cbd3ef44455f43781a70cb5077be9
+Tag = 2b369d68f37f33d2e5783fbf54d0bd6761afdb1f6eb8d085
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 0aad1378ae47d665823096c057256c03d178988b6ebabcdb67fc9723
+Tag = 210c21e4597623303773b1783edfe3e900c6e017de51f3a364d092c7ce7fa318
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 80d50d3000048bb4
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 7b443e9c36d7510c639356b5200eed28
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = c518ecd02f96d441bbd6bd80c5fb3747f50780408f2d9b7b
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = b342703337a1c4dbe5c76bb21b9eef97ce594f35993a249c9fa153c5d1a4d309
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = f793e0b7305345349c6ff5fe5b91477fa1ff5bcc33f60d636940ce215edfd0acb85bc728e049dc
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 480b42a015bd4a32d28892b6628d106c7f7c47d99e7b9abb5327e07792929eb0ae4f32db0496c6
+Tag = e508e9d57d293a87
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 33214e912214095dc2a77b841e065b396ef5d62923217f9969b4df2897a26465da5f69cebcf89b
+Tag = 88fe9a32263e0729ee38cbc6797e7df4
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 33be45fb86e8916407ee5b467d875104c30f99aadc79f2038c7ed6f0db9b1c575dd74f26140645
+Tag = 8ff1d969eb75f3eb599308eee9ca8f8986496b4b7e9fa0e1
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 3e93da072de4e5f8822d302986836c318b3ada4a1635d3a14589ff5db20cb796969e9ab216a1cd
+Tag = 94459906f4ac2fb8124950bb34b1523ae382e49337629250254e30c414a54152
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = a0003c2678b72299
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 16d89e1a94bbceed3bd6671b8973d9d8
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 7b9109ca8ce27af66ddb1a984f6eddad81970b2179838c60
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 777f84396a2af2c0f910cd4106e3e1e9d9df8b7a30673d1d6af3a9eb4e3c83d1
+
+# initialize with key of 128 bits, nonce of256 bits:
+Key = 52eb841db64fe8811ab34ce57e17b049
+Nonce = 73d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ec3f9d4af684fc30
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = b5677631be872409ce3b5e90e68e4af8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 3949b3fbe718a3659d1ece3bceeb3bf16f0166cdf55b10ba
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 98679078026a8a57c7c864b5096e8bcb0ebc76ba0cd57130d2daf9590e90b590
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 5bdeefeee7
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = d5f452950e
+Tag = 1fa70d9164b76af7
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 55be83e3a6
+Tag = e111e701020fefc66fa5012329abe291
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 6e1e3612f8
+Tag = c3b186d5d8586f14d0907cc5a2c3ce525ae37f9f36a5b98e
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 3ffc3d69de
+Tag = 4e4944c0ea5bfa9acb68ded84f121bbe38d9c048fed61c3b3262510d0e633c2b
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 565684b8098058f5abe724c3
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 5d428d3b53d42604adde7eba
+Tag = 568a0f025a682d7b
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = bfaab6b19838ebb9fe4aae88
+Tag = 03bc4fe9fc625ecee778238251a31e2b
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = bdc84948297c6cc2706619b2
+Tag = 2b0abd5e5d780b6e1baabd86478967b79da4cdeb9d1b1a02
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 4e6276d92f9def56625d85f2
+Tag = cf33aec3b17711ace84e38915490214c8174d1cf38d1607d17b1a9e00d132661
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 1715925d3bb7251daf8cb668b7bb1ce75c7def6b915f46
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 945385f1afb37d8c114324474e068cca76470c92a6172d
+Tag = 5ab6407cb916f91f
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 5664a2e1580b4d530b30edfed9d0b17afb0089aa9e34c9
+Tag = 6241ab653d5720529fc26b858e400131
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = ae94469f2603334d7cbbd48c99674256251b43e7938ea4
+Tag = ce939713384dfb3e0b466ca17fd069c3e4f51533ca4a2301
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 2b1b043e8563bf1b58b8866536bb01cd256f083198fac3
+Tag = e7a5c603aff7fbe357a6de5be7547a5b7fb10eb71a81c8e67942c4970ca08a7a
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 5727e96de9dc5f364ac84c04c8d275cd0773bd935725547c66e33159556f82e1b036df43a1990d
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = bbddc30fbca9dd94ded431b51c9c728f94ad3c6c7855a85e22697b6991d1cffdaf7684f7ae8afb
+Tag = f6c0f142c1affde9
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = dd48f3255811289ceb2ad0438d2e6340d2cd8c54be53cab4dbe703c210ed7187fec47bcfa29c6f
+Tag = 0a919ab65615c048f69e140b3499a318
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 4a114b0a0299a22b4cd02261d7f660ad76024bc8a25cb9b6562e0eafbf113b484a0e2eb9702c0d
+Tag = 5ce96860a4e27c827baf02b9c8dbd1eb2bf6620c4ab9ade8
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 7bbbc8adf730c86da4d2b89a48462ade68c4c373ff1deee525bc8730245fd44d0943d78b1735a2
+Tag = 5c0e61374a3409722b7e3db0d2c26cb96d59e34c9171e98341f4c14b9abccfc4
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = 633ada10e19d0e95
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = c19c7c32ddb929662e01dc603897bddd
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = 32d1b20ca05c82bcb0073472babb200a58c057d21691522b
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = 11ae3b92353c2148120b944e4ef0623af6a4b6d114767e365370bfb9129bd01f
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = 446cf8f9ef4c89952dce894f6bfd25d0
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = bf98f647e020671f789c24a436251581
+Tag = 61d14fe682f075b0
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = 2042e7d79add4dc5415116a94dcbffc8
+Tag = 7a6916e877d555e43d3059e5246ea8a6
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = 67fa98704ecc6d28b53c2105b8cb7744
+Tag = 64c89b8734f7be9301a83a6b1ed55a7b774146334b916e62
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = 5c2df6eab54a2f6c6be510589b667d70
+Tag = 942af8ac0482d01439aec934816cc827d7ff9c6a9885df738ba01eb15b368093
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = 8a7b52eb2704716b3f7befaec3755f116e80f456c2864aed8d9ea1a0eb674da2512efed1e067077d
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = cea7d8c02d11cc9c6c7435bba1dc7f162aa6b565a70090055dc90fa133f5c13986f5ae647c34cdc1
+Tag = fc27cd9a225e9aac
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 91a69d72e2bf41ab6ea30ff092f4b94cb2d26702e55982570077b12895f329cae218669a9e9d20f8
+Tag = b1678967e65fec170ef86c973d62fc3a
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = 92d1d82c9af7ee2b3e68b7b923dea7bff481d677fff9738777220cf3a3d4e523a9527f4a18b98f7e
+Tag = 8e7f221b8bfea7c07715428af7276c4b6f8f929fdb80fe5f
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = 2f5626ecc1edfe26e2110f96cf4353d88917302a084aee9450b10c55421173941ddacccf6fd4074c
+Tag = 4ac40ea1a83c8b43564d02b3112819d2da2a31b6dfcf30ac248953949bf30760
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = cf04c2d861dbac8a
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = 487ac1a9ade8492bfa3965bf8f6cff3a
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = ae1f3511477518c57bbbbb5ca7b9fa507228aa60655881e5
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = 6eaf0b2af0de1b47d1d1420aa16729d2b4ff0433d152ccd284ece73bcee422b9
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = af19d4c675e79ea3d7bc2dbd9030fc2732b3acbf3e8411b6
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = 447289611d625f0b672d402e7734fed7fa0eb114bca114e4
+Tag = da97a33eb8b85b67
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = f6716111439219a0258f7e4f8be15b3f3d5b55d19706f3f5
+Tag = d6fd768a99c68fb5c9328c92269c1443
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = 81a647add0b3b0626b3656665e5fa58be89c3523d3883606
+Tag = 73ae026412abf0d1d57abbcc0b004f5afce1b4f0e3756b62
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = df39cd3fd8cff12a212ae6adc2907c7b211774d9e5034714
+Tag = 7d266042b3499f9668619d258868ae29ef8a1ae5d3078d20af9d12681d0f18ba
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = 300ef30f9416e1af
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = 26c08b700224ce26edd193cd4a304239
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = 454d90413ae61aeddc059af247e02f948cca8ca7f2f7e048
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = 94214f9ba55c987b37f8a66fb8efdc9fc1ff685a0d23d2c9ee4a23d7f48dbd9b
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = 1e961bf5039442ddef30e97efc6d3006bee03946889893f691d47cb15933f733d859
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = d3e7012bba9bf695fefdbd01ef5a4c51432847eb189b7269e154c153566c7a9c2789
+Tag = d3077531f1893b4c
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = 90501b5a13bb93278ad58c4625301e4f54527ae772fab9fefad969cf438629f63feb
+Tag = 64ca5ea05b4e5afee3377a11fdc913bc
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = d5f7e55308b1a328d6ca2e798f738bb690128263ab4d9ffb3d4832aac522e16832c9
+Tag = 48d5a8dd5a750907a4889bf360256f842459bf86991f79da
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = ebed339ac83122e1c47aa79af3a4e13ab0f24f43c00b0d5cd9ff9a129315933ba381
+Tag = ca38384a722ab520af59a1af3995bea58ffd730c5b30defabecd948719638dad
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = dab67d70c586b854
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = ab2350219956b07d02ab0f9da46fa035
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = 0c07aa05775f046a5897a7805a3e52a5df0ccecbd46d76c1
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = 2fa40a1d66c7812246fd3c9ee7ff28f777efb55eea0a6a8341639845efe7ae5e
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = e66aa6cec08acdceba9b1e6538d9fcdcd58bfa05a704bba6fb185ad662c1a1bd764c460fdb041fc91fb2570ac321c9ed
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = ed5d9eb35f61a03e893a0b14654f4778912de4a00ed675da6b3548538ef18b5a0d144e359cf40fcfb4c47868d93f0192
+Tag = 6d6abcdf34312faa
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = 3c937834e46ad473c35e14c35a628fc6f9bb8c60277717445352d1399339314651b84b84c00e27bfc5136c5cd028246a
+Tag = b8eaf56d0e68f82ac7ab7854fe5f1a93
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = 9197c92446a8f15c29186b6998d49bc54a6e0616fee5c2dcbc199a537d785231290e0ff14cccfb199eeb74a36c4555dc
+Tag = da54a12c6c78d24c9b244dacf94379628db6ccca9dcdab1e
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = 66aa91f0e3e5b76796567f23a3e14d7131601562c88043d1752501e6cb9ee22c92fcb54a8cff22c3070d1d215203da9b
+Tag = 5bce7dc98f773c642a07a84d453136dd1c897822792e077f152c34624f331568
+
+# initialize with key of 128 bits, nonce of320 bits:
+Key = 5af38c25be57f08922bb54ed861fb851
+Nonce = 83e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a1
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 33c6886a75558470
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 317e3a631888a56aad4c1ee482ce89ae
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 580873c91ad3f23190e91dfaa7c0fac13a84f78825010ccb
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1f4248f1b764463a3716e752acb84fa4b653e3609ec7bf71904144604e5ccc53
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = bdda3298dd
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 5c4c9c28f1
+Tag = 075aa59b618cec47
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 21914c7cfd
+Tag = 1ac5d263af357a1a819559cfc838957c
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = e670e37036
+Tag = 5a6e023ae43c7ba27b80da673e8da5ebec5cb78e52869065
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 752bf9072c
+Tag = 5d7ac8a32f75b3efa871eb4dafcc46080d057d2565117a035b86551ea465cfa0
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 88ce16c77c1dc5c155fde9a4
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 20beaeac25cba8284de4e12a
+Tag = 8f4560e157dc76c2
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 4b8e7f9a343dc6facbe7109d
+Tag = 0f0bf50ede1ff1845b431758f9fc4c37
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 130958faaa50a03f4e45fded
+Tag = 0abcdcb6721e63d55de64880ff813cb1d9a51f279305ebc3
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = c18a95d7f05a8d083d5464e6
+Tag = 3d9a8cc0f7dc0ae00c4abbbe163d53705ee1c90ceeee94c3b3abf3ebc5f6f0d1
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 2f98a72d459d2acbaa45d50f1706a1bcc1151f15b1ac39
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 62898f252d32784126eed963f5fbfa9fabe23c63a180c1
+Tag = 581820f2774ec539
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 8fd95206b34ac713ae730a525020588cc0797dfc1d0e50
+Tag = 4366d564edf5f10a9e7dd6b7a19893e6
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 0a3541d8492008fa8b4e7b847d6f9dd88c31baf8e95df3
+Tag = 46129a971085e56b4b0c6049dcc31cbd169f4996153ecf5d
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 2f4ea9dafc472204ea45af4566aa1f81382244944b6cfa
+Tag = c93886f11a528f088e203940eb7200258e924eb0845d5de39b91d9f577a82bca
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = ed8070ae2d13cce235e9195f39cad658367994edef0f99827cea1dcc26126e713f709fe6b30e46
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = fa8ba14e87e9a76f281104423b240290ac3db5eb53bed893d13b2dfc79d281b12dbaccb9689c55
+Tag = 7b1d463602c4f47b
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = cefa642470d48b0bc07ff5d3095d9a02cf69f5cba4456f804d1f26e6cf757b2698349370dffd68
+Tag = 2b155898f7f6cac331a7a4434305456e
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 6f83aa1e58b5904051262ae78868cd4b950fb179c34b8d15dd75b27a633fd5b828226f20e69f3e
+Tag = f8e640ea6b2ff5c605bbda8e1d92d81ee56f90d79cefadae
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = f17bf45efa7c8104a51d3b32f1bf89477baec26bcae6efebd90bc06a96a79dcb0b5b16989d182f
+Tag = db91d29cea7dc3049a0e324c31d6d1a391b5e6c97043521c9c8bd2f02ab4961e
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = 9c2bfea21d84095d
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = 3654a996b299267bdef2ee6365fb8458
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = 52c8fcdf77acaeed1346d2fc75a31237af581a0ad1839f15
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = 308a18912768ad5a02cf30edcdfc5f1c1a1c444a47db7165246192ad1854ac01
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = 8bc00291fa7b0585282241056af9b07f
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = a0c0e8d2f58b582b167a00782137fe3d
+Tag = 7f5dd38259fcdbba
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = 0b9698e76fc95e74c17875278ab6bbdb
+Tag = 122bcd16c6e8d5cc7b7395eea6cd3863
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = dbd205ba35225a79ff1cf5b67c95ecbd
+Tag = 4f121807e73fec40c80190d54a44b8f2b3ccf3712ad0b846
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = 24324cb20f33a884205be98266c73bea
+Tag = e8851d955d79962e52405269c41274b1b6e9f436e2029cd63df0a0de12e8c486
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = 94cafb7bece73507f3d4651e3e38a44861a71919c2c9a40da6b7d6e81ae3f5cfb8d0c9f4ba6c8609
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = 1a787ec69cf48434a1a9ddaea5b2ff13115e7c587756b3146f79a90b90a225a122ee46822de04339
+Tag = e2756cfd5e2d3543
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 1ed653991d96a33aa66dc9021dc8c91507c505caef2322b241387ca20d7008ab517fe0c96c76559d
+Tag = ca0c357a43f49f58b98ad6538e818375
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = febf40050e7d6b2750f9cf6346a8196580f16ebe72c0b2cd7f8b76755036aaa5c478a935f7282f44
+Tag = 0ea19e4e7c3158cd617d6e5e58ee0684867dc50f4f65ab19
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = 60a27e48774bd7944d283f375e703803ab90aaa49206248109327b50f52239061b4eabd1a5f45429
+Tag = 35a9626b6c5ab890a6f1ddb51fabce072284177485bb6c4396c22c16651b5eaa
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = 37ce2a4766d4f600
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = f911b2515fd2b355baefbbb6bafe380e
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = f4676e080c21abaebb9f41058f92ad646858d805ad10e5c2
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = e3c152adc177ffc95a1a8a1b0480189bdfe67cbc6eadb2694a7d5f420db83868
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = b19dc93693416101902ce076b7e91627c9b4e902828f6369
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = f388ed4470a0ce45d1442bb9667b48c0b1ef1695c4809491
+Tag = bd781d2b3d2bf51d
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = 64888c085894b42bd22bf1b0ebf00f1630b9a37d3011edef
+Tag = b91b97c8d8db75d73a7b32d424574547
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = 39ecd0e89eee9ad862263ca0d1b7476068d1be0fcdf5721d
+Tag = 6180425ec307fbbaaaf882972571a09855dea06cd5ca3402
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = b1074a6c95232cf26cb192867e473cb757cbbe9e659ab3f5
+Tag = 1cf6d4e8e888c69d1c4bb987bccda34aadd3c3076c1872f686a5bd12ca6b3c65
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = aebd9cf884f74757
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = 0d962653b4ae7abe67b1107d02ec4262
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = ec26c17d22565218fc93518ad3162d8a40686674fd7f3296
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = 60c4b9e709b8bdbb5f40e11e65876c248962685b5e1f447dc331a1e22cbea2c6
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = 0bbfcb099e0b51c45bd8cef5ac667f869a9ab37bb5806941c34d4835913babdfd1be
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = f9fc9fd9994c2c07450d234b702c94760e478db02daefa6da971a58ba80e27ec1332
+Tag = f717e153396f6d35
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = aca9ab8ffc23e0fc59f2b3b3c56a12237319595006c23e2339c8a28c1eac1d668682
+Tag = 33106fccbe6dabfe1c404decafb70163
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = f230fab4b5caea8b23aafe2c0bddb834315cf19425769da3561ea428b96971f14e24
+Tag = 4529511b9a0f1e1d563cf098e518b074284cba7cfa697a46
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = b0f27308679344eddd009ee7a34797266d24654b5f0256c0241e5df2943d56037ac7
+Tag = 73a222bd7571c507fc9d57b8bd467d4838ab600a587a2801aa8f09b27d4871d4
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = eff98cee9f0d33b6
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = 1677f99114a5b2512c07f2b3630c0cc5
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = 24708526b7fc02a0e9d860317c619983151f11d5445ecacb
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = d58de5c577649c65cc5e70910be8102223e0fab6b45294d242c2cdad1b4ababc
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = e0750abe2ca1a6916bfcff289a5fafab3b5ca7ff1a0af7c610755a035100ecdf056c6f1ed7e575a7aa51522e1cfb4711
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = 5e468462de8df190a0ae118794cd5b5060691fbf6c72e6c43d19681a4dd8ee6dc5c12ab761115491f98b4da40480c746
+Tag = 5e6f0c7569da4969
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = 96fcd6af42e60464054efbfd398f4167c63258c7557ae4e1867ab49ebea19ac258eaf6e364942b7fb3d644868e65799b
+Tag = 48d02a5fa9eee22b2ca24cc058002552
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = ce9e3b8a23271c857e0c83b70419a3f3857fe5cd9281ba5b66533fd7029d7e1903517c48b71fa8a21e4dc00e76968a0f
+Tag = a03f35ab5b3cc1e4eef8cf7f3417f840215caaab795d46fa
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = 60e96cc6d9316a0aefdf3b78e9a5dd40930e7a1b3c185339b1270fa0ed79e8c31d809b6742b4505a038783977a763465
+Tag = 96bb15d078716eb3825fc993f9a0550236a23363a04852f5c71fcf73db02ce4f
+
+# initialize with key of 128 bits, nonce of384 bits:
+Key = 62fb942dc65ff8912ac35cf58e27c059
+Nonce = 93f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b51677
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 571313513bd4262c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = de6083c874a85dd899452412fdaf07fd
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e5b166a31961513a09fc22fc129bbb1000126ba9f40df139
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = b6c882262055a78a773bb4b6c313381d32f3566ebe736ddee9b1f4f6e7c16fb2
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 5dce2896a0
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = f8646ef4c4
+Tag = 197acc5cae6bf7c0
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 208b24a97c
+Tag = c283bbb8d77b14f25e36235f860dabea
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 383068884c
+Tag = ce9bf97b3c22ce2e8e9c4f9a17bf91e393e480a7de25098a
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 8cd6fa0a49
+Tag = ac6df31c36a94d784d50331e3923e1000907e5d1f3a228215c7262de3b0941fc
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 8d443fa2b4320b6a44549806
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = f51d37020cc24e65c2376d1a
+Tag = 93de418245e33671
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = cbcba4f882709cee93e9f37f
+Tag = d852dc36025e92ba08d90d9c8025d9fe
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 168e8f47f2e209a2b35f2d59
+Tag = b1b4ae787512ee83ee240120ced75a265bb06e81f1e07849
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 2dbf65e63e9065e35777aeb1
+Tag = 9f2a94d42f1b274904e44a3749dbd7159ffa5321a6de03a44c50cd81cedcf2ae
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 6c6f2c5e1a4f580d0cf864c5ecbd0dcf37cda8dc3e2aca
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 3844c4fd2f14c1d9697411097d3742b8f82f17e9d2dada
+Tag = 18f33fe8e1c28393
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 3202c93475c720f5e55e565a60fdb5c8c45694f8b99fe4
+Tag = 73215e3aade83c700ddb16c8abd43c65
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 6a254459419e8151227829772fe3af83634df20f6df4d1
+Tag = 4c0a7aacdf0d52138449ccfd600416e03b73aec612f5ddda
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 131c3a5c1707d2a4917fc8b23e8095129d7529c6f97340
+Tag = 7e1f74c26479cb2165aebea892f90d8bfeb34e318d0e18f8dbb9d3a045b6cc37
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 6effde99cef27db4b0e61974f02fd4f6da8fb32186b031a6d7240c44dc28a889aeacd06218e5b3
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 0c2fbfe9e3a9843266ec035fa18b8c47d8deb200aaf79ea929035339c13ef43a583bfbfced0bcf
+Tag = 60fbda8ba378104b
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = f9adeaba73e9f078ba884ce0addd2810de4cb1f382bb10d9258297410534c4334200d5ed0095b5
+Tag = 7f2b6be7fc815aa25917fef343f4adf7
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 6748e417c5442bdda9f7222a863284787123e49215d4c6fcffe7e5bb4915a19767ff267acd13a3
+Tag = c7a083621308bc8bd5913446de4b96a07f653130740eafdb
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 35f7b6ce274f780cdf1cb98f2f89aeabd18dc17b5a2edc27505e45895789c2643fa29cdab46127
+Tag = f50073c04086248f0dce842ec7dbd2a9da2abf037210c32d49cc06b193b9757f
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = f5e4675a3f53158d
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = c38f82e37699c876e17fefa7f787bd2e
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = 064d9b4fac9682792fd36cc0174a0aae72a86921d7a22877
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = 53e0bea2ba4a71b762e03121160912353e81c0d975fc300771d960897f1f32af
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = ac5adb532f7d9e16772cdddd58e1fd45
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = ffb12ceb64e0ced771fd03ee31cc2554
+Tag = f5ce95f53ce55519
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = 17b0678aabb70d6bad68db105a3d3f5d
+Tag = 4a2b60cfa63794771f4ad7a0cb0792f5
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = f5c779f93a1799c7cc4d7ee5cefaf07d
+Tag = c95c2e0fb4d7d13eb61f3b075194e5c4485d2d399bc45db1
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = 80beb3540e10b10e13d53ea9ac4b2a53
+Tag = 76edb785ec99c8f9116cdeac1bdef646cfddba96d88e64c84599785b00af49cf
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = caa8307da38712ba141b0aa3fa61b496b4b81cb5fa966b33e7d7725fb58160e3069b010af355c8c7
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = ea224ec7bac4f317bfdf5a728e3fbf68cfc71005e649ccadfa0b4614ec19880f30fad129a910389a
+Tag = 2a70c062a8a80c14
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = a15f68ed18b5a313b299f763a2b0fb6bc55b43ed3a61731f6ff9756e6096995604b54b2e5f43e7e8
+Tag = 06e3984d53e8588daaf211f5d918662f
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = 45807d264008a91cfeda84d58ddc562c17151b80f57d8f8c78ecdaebccf6535e731eb8c6c9b37ef6
+Tag = 2f2c98d89caf21b014800841d0bfdfe1f6f458d1ace3b94c
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = 8e6367b8e319f5304c3cb8551c472016a3800f42384c336f9b21ef454938be8183b736006b922f19
+Tag = ae42584e785e9904e4032103dd6d01873f59ff7c878b6096f89518a5e93776e8
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = 4fc8d21cdb08e4b1
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = 966792d102b8c89b4381d07c570efdaf
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = 7277214a93d5b83f2349388aa8220b10d520d07f83adc041
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = bc820ae6ad83cbcdd2b13232b5641c06483c27cdf8cdc2cce5555717f3f7c84d
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = a10667884bd3d1d47cdae7ca2ff2ac8fbcd24ed2522dac87
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = dc17b6e4d5bc1632999e960ac529259499c8553c4b9951c5
+Tag = 98df3eed14cc7ce6
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = eb745c48e9c4a6fc0fea561dc411c3ddc6a868f23d3dea08
+Tag = 200eee9cfca4ad4783dbfcb0bc724cc5
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = a5840630e35bcefac8c47c7e7fab453dc973534d18007726
+Tag = 36d70c77add47fc614a1883581d6df8267d16ae3e4006827
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = e1648e6c2c3e1433fbef56276ab22f99e79110dc386e1f17
+Tag = ca9b407a3d0c64f5c76a239be3c71305548cea53360bc118b6fb726b6e43303e
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = e05105d4024e23e2
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = e499e7abe08cf101aec2191652a86d44
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = 25fa5d8c08d2d10e3076183add992efae277260fdfe258d9
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = 4f2418966f2b7a018485e06fc68a5973708759a3876969daf577fab7310e0bb3
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = 47744da4149b82b28045c3badf3b78e4b0f758efa8ee9fb158263c17a216cad89e9c
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = 648598f0e8a4832526b12d039729945fd90fb7e04af9d257977c7cf659cc66caf159
+Tag = 572aaab24f5d697b
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = e0fd6e8dd069f90ced363ac631f74c6376475c205531c7c6b93548692d5eb305c003
+Tag = 341acdc2245ed5a48a39376e1d1797a1
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = 72ead0d8e021004086e3a7081afa467bdd5c15899ec8e8fa1c52050082460e405355
+Tag = 8174a3d3a31572ac292fc0e6834537ef55286d3b6b20fa0a
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = fff4b85e7c94e8820122010e33f054638b9c43176df032b04bdaa580b44c3174a77d
+Tag = 25074507d30bdce23686d795eaeb4a0598e616d71a9a7ad1264f46654d7743e6
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = 0c9e39aec40f615a
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = 5ff55d0b20d2ac202a497122e618f6e2
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = 16c9640f019e79c303ff6b4315ef792a39d6692ded4eba63
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = e2219b9966890eeb6b9681a5e249a84b7adcb1911e985770ce67c2e3cadabb59
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = 1098281fb1e09cc24f4447c94f6e252f658779e1349b5dbb3a5fde9d02c4534aa92fd057ecf17d89c7340d32eaf63870
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = 59e77313463c9e9a01eb729515a1317a1203aa4c31aaa4aa6d62df3636e03a895675ebdd151365ce5987a64012e600a6
+Tag = aede2eec0b2b61ba
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = 6f38f841f42bd75936e44213eaad82f0b4bb6d4321ce21bf04ccaba7edf7fe73167bd34408ad5bf007f520677e6ec487
+Tag = 18642b8b7282a97e5d19accd18ec5b35
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = d139bbc47afb30f6a548d853dcdc104c6eb17f8774d2a283fd4ac42aa421e3d6bf603e7cfeb0ffa3f496a386dca9edd3
+Tag = 43ab79ce624a79978d4052b61e409bbbc0243d07567dec21
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = 0c7e8cea9fa41ae007a889bb894075d70c3c37862b1ee12c0879ad23163d8c7d593b33892d88c2d445238df1309d5268
+Tag = b86d266de6fd520d575a0907d2e80803d89979f9f34ac6538216ee828e24e8f4
+
+# initialize with key of 128 bits, nonce of448 bits:
+Key = 6a039c35ce67009932cb64fd962fc861
+Nonce = a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 08ff1d91194dc1aa
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 0224ef0d359339fb1fed06779ba113b6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a6f5141f46eb2e763641af3ff2aa7a0d3a3c164b5d1e714e
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = aa51299dc97d4732a453488e9fc78a0c6a4b1d5cfe2b14c997ca743529d7045b
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 27534e46f6
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = f2ca63474b
+Tag = 1f1504028eaf581f
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 10fb31de68
+Tag = 9e074c80f64633dd2ce07bc9997269eb
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 0d681ff46e
+Tag = a1f2366973045d7403ce9719a6391d2ef095673a2badd664
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 84abff25aa
+Tag = 07bb8752dcfba3a846706cfdc84f794a2f5e0e33a369c61e2f82c7e1e9a40bcd
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 3ea90051c693049dcb87b9a6
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 8ad2cb42984c740079859cc4
+Tag = 36bd6e615cf481b7
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 38319286958daf0c360de893
+Tag = e1db2cdfc4a9d04cd2ae6d2aa0d7b41c
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 653cde5fc6d52cf264b0f406
+Tag = 3e070ba358bdf0c25eac3b31b23c7730efdb272c032eceaf
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 20a5850a9254d6d5aff1e67a
+Tag = dd522ba2a154f282eaa7c2bca4aa674c07ce207e5aea83da069c1100c4eab2a1
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 483819fd19e5908846944acb1e8f72c8956b05b7abf712
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 28ea1bb87d7f1cccaa333534799b8cd495c76471c19821
+Tag = c2e4a346445b54a7
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 9a37b61b7972d0ab9eb3a7703451d416556c2b21955418
+Tag = ece568fff70ddb4ba42eb1d56c1d37db
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 24e2282581d1a1c7338fe4621fba695b12eaf079bc77ea
+Tag = 9446780c6a1c883b1524a1afe1a1cacb59ce458787e7451d
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 66cb522b7300c48bf931dc3825276e974a78ca5d4bb16e
+Tag = 70521fe6d4b5ff2166a2f0c4284241064e8d00c8004497eb23ea7734c86c72e3
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = b39b26aeeb5673b4af24ef5f72f2bea17c800a71fcc829e55eb66946e8ac9481054961570ed11e
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = b3121c219f99e949a0c87395adfd764844e6d2238a621ce13f094199c4e9133dd9bed2045c1edc
+Tag = feefaa4150a4992c
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = a87c98f3ac6d1daf2b559afb9a31c96a40a320d1a374ca25b9d545eff1bf30483d217538300d33
+Tag = 13fc58be1601e606c6cb1b95b3880889
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 374ba9f85d34673494f466946edf93917234f0d735b4639c197aaa22f57a15c607c9056a5bce49
+Tag = a979ba8763533c4bde1f9d049c8f912186d8ea6ae00b9d70
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 224a5ea3ec73c7c7e5e11ce3e18d1c4a3a1a0597702d4c8541b17ab2c637e465ae5b19c5a507af
+Tag = 51009753c2a4056b18041394a9cbd0a5d8b7518aafc95dd1a117a0ee7e149752
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = 0df8274329fc945e
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = dc73120d7c16da28dd2faab3f0e77c73
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = 06ce8b91a772d578f542dd5b530feb22bd037d6a9495fa4a
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = f974bfcb95d2cf46cd039c04a3156c67ec8c058830431c3784ec8ca533297ad6
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = e19ffcd638c13b4f47af0e1f6390d8b2
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = eeda1fad83277f6b85eb66dbd33adb7c
+Tag = c8dcc191800e030c
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = 5872063c27a26d3fcd5f48026e538343
+Tag = f48dd313ab28904c4bd64a09d90e02e4
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = f22c4d27a51c962375ad663eb5525031
+Tag = 8423df7eb27720b65b8fba738fc89c5f54d55da8ca934bfe
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = a3a1c9939e78e3bb8e9522bdf6959bbe
+Tag = d043a566676630809387549785b9a65045eda6699349d331a993e02e7a596bfd
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = f18aed0d42dfad971fc221e0c84983777a95225086e754894b6a3434273c92fb9e35da5318fd3439
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = caa99496d713de3bb1373abbd37efc0db62f98f7ecafe7e742cc4099605ede648ed0bdbc58563ef9
+Tag = 6db9da89f2ec41e5
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 524c8528f8391fcdbb9e94feb2deab3fb99fc53ef822df797f13cb69e7f8b270c634ac0cbf939fc6
+Tag = a1ae6851f72b33f214d2f8361e892f2a
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = 4b1c820b219cfbb35ff35ccae0281fc27412bef3bda3cfc2b87e0dfa3029629215a3d002766cfefe
+Tag = 78615ea4874949cc9fbb4193b9ae5e2ce44ef6c5b6351c54
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = ece3b6fe1679bf2d962086702ccc22151bcf8392611bb0622be00c8f176ef1fc896f107a6e4bd59b
+Tag = 05424d1b35d92ede8bc0fdc65a09164e4ba8b0559111a9e89b72c22bb65605c2
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = 82ff7c893f93f13b
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = 5aff6166f4aa2e5558cb9aeac4591a61
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = 83297838074ee2e658b33a2688f64b63e1b04815871fe941
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = 69825e54860fd0ea22f9b4a28df2551fb423f1d457d1ce2e3408bf687ea45e5b
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = f53b878d1e248903ca1ce24bc54f5455c15fdbb547a2adf9
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = 029a7d95e4b793eefc088303414b1181e6a3a4d4b29f03d7
+Tag = d20a6bf859a1e951
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = 5c0063c79c13896ede0cd4385df5e393ac306cd5689bac4f
+Tag = 509fbea6351709b879708957fdadf1f7
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = 8eb882e8e36013d7524b76552db48d6b02d419706e06ce1d
+Tag = d5c5bc6e39f4ca973877dfb85be6517ed286013fb758abfe
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = d0fe9622f6b5d08daa1fb954301273a554f49f475c6ad900
+Tag = 0b59d2819aa13cd739cfb90e7df2d19fb7b470ff913529f7f78f88022abc6b22
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = ced39c0c97518a24
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = 53112dd7173a81fef5dd09c53010c2cf
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = 2f3ece12c744bdb3d2527ec09311661415442165f239850d
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = 0a48f447b84732ae3ef126559bfca5727318c26cca101e2198fc4cebc6dd9ea6
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = 8a4588eb33f1b5e9f99bfe3b9b55ac3f3398c4799e5c9e2d03fd1a08a8bc3d5188e3
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = 9c1b357ecf416145d3293f78f5a26e29ab26eb60d0c619f306f7ad67d14577cc3333
+Tag = 9fd2c538ff1ce98e
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = 2953c02f6bd50deea3acfa59dc8d00b0f6d8c1de65bdd72546a02f3f435787fa963e
+Tag = 4f6f31b8362db6e275b7eb8366d38ebd
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = 22455e74e0377c242963f1bf2bbdc523ee1ef46ed92a9b45a1f86b10d91f88920201
+Tag = 595b02ce805297131bd60a439aeea89413226131533aeed4
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = ce1d230b9c7f4f870aeea3e5edec0f998cda5ac8e59898f04316476d2b26595f0c2d
+Tag = 0f64bd294b056c993da0957b1018446e916e7577f97829af8430208fbe72e984
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = 7b09a5db16efffa1
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = c6f4ba4a5a38ca38424241819c6ffaa4
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = 9494000b2b5e97d5e2299b2efda0362aad491a483f4e5255
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = 78dc81a30bcd126a126f1e6f118856023227931b3218967e2dbd9b2623ff046b
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = 1c622ba6ea9a64464a75f7899f938a44c40fb0c2056e0d822c24937bbe48c24ab7895e921a57d93bc10da14153bc3f15
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = 27c9fec932e0735e9142c61edc741b8b8fe5f390d63e87da5be551d5a2253a08eab15cd843cbbb8e5ecb56e555d45b10
+Tag = 6f6b8f5cdd53a107
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = c7c55742545fc75abed2e82464b9f1aa025c52ef9dc93b455da4863b443c20dd7618b11850f315faf0a6c05d145e0ff4
+Tag = 7dd3e4c1c3450b49756230e3a5bef7d6
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = 2e48f1d4d2cb82548ff0d9f84d5fe8d07d0ac7dbc436d6cf7bb83f912cea633a5ff2f7d5cc311b5ac3dea476bc85c81b
+Tag = c2fd550cb3a886dfcd13a30db9902bc3c2d238e5922ebaa9
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = cb7db9cc0ae4dfe2058050305d3afd9d57bc9fc4941dee17be60473012fcf00529754f4399fea0a1fa6f79664d1f1729
+Tag = 21f163383b986f2e82192aedeb15f1d3c40f658860d78452c481339fa94530f2
+
+# initialize with key of 128 bits, nonce of512 bits:
+Key = 720ba43dd66f08a13ad36c059e37d069
+Nonce = b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 905046161006f352
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = fca34b92a4c445d526e0574993ad70d7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c5f94db645ce0fb0ca9fe486cf3644b5c228e007e93ba56e
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2ebd7f041980350cae468d65a6d35723bdaf91a1248bfad8651335c15eb19b33
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 49bbc22b69
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 772cce6b53
+Tag = 84d06d6439824c4a
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = f21cb71622
+Tag = 85a06b965e29c6498c3e3650c12e8570
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 91ffcba7c0
+Tag = 22333b5cc88b9360e7c15bcef994c3a8d543fbaec2e0ed88
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 96de28a8fd
+Tag = 8d4f91f34590e05e53594ee0631853cf02b6f7c927bede68d71f84d9e9c88ce3
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 6ef5d1ef7fee39fde0f04114
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 45dc364bf86f640f8e124136
+Tag = a467b3e43a7dec9c
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 0bc3417ff2ebf75b8d124595
+Tag = 51b040a36a78cfce302b9605365ea0bc
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 4ba955721cc2b536768ad63b
+Tag = 5099c8e0126008480c16ee132d69a354805116955b385b0b
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 5dc0dd591ef4f61f27d7bc62
+Tag = 0fbe83ba59db64ac65523b52b1307987d9451385f1e5a047835e1c70f35b47ca
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 33aa70ce5daac7bae38797406fa2d7eedb690154d5ad74
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 6cc291ea01afe9bb00aa5567cc10f9805f080d81e4676f
+Tag = d00063a42b2e5bf6
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 1a093e725c45e4d5cd99e84286225d0d6f3d9e698fa598
+Tag = 80b057c5de064041ae3ca0a73ee3741b
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 5ab6e11cfa3da31dede2027affe7684a72248407d687f9
+Tag = 4bdc2bb651cb7c6f5edb4c3993cd8f5eb5602890fd3a5f6f
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = d28b4e37588fd6438631eb365d96fa7a414c614ff06582
+Tag = 3e34d50cd166138f1587e17913f0b871207e42dcc0647702b7fb2be14d493500
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 7554dc82810e872ead74e663b8b57c1e1162393abd68cb47415dc411426ad0c807131f4f5affa3
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 106360255bd91d2ee690d9c00dfa051914869c84ec3e3dd19e9bed820148cb00f40a1c807575c3
+Tag = 0ffa80e6c2328d0d
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 2b64c4320865bbad01d876da3389e6f17fcb46110f135a10bcd0ceb02340518dab5c4fa2e64202
+Tag = e3ffa809f90675c61e8a0073322180b3
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 1a008e963a02a8effd5c304e12abc094c569cee490540b8efa4015fb6c9d870220559f49160b16
+Tag = 5c444c6f8884872d920bdf9551cc7f9ce084a155840786d2
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = fed1ce12b252b5042e7eacd9b0ac74642374087ad6fa19e026d6fe6f22ad3f52ddaeb17be9eda8
+Tag = f338b20b8d2586b40dab687a83053c766a876bebbcba65074c80ffef818ab9fb
+
+AAD = a233c455e67708
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = aa3bcc5dee7f10
+Plaintext =
+Ciphertext =
+Tag = c1d31635c4f98113
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = db2b7a97acd4513dafa3434b5e759ba9
+
+AAD = ba4bdc6dfe8f20
+Plaintext =
+Ciphertext =
+Tag = b1cd6a550efde4066a4877da8f0c3e950a2e15c747bc07e9
+
+AAD = c253e475069728
+Plaintext =
+Ciphertext =
+Tag = 47a6c74a97e72e8c6775ed88afbcbca54dc9e5ac23a562c550b173306edc8ae3
+
+AAD = b445d667f8891a
+Plaintext = b0d15172f21393b43455d5f676971738b8d9
+Ciphertext = a8d439334057340f76972eb975f013949f72
+Tag =
+
+AAD = bc4dde6f009122
+Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+Ciphertext = 599ad42db14944a04f4b895c324a8f29fe2d
+Tag = ec2f1668abb8fe38
+
+AAD = c455e67708992a
+Plaintext = c0e161820223a3c44465e50686a72748c8e9
+Ciphertext = 7f1bb2a3aa0800a700b228d8cad2bc0bae5c
+Tag = 3db8abe18ef4c9f787878b2d3bce67d1
+
+AAD = cc5dee7f10a132
+Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+Ciphertext = 445688f97ffa18f9c81036ea7f615bc356e4
+Tag = d45a9fc385458dabed21708d3860e623f4974c16830cdc13
+
+AAD = d465f68718a93a
+Plaintext = d0f171921233b3d45475f51696b73758d8f9
+Ciphertext = 4233e0023acb329c5deac2e94296f2917c5c
+Tag = d3ce972af1b3b32fb6942be3d53af68f8452be5c7bb4805ae81dc65cbceef150
+
+AAD = cf60f18213a435
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+Ciphertext = 88796533cfb16053184ba07f938881f8de5b950198aa998c442d8e26ca784d9513aa12d1c5c2c4b49e4c9bc33d
+Tag =
+
+AAD = d768f98a1bac3d
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+Ciphertext = a4d2441687115184d16145dcf1d94628ca3658b092f0db4e8b271e88e96b9b3206edd357292a2043e3e504e355
+Tag = 7652dedded3ff10c
+
+AAD = df70019223b445
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+Ciphertext = 9c8b1e71d5a7554a530d76abed2ec5436133218a8221ee60a069fef9dfac4837f404fc1f1159417889cb3dc437
+Tag = ca68b24cae556ff70f57f0e9d1aa53d5
+
+AAD = e778099a2bbc4d
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+Ciphertext = 1472188ebab2d275f5ac05c4c32fa5a0138234f89b431c6ec162c9002e39c4964a16df7ae56a0ba82d93cb9884
+Tag = c8a6067affe7bd12bdd519a5e9800f0082425e5dad11997a
+
+AAD = ef8011a233c455
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+Ciphertext = ea140108fe42bf79cbc9fc64ff368cbba04cb8086ed7749cc192e294f1acd893b6057bbf61b5e5a0af3b3113c4
+Tag = 9b87e885eee374166d34dab4efb0752dc36aeef25e6f55f3256c6a1ccfca0c33
+
+AAD = 54e576079829ba4bdc6dfe8f20b142d3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 5ced7e0fa031c253e475069728b94adb
+Plaintext =
+Ciphertext =
+Tag = 78e185a427aa5c4b
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = d97d28d5480f8517d2ca8231c272d30b
+
+AAD = 6cfd8e1fb041d263f48516a738c95aeb
+Plaintext =
+Ciphertext =
+Tag = ef3d2178003bd945296db5373c97d2d4f5d3e791f9938d61
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag = c2109612c8f59cde3efec1ee35e838451442227db9987b8b3490336cc2d38ae0
+
+AAD = 6f009122b344d566f78819aa3bcc5dee
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = ba4b172d283be1dc213a677fd3cef7cf037da33602976431afab98
+Tag =
+
+AAD = 7708992abb4cdd6eff9021b243d465f6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+Ciphertext = 32cacbba8fe93c876e246ef2c77b3c170cef0cacd1fd34a9c0e109
+Tag = a8a97bf98213581a
+
+AAD = 7f10a132c354e576079829ba4bdc6dfe
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+Ciphertext = 9bda8fbe8b655b532324f2af5639a4da595aa4b3726d3ddb557ac5
+Tag = 4a2bdfb3c303134542ec4d3329b60667
+
+AAD = 8718a93acb5ced7e0fa031c253e47506
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+Ciphertext = fa8f743130153af92f82ff330202903fc9d3001b25f229accf31dd
+Tag = e294bd382afc4fc2f7fb5f8dc5454b8ed3161eaf904cf370
+
+AAD = 8f20b142d364f58617a839ca5bec7d0e
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+Ciphertext = a1ef2836a5eceb2a5b3d5f03d0313b31d14154e0642a3e986d7c37
+Tag = a45d2f551a838ad93eb9f02e99356a9d8ab99123b9506e992ce392b3017ec209
+
+AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+Plaintext =
+Ciphertext =
+Tag = 3829f81492e158cd
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = edd1afe90988348617acabbcebe995be
+
+AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+Plaintext =
+Ciphertext =
+Tag = c6586d0191aba33c64de99c658a481cbaf3be98e72e1327e
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+Plaintext =
+Ciphertext =
+Tag = 2f23568e1d513a7de4a7bf63101dcde3ecd84ee49d93740971a5e2b221fabba4
+
+AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+Ciphertext = db5644acb7482cc41880121bae45fb51b3f2d65f1e1a7ff36c1882be88a5710383addea69e7a9e
+Tag =
+
+AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+Ciphertext = 8a116781f063ec62de53f2f871db22625e6617ea8e49a2501b3d58f62a26a4616d216cc08f9b6f
+Tag = 93a65e16230a5fcc
+
+AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+Ciphertext = 3f4217c53ef9ae72010e5850708c5435f512be53592e2a75ddcb740e13d1f79acab62f61447c39
+Tag = 7935c9b4b0ce34403ed2b71e68471651
+
+AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+Ciphertext = 1680c5d1a435ffddbdfee930671c2f4f795e7976b535de762cb9e81837d93fe4a8ff54723aacdb
+Tag = a7f57679beb465aa7e2664ed1d6121b7de2cbbc04a8a20e4
+
+AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+Ciphertext = 4d50207e294ecef0e2297d32f1f52cdf51adf242708e102b395566cea5e88d511199570d3d5f21
+Tag = c2a29af7af5e26e3d5174f3baca706ac52998488eb3686bad515707671e21064
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+Plaintext =
+Ciphertext =
+Tag = 7d9f2411cc6470a5
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = 69c595b5161d1c01c429e402cefde72b
+
+AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+Plaintext =
+Ciphertext =
+Tag = 8bea3967c172b80269d1a20d1765f68cd2ac0866a4ed5e4f
+
+AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+Plaintext =
+Ciphertext =
+Tag = 4b9c3fe2fe4e1da6d7c609c5e5baa0eb17d2fcc2693125518da0673b08433b08
+
+# initialize with key of 128 bits, nonce of576 bits:
+Key = 7a13ac45de7710a942db740da63fd871
+Nonce = c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1d1cc6fd62c7eaed
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 64d9a3b5b3a2c70de7a1be4883eea935
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ff4d9ffc5134b5312fc6b1ab51d1419498a23ab30e9756d9
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f87dc6fd2332628c39769f259b597ad74ed7d0063e36dbd180660bd8e07f6b98
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = f88f5730ca
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = e3a7d0398c
+Tag = cd33c07edb22bfa8
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = ffaa76d3b4
+Tag = 4e8ed9f8558b1b601875beef864dba5a
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 7b435a8251
+Tag = fcb8bfa5453300d4e64f1403ddd97be699272fbaf19f881c
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = d57e780867
+Tag = e73166263e5f9b7c95c3d472e31fd31a6b2ad397e38e68214ef7b4229bd6bd93
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 1f62118cd1e59bdb0c59686a
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 6d7c7eff2ee805f33dd0493a
+Tag = ed24ef9f792bbd40
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = db1356f596cd85a42daf1ec5
+Tag = 9679967c6afe6f87bcc0d8e095b2e8a8
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 4e19a5ee9e59b7c5f2a1f968
+Tag = cf38955f445a63d9694a3c06444f5205982b0ba364dbdf47
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = d71807db6faef5ffedb28c41
+Tag = 53c1e29d9a503fb3d3f75892995ae059f77d1209b7d0514cad4a8e26f000e408
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 2ef0bd4dc2cf0d921147eab0f7b51a34a6d66637e5c668
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 97597a47a1e842fa9d69f4bbd8bb8712ce39673fd42e0b
+Tag = ffd26f78fac38d42
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 307bcade071efc9221f2f5912be2b873382889fd6b2567
+Tag = 69102a8b42571dd546b382571fa084be
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 2f04ad5c3f9f925d81e4c44b2015cd5cf463c385401db0
+Tag = 3f1967bfccb97415d00d74b8d4db1d0141c66238f4a32b66
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = ba079a481d7eea617df29f9efaaab7a774080f8ec2d193
+Tag = 2a2410638232cd139fe919e37c9ce64dce266c096dd410be1b61a4de9b7404b6
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 9174cb244933bc2f09c50412b2a6403f572db35457b012e32f858d189d71579e9f14c68dd93eca
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 457d27b7feb85c63d953aafe4a26faac5ed9e02534d91432aec7924b68f9f1406cad86f5a55942
+Tag = 77d43d83c3cec12a
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 3b522d5e6e4dbb90eaf76bbd9a6b276743e77cbb38b6d0fe5a2b3d10d91b22d2df5c91fba84fd5
+Tag = a148fc8faf3a51594872e565c68489ef
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = ea725d8b7958cbfc658158e8ede8535a359607cf79ceebac60701d07a9f37cbad6d8f7bc20c8c9
+Tag = af0978d87a378b66aef36e3c9f94c326685e07ea759dd3df
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 1e4a9f9b7cc538553bd42dd7042882c7eeff4699507fb14567bfd35018c327f498bbaa27aef99a
+Tag = 28d977d8654bb12da4d74a6dd4eb8bdb0d3b6d6c8c10ee931e7ff60308b63ad1
+
+AAD = a233c455e67708
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = aa3bcc5dee7f10
+Plaintext =
+Ciphertext =
+Tag = f90c87de0d543d40
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 17ddd9745b5fd571a81638e582894076
+
+AAD = ba4bdc6dfe8f20
+Plaintext =
+Ciphertext =
+Tag = a0c0978081ec69074c9086d3d87640c8a5986d3d27c38ac8
+
+AAD = c253e475069728
+Plaintext =
+Ciphertext =
+Tag = c2d42fb8e84f792d874877fb83f5c132be41c3c22205b09100c8108f2e43d343
+
+AAD = b445d667f8891a
+Plaintext = b0d15172f21393b43455d5f676971738b8d9
+Ciphertext = f80e74e87750e238b94bde879698b2187270
+Tag =
+
+AAD = bc4dde6f009122
+Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+Ciphertext = 14ef2cffee0f16f29aac6668815503142001
+Tag = 9eaf6899776974db
+
+AAD = c455e67708992a
+Plaintext = c0e161820223a3c44465e50686a72748c8e9
+Ciphertext = bad8ef823b389b44b9c00f7a29adde71bb10
+Tag = 0fcca02b00a7671b7cb7e215d595af1e
+
+AAD = cc5dee7f10a132
+Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+Ciphertext = f2eaa464d4f30695c528841c6c9d90beb027
+Tag = a5b5dc3353b7243a95a80760f67b519c996a2a4f22e04b8c
+
+AAD = d465f68718a93a
+Plaintext = d0f171921233b3d45475f51696b73758d8f9
+Ciphertext = c2b40b6f60f63091541b3c8d855cac85f684
+Tag = cb6b8bf587e74dd5354b064b78229a73b09fa6c68c17c4ae6c371239db3b4a72
+
+AAD = cf60f18213a435
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+Ciphertext = 34f4510460b498153c453625197c2c6be661a5034ece280d9aa86396c8232c90f96b3ec0a22362e498cdc6fee6
+Tag =
+
+AAD = d768f98a1bac3d
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+Ciphertext = 33a8de7a8986ed342752ce638403fee65e14bdc8f7b9aba78316d4af0c9f571002b5d422db517a0af27431ca33
+Tag = 07700ed8f4eb9055
+
+AAD = df70019223b445
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+Ciphertext = c68524d72f9a6014045b7d7daa72d79b20e1070d0873b124212e2a475d0acfc209c78006814ce10f6ee218d1a5
+Tag = 76cd628cfce6c2b5fb97205371f61ad3
+
+AAD = e778099a2bbc4d
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+Ciphertext = a5b0d7b338682ea60557633c3c13cae60a86fd596043aabbfb14701eb630a7df965fba08cbeda8a549dd4b124e
+Tag = 867527bc34f52ae0c13ba9a10656cf4cf8c67288c80a8f18
+
+AAD = ef8011a233c455
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+Ciphertext = 79d558204fd131936d04e273b9e73c0c9e5b9a972dfe5af25355e3e4ceef5b380a6c98a9764e95264b437f6c7e
+Tag = 928659327a01f659bfa0261e7d95247b42c2708e6fd838cd1fb8812c7dbb93d1
+
+AAD = 54e576079829ba4bdc6dfe8f20b142d3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 5ced7e0fa031c253e475069728b94adb
+Plaintext =
+Ciphertext =
+Tag = 00a2ebcdfd191fb8
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 9723758f610ae3d063f73f3d79e1dc4a
+
+AAD = 6cfd8e1fb041d263f48516a738c95aeb
+Plaintext =
+Ciphertext =
+Tag = 53f8af4a900697c65fa5e3a4b8e78420d5ad85f2c0c33bfa
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag = c9fb6ac839933498cb593a1c1b9bd6c46f47d23187b1236346a3aedc94316a8e
+
+AAD = 6f009122b344d566f78819aa3bcc5dee
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = bbe038028e324873131513f4aa886462c3a55cc1ceffa0eb5f1bbd
+Tag =
+
+AAD = 7708992abb4cdd6eff9021b243d465f6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+Ciphertext = b3b42c2f0dcbfa9f9f3f3c8852304dde32558cac7386a3cf644a0b
+Tag = 2a5d1dd723d76bb4
+
+AAD = 7f10a132c354e576079829ba4bdc6dfe
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+Ciphertext = d6e59078153e2ba5a30f1f2f9df8e167b4c175baa32ce56612043b
+Tag = c0194d6d410196244d648bb7d804d607
+
+AAD = 8718a93acb5ced7e0fa031c253e47506
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+Ciphertext = ae465a34df4ab0b31a4984aedc06f66edd479aabadf5a3ef781016
+Tag = 3b6ed456110dfad12f7206effc3cf1358bbf7ee3c830aa80
+
+AAD = 8f20b142d364f58617a839ca5bec7d0e
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+Ciphertext = f06a7c85ac848f04201e17204854d2bd640b61b24fbb77e0e533c8
+Tag = b976315e97c909c01dbd9c2303d64403d9f8f797ca5bd19d40d7fec0d44662f4
+
+AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+Plaintext =
+Ciphertext =
+Tag = 0bc91e932c45edd5
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = 0f2b51d9844b2ed7b6f590b8d5f502d3
+
+AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+Plaintext =
+Ciphertext =
+Tag = 939a3b8e4c16ca5b1cbc33957c304f47c11cdf21857ae2de
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+Plaintext =
+Ciphertext =
+Tag = 89e4c348638fc0965961a3c3eda499de18f9cae991bb544cf5876e8d9ed12ba1
+
+AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+Ciphertext = e92fe469af09d257301e93c2238911776c893d8f489ea132576b97a626fb3b048b04ba7a0315fe
+Tag =
+
+AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+Ciphertext = ceea2417e251da8e541678bb182202829c82aa512c346d2b2165279d2174180543fe86fcc82eca
+Tag = adcfc2487722e85c
+
+AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+Ciphertext = b0273d1e48d8a1d103a5e171ead75d2c54697a564b46a0c138c0d71d46280d7b6e615746d149dd
+Tag = 0d46608f7480bb40b2fe8a014e994754
+
+AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+Ciphertext = dd3c259c99122913a8d840ce484487873eefbab4549ab6a9063e26ce2b8b87b1c92f3ebf25e562
+Tag = 6a4368b5e4f36d3c76630cfee14ed4b661dbfb5f7e83dcda
+
+AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+Ciphertext = 807f10a7d69d537598dd2d8b3ca82a428143fe5cbfa4221a4a761d18d95bf1671c2407715e3858
+Tag = e47a2e652112fc2e24a05df85b38a59ed5324a3cad95f545f6a08acf1430f20b
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+Plaintext =
+Ciphertext =
+Tag = b9039ac45e59cc6c
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = 49967e25a36daff826cc4d1fa65819a8
+
+AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+Plaintext =
+Ciphertext =
+Tag = d76227b5947ffa4a32681f907d9e35f3db043a0626c9d1d8
+
+AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+Plaintext =
+Ciphertext =
+Tag = 7a7bedab5b97491926d9e2e431a24be84863bbab368a3f72a59c8cb6104938ad
+
+# initialize with key of 128 bits, nonce of640 bits:
+Key = 821bb44de67f18b14ae37c15ae47e079
+Nonce = d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2beb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d9eff602081e2430364c526e647a809c92a8becac0d6ecf
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c9b14deb7210854b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4418f5c95ac6ac3a16244705ddd0cfc6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 52d024b501d6de0eb9073906f913fc59e6c9efd4ffbe3c5a
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = afd68d0db1c19969e11af020720f40046a543fae0c20367140a0f9f530498fd9
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 9f527652c9
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 109dc06045
+Tag = b8268fbd7d84c451
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 807dd2a69e
+Tag = 885254742822c9587803fc1ccaa4e2f8
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 08245d6a04
+Tag = 6e36c5e3d109e05adb7abd82ed66e58d11ced695f1fef392
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = e638f11fda
+Tag = 3162d25b1a549628d55aa00b58817a1e27ec6ad5b5f4790ea9019bcb091c8195
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 3bcc58bd1d27674aa349933d
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = abcaa3ab35cf533965adf6af
+Tag = ccd56641984bf845
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 6ff7906e752f7cca92c0b602
+Tag = ab71b502e59b3db482a6efe3c89e8224
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = b43d2d23820f5debcbb8c3a8
+Tag = 872338634528b8b5a03f0d3c47c18a58a10feb32b4e7a525
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = dafd906ac47f129713647493
+Tag = f1565eaaaba8891af7a68f6fa1307887648ca7cd9358c95393a15c28d9c7c85c
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 149a0721a3eb46d7fe1d9a38d50a741f69478902fa3cc9
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 55d51d2f173afbfaf62539cce15d874a5c428ece3050ac
+Tag = 5a96c688d1e692e8
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 85d32004535aa4d595f4659128359ec313054d078b238f
+Tag = d812a331c9a8e23fe160c57d087c17be
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = d32bed8926ca9ae7a490c20927ef925b49c6eb3676db3e
+Tag = 826642fbf26dd76f0ca5ad2d0ad5a830eca50726f2834943
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 71eba47090e3cd484dd172feddea2b6ca6e4f36f4690fd
+Tag = 6357c6f26d21ec8f2122a7685a2bb1d43920e173bd4aba6975dc9de7bc2d40ae
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = e73faab21a7a787bfe88843724aaea70baebc7682fbcf588460dd0c868d9282caf6f8404aa3124
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = e52c35e251cd3e40e20e48387dbaba964d02340d5a18c0fbfe02bcf92be6ec0cb656a5abe76ece
+Tag = e8497d00b38893dd
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = c885e15513a1c4a644fbd62968041ec6dfd091e379bb938cf90b206be6b11e758d2c36c619f261
+Tag = 8ea855f0707acc3f9536c5999d328b19
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = a6d79ad809c7e98215edb9b512f5222dd1dadf579a95c39b98349ad52a4cf0af238c670ffbeb9e
+Tag = aa6f2cb55a1abd8e3da6449ff654428843a50c4113caedaa
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 99eedd546ce7b40b3679586f6f3a51eb3e7d7cc031ab1bd730244b4f0da8c1b2b05eef98d355ea
+Tag = 408bf7d6f7376d593256a77e355727f5e712e26cd46f5b35ffe8291bc3b5056d
+
+AAD = a233c455e67708
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = aa3bcc5dee7f10
+Plaintext =
+Ciphertext =
+Tag = c5e3601f70555194
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 5681d2203ecd8817043b892b2cbcb936
+
+AAD = ba4bdc6dfe8f20
+Plaintext =
+Ciphertext =
+Tag = f7d6e1fcfa8e255805f1910a732bd43cbfa06b1292c97d3d
+
+AAD = c253e475069728
+Plaintext =
+Ciphertext =
+Tag = 31574046ebd65ded2ceddf0b0f29a993e906bbdc7add2907ab6038e8be3d93b2
+
+AAD = b445d667f8891a
+Plaintext = b0d15172f21393b43455d5f676971738b8d9
+Ciphertext = 60fb8939903545646a89f2332e8be6055ff7
+Tag =
+
+AAD = bc4dde6f009122
+Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+Ciphertext = b2b4cf0583362c5fec453c415c23a3232644
+Tag = 95ce17ecad7a905f
+
+AAD = c455e67708992a
+Plaintext = c0e161820223a3c44465e50686a72748c8e9
+Ciphertext = 3d8af7230484c891dd35dc3d8254f3fbc35d
+Tag = cf74293f44b72ada93c52aa31deb004a
+
+AAD = cc5dee7f10a132
+Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+Ciphertext = 705d5dacc198312de028b6162c0bd7242703
+Tag = 2e7fd009c84d02dc86518b49417e3425e2c95c92d35727e5
+
+AAD = d465f68718a93a
+Plaintext = d0f171921233b3d45475f51696b73758d8f9
+Ciphertext = a8f0a941c6e08c26c7eab75aa5183f944631
+Tag = 181c0b882995b2ea5fdd5d53b7a753cca65e9a0ce50e8e10bfd6fec3d21839f6
+
+AAD = cf60f18213a435
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+Ciphertext = 528e3a35f4249b7de29d8894d6b3cd07c7af5048d55c548a97a789e41db0043335413ea3840369f623c8bc99c5
+Tag =
+
+AAD = d768f98a1bac3d
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+Ciphertext = 2f8f49fd8dbfa2fbaa4655f3cb9ffc55b8635a9b5d1d1cf4a19e1898db76f08d44b2df5e8fc1c61c462a15b731
+Tag = ee49265028af20b3
+
+AAD = df70019223b445
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+Ciphertext = b0503f549a781e4a29d64c910a8b3e18a046399faeb33543f4da10ac26f6514e1ebce49c3cc8695f7ddd6f5976
+Tag = 62b1af8b77164e92e215c73a766ec468
+
+AAD = e778099a2bbc4d
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+Ciphertext = e14a75ee5b24b51e13143dc678c18b9ceab72f8c9416e50653f3759c473ffb2f2bbc45ffe005a10dc1adfedb1e
+Tag = d6095aabf3803d8cb91b55cf20196737e92c8f86c1319fc1
+
+AAD = ef8011a233c455
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+Ciphertext = c51853146b416c2873965404bf3b509c0aaa857749d7362b0109850642699e4226053788581868eec0b1c58ebf
+Tag = 30f3314091eba609d7dfaffa370e2e32f5a53f064e10d6510707466444ed9f06
+
+AAD = 54e576079829ba4bdc6dfe8f20b142d3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 5ced7e0fa031c253e475069728b94adb
+Plaintext =
+Ciphertext =
+Tag = 137d652dee2b3890
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 252f1a3033311f6c7c2169a87fcf6d60
+
+AAD = 6cfd8e1fb041d263f48516a738c95aeb
+Plaintext =
+Ciphertext =
+Tag = 572a2bd5ff12ae5387721a6142a4ffe2f91a1e330d80ec2f
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag = 98eac818e123e7ffcfdc76a6ab46a3a5121aff12b917014262056c2376e31e48
+
+AAD = 6f009122b344d566f78819aa3bcc5dee
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = 2f9170d1bc1ebb38220790a741c3ca3a62e514f861dd407807bb72
+Tag =
+
+AAD = 7708992abb4cdd6eff9021b243d465f6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+Ciphertext = 29e5dcfeeb6b2b18393ab1630c461abe7e63f98cdd1fce05952526
+Tag = 8e013ec9a218ba07
+
+AAD = 7f10a132c354e576079829ba4bdc6dfe
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+Ciphertext = 69dda85a6eac0e36c4d2639a37f2fddb0fd158fc2b4272f9beb313
+Tag = 7d186118c662ae7a4700fb1c56a8d13d
+
+AAD = 8718a93acb5ced7e0fa031c253e47506
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+Ciphertext = ef052db258506a93b6cc9ac99dc456a00a122d196391b001bb1af2
+Tag = 14bc2f070bef543d6fab1ae82cfc96257386c303c97f8794
+
+AAD = 8f20b142d364f58617a839ca5bec7d0e
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+Ciphertext = e7fb119c6e51cc3675e6599259e9aea6f6bed2123086f35d2b1796
+Tag = 48f54e4a89d2597c58e4b0528cc9e27d1f2c2912803fc85cfdd211bc40d18b5f
+
+AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+Plaintext =
+Ciphertext =
+Tag = 4177758b2c96a15d
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = 0106f4adffb2206e93cae6af52fb4f24
+
+AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+Plaintext =
+Ciphertext =
+Tag = 976132981df0a7c259ff62a8a9b13fd0b8d3c4cf86f19c11
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+Plaintext =
+Ciphertext =
+Tag = e4219ef913039ff02f6e0672e24eaf85cb8c58dabe6ab8ad1862e7237f2641fc
+
+AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+Ciphertext = 43068574ad814e660bcafd4e832efe1552d5eb090d5935704f8934ede3b1929612c9b134dcceb0
+Tag =
+
+AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+Ciphertext = 60dd30ca650886ecda1252fba10d9dbca4dbb32f3b9a41b166a139f294c010520fd00ed054410f
+Tag = b5620ff3561f2a13
+
+AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+Ciphertext = e2e28c21e1064a5ef6478497988e8d1599b524a9a0f54e4647510dc69352f1765a2e2530239036
+Tag = adcd89918c9c3c041461981f93ddabeb
+
+AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+Ciphertext = ceb2341faea9958276c6b40180871dad7988f42c33a34767e65ebd336526efa3b346cc12574d05
+Tag = bb0885e2959f513f1c2d158702560dda758676fb283a5e97
+
+AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+Ciphertext = 2c05aac1e69aca316290c89e0574bdb448407895cfa81fadacc71fa059e6cc1842ae9b0f9e220d
+Tag = 6afedec4d9a766c3363706ce055f08bca2f60bde083383e935f58b3dabf8aa66
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+Plaintext =
+Ciphertext =
+Tag = 6e91e63feccc2bd1
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = 7396f158fed2057ae76c7ce5a7f7174d
+
+AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+Plaintext =
+Ciphertext =
+Tag = 5fda1b4b38b662d2d3ad1fe4f29ac1c18dd68f7dd07dd100
+
+AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+Plaintext =
+Ciphertext =
+Tag = bbaee3d2412409fb7a02bc894962d041d3cd3b51c016ed60047ce3d90a9020a0
+
+# initialize with key of 128 bits, nonce of704 bits:
+Key = 8a23bc55ee8720b952eb841db64fe881
+Nonce = e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da3bfb5cbd1ede3fa001c12283e4a40566c787e849aa6acb2c8d4dae0f703091f2531374d536f657b819d93a9bfcbc1d7edf9f0061c282e344a5
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 534cd0a431735501
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 53cbd422fd55c34ee32a8a4eb22487a6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1ed0b2c5549b3f64a74f8f6035cee2738e08cf6045cdaeb7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9b7135be2dfc49f443d3da0e4ea9f56390bd27c609e72e11ab49d11fd29e33b3
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 77ff879847
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 946cb16c6b
+Tag = 2f0312a5a3efc44c
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = f7cfc2c756
+Tag = 7233cc66b56478282a5e7eb5b73f4839
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = f408b47b8a
+Tag = ed7c05f56147746ba72475daca6a2cd39720fbbdfcaad4d0
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = aca8ad7c9a
+Tag = 5d37d98532f298aebe897ba2a6eac54f40706982fa1173a4d601b39cd286971a
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = fc8c32ca4cd340e2fd492a02
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = a23926c8356894079ba04f05
+Tag = aaa0b7dd666a843f
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 9bbd39ed5673695debdf968c
+Tag = 592894700f2beb726450375bcc8ec70f
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 285fc4f10cafb17710e1f920
+Tag = 8f721021a532b7176b9ad65427bbfbf10997c8921dcf084a
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 55471f3a72834ba325561d94
+Tag = 942476dfe4f0d4588eeee440801df51622b58ff5e6f8047ac301cd91698e768f
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 28b9011636b5f4958ac1cd3b92ffb554c526b8d7d20da2
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = dbbcbed166f56ae785e85e18197b3518b787cc4ef01917
+Tag = a9adaed644ad8300
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 5b7800a0b402d5c0c4428719537be9503941121f239f57
+Tag = 3c5e16a5078a4bda7eb7e7d4c7ae1d4e
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 651aa0196d9ceb173144682ceeab55551517e199d90705
+Tag = 80f701f0d6d1c7361239859012a4af810352c110032eb9af
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = bec349401bedd3c1f18f75679c7a59c9c8c8138efc1a89
+Tag = 074c3426f6855b27798d174bbdef6d98b8c6abea86804a052b457a5b3c38b0ac
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 8558033b63d6c6781ea0da1f3bec1d7dbd75882bbe6d7edb017be04120a9db103543ae55946e8d
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 2b1d01629db1b79107369ad9d130ce0b649cf9148fa4756bc388f0fda263b3ab39c2035a0eb766
+Tag = f4daf0457710b339
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 1ebfc7abf4320134d5a7caff805e25bf60b9d325aaa8995772d6d35b64a7ae3a6ec620a7d368ad
+Tag = ebb1cca3b3d5bfd14d07b8b4b42b75f5
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 96d717cd82b6312a9f0879d224e18cc607c36135198a53479e51b47944157b8f6951a3f0d68d55
+Tag = 3b20187e3307403e882d8ad25c844f85a31ddf01f8c5b67e
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 25e657a43a0064639f38a87d3dff3106dd3ae15ac31bffe8f2562aa43dc1a20e201d1101c778e7
+Tag = 6b81c7c7d7446d8e320c8ebd9c1d807ad6c86c1f418007a02d9682c72c3a730b
+
+AAD = a233c455e67708
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = aa3bcc5dee7f10
+Plaintext =
+Ciphertext =
+Tag = 48b28fb07f73257a
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 01552079c0126f43883a04d56c5f4608
+
+AAD = ba4bdc6dfe8f20
+Plaintext =
+Ciphertext =
+Tag = 11606b58521a06880bb3aebb1bf993b1fcbb789b47bdc835
+
+AAD = c253e475069728
+Plaintext =
+Ciphertext =
+Tag = 1ba35ffeb9f81053ea9d588e680a6c859d411c24c905bdf4ad23c5f2da409dbb
+
+AAD = b445d667f8891a
+Plaintext = b0d15172f21393b43455d5f676971738b8d9
+Ciphertext = 22e04fb197058dacab29f25383a8cd73d5e6
+Tag =
+
+AAD = bc4dde6f009122
+Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+Ciphertext = af1080469382333ec831ff93cf025774d642
+Tag = dd62fb616a47d366
+
+AAD = c455e67708992a
+Plaintext = c0e161820223a3c44465e50686a72748c8e9
+Ciphertext = 5221c8807bffbf9ca501516fcc619931497b
+Tag = 46a00541e4bc2a96978833f853b3aefb
+
+AAD = cc5dee7f10a132
+Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+Ciphertext = 27e083c554288379b7e67036d265619d2dfe
+Tag = 4e4528bc1c84405967c57d98a57001bfe05e66b8ef5ff9af
+
+AAD = d465f68718a93a
+Plaintext = d0f171921233b3d45475f51696b73758d8f9
+Ciphertext = d4bd94ae157ae498e07ee85e241a6e324d68
+Tag = 641c18defcca6aec5f7c18907bd99b5834e77f0f76a7ca770d2b698918f9a85c
+
+AAD = cf60f18213a435
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+Ciphertext = d4346d0114eea95d0518ed851acf70fbb85654d207a2ed5dda94586db55172455dedc4b2b3f8d06b8abd73a8d6
+Tag =
+
+AAD = d768f98a1bac3d
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+Ciphertext = b68f350c0082dd859d0358ce0aeb2f08172579d2ff701c51ea9ba12723ec3b19d8715dfedd392e464921a6fef3
+Tag = 3e2225025f50f0fb
+
+AAD = df70019223b445
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+Ciphertext = a2106a71b6fb28914a4e706f577c837a07f053694a9546e0ac02075cbd0e9d6976f217e2bdfb83673081403e9d
+Tag = 926c8bccf757eb1fef8531660478de69
+
+AAD = e778099a2bbc4d
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+Ciphertext = 71a784f2cddd2bcdeff53b4b1166c1fea1d805177b66a109e74df8b95eee5577bf0740c868ffb61d7fc92206d3
+Tag = da8e645646f083d20f4577e2e151b2b1d399cea95ac04b93
+
+AAD = ef8011a233c455
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+Ciphertext = b2a62822d837e8e4ca21a4ff770abeef3804ec7bec68637bcb3bac4ddfcb2ce06f0542f328963372a717cd2ef2
+Tag = c124a16deac6543ca980db251487b4dc4da5486f712bf7a18fc5fdea423b4a58
+
+AAD = 54e576079829ba4bdc6dfe8f20b142d3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 5ced7e0fa031c253e475069728b94adb
+Plaintext =
+Ciphertext =
+Tag = fa8afe5e1c671936
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 6d38fef0f13f1f2746c78104bb8740b2
+
+AAD = 6cfd8e1fb041d263f48516a738c95aeb
+Plaintext =
+Ciphertext =
+Tag = a0709994c90c33c66a226eaff4198473db2e5fc774ea7ad1
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag = c716d647e6929e8b59eb44c356bdcad3652083c4d888b184cad21b1f2eb7761e
+
+AAD = 6f009122b344d566f78819aa3bcc5dee
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = e4e907850afa2e02f3b70476d762cdfdfa39681aedd373331ad762
+Tag =
+
+AAD = 7708992abb4cdd6eff9021b243d465f6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+Ciphertext = f90670cd80216596424ada1d38a8d5aa5663e66c2b85692dd1d01c
+Tag = a883aaff925387c4
+
+AAD = 7f10a132c354e576079829ba4bdc6dfe
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+Ciphertext = 62b18341977bec6c409604ca2c3c04a7d50e146864639fba6b7053
+Tag = 7de0ded769b5ec6347b186146430931e
+
+AAD = 8718a93acb5ced7e0fa031c253e47506
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+Ciphertext = 227efbbdfe1fb41c97b91fc76e752559d3fd2910a5e05cba073cc5
+Tag = f52ea0a597e16500ba4bec37e57b34dd50739df84dd0e7a0
+
+AAD = 8f20b142d364f58617a839ca5bec7d0e
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+Ciphertext = b796d09658de20fdcad2b43c679c24bbc2224655150ed670748f1f
+Tag = 08280257c4401f07daf5c423cee144df5ee398991d1745242521457e49da66a2
+
+AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+Plaintext =
+Ciphertext =
+Tag = d4bc9fdd1de9550b
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = 37c1db7477587c88f5b00eb96a6994b0
+
+AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+Plaintext =
+Ciphertext =
+Tag = 4084671b700efdf3f543de5a994185581384f37e5fa25efe
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+Plaintext =
+Ciphertext =
+Tag = 6c557930eb46c4a57eea09e05d9740b7237f9bebb236bcc0845a824758645d0d
+
+AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+Ciphertext = 91803cef593dd5bc83eac04a256d031c85955fd1359d40b257c1017e766431b8bccb49c8abe288
+Tag =
+
+AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+Ciphertext = 703939868321a0bbe37a6b38c355307727dd4d6a280daeedd595cc14514a0c070e1ae5d0511bea
+Tag = 9243b0e1de1fc542
+
+AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+Ciphertext = d7b68b5dfed8bf0558d3ae70ff1962c956e359dd3b9bff9344840ee5e7090dc9aa096744a5435e
+Tag = 3dde51abd657710fb1339672b757eedc
+
+AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+Ciphertext = 7ce32f34015faa206644e4cf8601c67fb5d7a12bf2551607a98b204ee16c50d4ae487b7611a1eb
+Tag = e630e260300b0f4d6844de8a9880a4c8c7b15771fc833de3
+
+AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+Ciphertext = 3b3754b7dcd8e31130ce7150a551ac5a8b1baa4bee134fcf59a2850b0111ad3bea4153f72b5a29
+Tag = 21f7ae500494ace6f9d050e337704db7255943ef902da5c140c5345f46bfd9da
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+Plaintext =
+Ciphertext =
+Tag = 9a561ea80a3c0290
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = 1a6774cfb3ca2fb0306bc86a5204d734
+
+AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+Plaintext =
+Ciphertext =
+Tag = 914f4d81596d69b66002c4efe55bbe5669058efa1793da19
+
+AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+Plaintext =
+Ciphertext =
+Tag = 41ee138ce6803aa4dc9fb83248e3d0abae6e390673bf7fd2e8fcfeafd709388c
+
+# initialize with key of 128 bits, nonce of768 bits:
+Key = 922bc45df68f28c15af38c25be57f089
+Nonce = f354b516d63798f9b91a7bdc9cfd5ebf7fe041a262c3248545a607682889ea4b0b6ccd2eee4fb011d13293f4b41576d797f859ba7adb3c9d5dbe1f8040a102632384e5460667c829e94aab0ccc2d8eefaf1071d292f354b575d6379858b91a7b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 257090f77c284721
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ae4182f0ae6103790cb070ed89d8b6ab
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 61a17f87158587fc9d9636be02a564aa7ea310bd86398fda
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 649cacf048be9188800feef25f67938ca7cf863fb9ed7a82a358bb8490323f22
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 7f64c78f4d
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = e390ecf887
+Tag = 92223d8412a9c5f1
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 60367f1974
+Tag = 21242d3a33923517ed487da47f50bd7d
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 435ea8c725
+Tag = 2fec061d9d160fcc4978d7d865d0dc221711e61d7f9cc32c
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = f7eca14a65
+Tag = 59418e8009259740db63a999f8d5514249075ae6c4efe4f97eea73eb30c1c6aa
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 32dfd0771d966277171684c2
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 0adf98a1870658a9baf0f7b6
+Tag = d3d4b74316b6b7c7
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 9f0277d612635cb319aaf319
+Tag = 44098061b86fbd8724f7078d8906267d
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 49b641289558a2d285cf3a9f
+Tag = 6e7fb1e8a588b36356de6abfd552f87b814255a874b34c01
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = c45bfad0f25f5743050cbd56
+Tag = 255c746ba88784bb0f4e430a982e6a801bef1d147ef2d981203e634105dcf3d1
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 0f1aee7616b9ba6a5fd73c0614f211baabffe69abfc17d
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 1243dc105852ba4939d5d077dba6988fb8e81f1a299042
+Tag = 42847fcf7aad5563
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = cf46073fe38d3f85feb11bee5f9ae4146ff6945ef82059
+Tag = 247606c9fa41b36e5d1b35dbc441faed
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 2e48b18f7d21b3ce5239cc6a8508fbb07febd6716a48c3
+Tag = da76a61b9a209edbcf89dde0eb07233cdf72c770db7440d0
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = d218f5628a7e645ff6efd7d0e85c2c330c55a74427b509
+Tag = 8a68c502a1042c88e9fe4727f4dcc2d385166104fe60f4d0def8b6a587e1f14f
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 1f45e463a640a6a0e2c6b0cf90795f05fd36537c69e36ace6c24515f7c42d56e4d284d72b3f347
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 222dae017d51212bd081b220b4ba4e313aa65d5417a5d1060464ea1dcce34157a023cb338c259a
+Tag = eca4688b8637d88a
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 77b551a03c8800a3c47d183db7820d3138f35e8d90503ea98d9097145ef1520c925f20dc5a76bf
+Tag = 0ea7f02c84cc13b0addcf20b42a015c0
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = f1bed7f09b521c2dbf09620bd36374698fe7b71755962eef3d60f8f52c8c1879cb8fb1ae68fab7
+Tag = 9b8f23688791c3e3413e7fa9b9188abab8cfbce456fbfb8e
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = dc87bc8ec601d2af568e8860115c33edaca2c170b19a7d98f131196767796892635224cb4acdab
+Tag = 3f4c02431bbce6d6c216401ff2727c91ccaa8eb308e42a1dc39eee4a0ca56370
+
+AAD = 44d566f78819aa3b
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 4cdd6eff9021b243
+Plaintext =
+Ciphertext =
+Tag = f5a8094c723476f5
+
+AAD = 54e576079829ba4b
+Plaintext =
+Ciphertext =
+Tag = f95dd7da308d5690f7cb9b869bbe54f4
+
+AAD = 5ced7e0fa031c253
+Plaintext =
+Ciphertext =
+Tag = a473d14f917b577964205c9b804db1e270a2f74fa8eb2f1c
+
+AAD = 64f58617a839ca5b
+Plaintext =
+Ciphertext =
+Tag = cca440f6d035c6cf273c8cfe00031cf8a5fcafc563e9ea984b78c9dcc787c2cd
+
+AAD = 58e97a0b9c2dbe4f
+Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 94c61a477cae6bb988adb58bc54c0bcbcd207fc4
+Tag =
+
+AAD = 60f18213a435c657
+Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = c1d8e53f19720cc4070bf1a08bce88e2c9309233
+Tag = 9d841625faad2244
+
+AAD = 68f98a1bac3dce5f
+Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = 58ad1430735ebc990f9d1e9d7da8d8ce0e870717
+Tag = cd7501206caafb399ff5653b1cebaa64
+
+AAD = 70019223b445d667
+Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
+Ciphertext = c7d4d94c7d51d8ae6c0062b49bae3c5ff9c2936f
+Tag = cde54ef5f5f4fd1461a6bf8a1ae6cbb7d324ef62da9155aa
+
+AAD = 78099a2bbc4dde6f
+Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
+Ciphertext = f9ef6e5197ed99435d374abf12ca9e63a9db2362
+Tag = 239e70b9de81c122baa7ec8d31221d3066c7699d61fd6fe08b708cd8ce02a288
+
+AAD = 76079829ba4bdc6d
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = b7c713271bbe5051a0c1c99ab1b5abec05af1a6ebd8ccab79a23e1555fbb17588773764ee856096b1de168a4f6356a2f36ec
+Tag =
+
+AAD = 7e0fa031c253e475
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = 881f2e6eb36827225032996158df75ed7b11910e6c94d7f515482b92bbd29c28b51d89aade616c1fbe8c3dce318599e2cd8b
+Tag = 6a311f6a94d3e9d6
+
+AAD = 8617a839ca5bec7d
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
+Ciphertext = 26d8c2d3af698f01f6a2303c6ba19b73520f7d67b75541948ebb122ffc1e96b881dd9662d4315f5c89c0fd87db4308d636ff
+Tag = 4c24ad19a0d9c1bfa56ef3593cbeca78
+
+AAD = 8e1fb041d263f485
+Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+Ciphertext = c522468d5579b4da65e76d586534f9f5413394b465c76b2444bb52f8805b760126eeefd73539095777c9bb82cdc5cfffcc7a
+Tag = 60e038d453325551b2aed60bb79b6238f5fbd6649fd132e7
+
+AAD = 9627b849da6bfc8d
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+Ciphertext = f0115819b3cb61f334e05f07ed71472f409f83d4420e11f64dfb5c395f492261c0cc6da0ece4482fff590357ae32da5a0a12
+Tag = 0862b4e4df0618b347b0d92e700b07b63ea6b33ba9f4605219fc5f244ff58c71
+
+AAD = 9829ba4bdc6dfe8f20b142d364f586170798
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa0
+Plaintext =
+Ciphertext =
+Tag = ea24ec1a2662524e
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a8
+Plaintext =
+Ciphertext =
+Tag = d5aa8fcb4b47fad9f74894192d52ff42
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
+Plaintext =
+Ciphertext =
+Tag = 624bcbe68351b128ddcdcf384065b6b3ddb75ae0c26e6d77
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b8
+Plaintext =
+Ciphertext =
+Tag = 96607c892b3a15fda8b1e1d7ab78811beac62cfaeb6f59fc383a2a43f4c071d3
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b6
+Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+Ciphertext = 6545148db611e243a9f41b6dbb8141d1b899c760c3862dac472d87e24ff6
+Tag =
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe
+Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+Ciphertext = f81d9117ba585443e156fa0d8ac7fa149ddee3ae3a9c2ad47319c8616c25
+Tag = 4fbe7f26413c6566
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c6
+Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
+Ciphertext = c255b9d727cb54ed034f889fb7fa710d9d187bf0c5ac3ca8c127269718fa
+Tag = 1ca7ea5a292a3537db047f049d15921f
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
+Ciphertext = 973d3eb7bc52ed3686c727d9adc6c02037b008422fd682bff1dd869d3e12
+Tag = 7f3de5054fc77601c5dbd87abe2da5ad61620841c1a56b84
+
+AAD = d667f8891aab3ccd5eef8011a233c45545d6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
+Ciphertext = 02b7186d3933eae5a9cab9d7e2daf9e0d2b7046b2323d55130cd6471b720
+Tag = b4ea6bbf1c6d025d0e08d8bd21b6bcd8ac65053733d98dc87c602bca89fbb34c
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
+Plaintext =
+Ciphertext =
+Tag = a4c2b9a93517eb8c
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+Plaintext =
+Ciphertext =
+Tag = e0f0305c463829ac1721b596070a0f5e
+
+AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
+Plaintext =
+Ciphertext =
+Tag = 49c6a456f025add55f4a0e677f63283d7309905fdbe91bea
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
+Plaintext =
+Ciphertext =
+Tag = f624bf7756ac159585a97875bec41f371eaab26ebd6071077142a51f12add791
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
+Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+Ciphertext = 22f39a03bd5ee90fda71c94fe22f79fb1f0e4f7df33111b84153ee20e185ca0c2164d08c7eaba108c2844e8d
+Tag =
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
+Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+Ciphertext = 83e008bd30d27d77699d6214a11e0823f321a3018d5f4b3056f27bf73716e63c2ba219238b815078fad77f86
+Tag = db57d743b18b34f2
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
+Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+Ciphertext = b6944ea67c13f2afa92515d7e09273aa910501d211ada0cecd50ad1212cfed0f1f45fb8d504d87f72a7bb7c4
+Tag = 1cd0684de66d1e0998998812fba1ddf2
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
+Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+Ciphertext = aeca5368ff55a0a97da1597902ac444dd53fdd2f74b600c5ab794a6ee8b2c0d33b3f06b849a9398f2910ed9d
+Tag = 9b9d339431b60be22703aec6a7d292c8e2bf195745e22360
+
+AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
+Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
+Ciphertext = 23055bcdca8fdc0451c5169d0188407a27705e37a9933773f56d30a82d04fb5f8c3067ff655d01330e9b65d1
+Tag = f8bfdc4166741bd099aac315c35a385c6b379633309dad9d0639d09c86ee185c
+
+AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
+Plaintext =
+Ciphertext =
+Tag = 2c2ced637c2879b0
+
+AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
+Plaintext =
+Ciphertext =
+Tag = 646f5a0536c3b3099a44daf25ba8e3bb
+
+AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
+Plaintext =
+Ciphertext =
+Tag = 69ca1124e84d1accb9830c71bdc8c0e18e6dd244eefb9e01
+
+AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
+Plaintext =
+Ciphertext =
+Tag = 0982618e762ef15c5987d4b0db50063bc1cbdf0080867e770c0ed962dea50f21
+
+# initialize with key of 128 bits, nonce of832 bits:
+Key = 9a33cc65fe9730c962fb942dc65ff891
+Nonce = 0364c526e647a809c92a8becac0d6ecf8ff051b272d3349555b617783899fa5b1b7cdd3efe5fc021e142a304c42586e7a70869ca8aeb4cad6dce2f9050b112733394f5561677d839f95abb1cdc3d9effbf2081e2a20364c585e647a868c92a8b4bac0d6e2e8ff051
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 3f646cac3a0e1651
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 65b23d8c219efa8bf68560b3172de0f3
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = dab5b83342bd6cc9b6995e05d552570da342fd910eba12cd
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = cd92250d86dfdf5052556b5eec04f984ce0899e86e31885a7ac9cf9a9b7af778
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 2ef9dded14
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 4d0d16be4b
+Tag = 6c689d66783946cd
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = f827769ac3
+Tag = c46de0399191398dda9d13b1150d9a97
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 80af0f3c9b
+Tag = b59ed5061508509a3d0a67286c9efe04adf03996ef6c5192
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = f5211c90d6
+Tag = 21a6771dfba0187b6f058bff9f0f1333156d9f32aa7d136efc6908212be3ef6a
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 16d43411e768fb563cfd8555
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = b66db058cc700d2bb30b1575
+Tag = da252e676839a63e
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 4faceb7f465d903bb2e59a6e
+Tag = 85d330723ae4fcf4a286ef98ca7f1091
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = b5f7043dbc578788b6d31054
+Tag = 52403d1f747e6d95d17ecb573f655f2fb0152d137817727a
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 0e8267d12e9207e8982968bd
+Tag = 208f53174bd2f1576ca4877cf6b70bcbfbb62871ffb5b493b167095fa270ef2d
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = b0ecffed5fb7999a8118b4b13f384cf7c339f9a4190e6f
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 4b7acf9436a0f4cbad29627dbd0efd12854bac94ae34e0
+Tag = 8ee6b8626a90bbfd
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 08e9d69325b3f48cedb6c3faa1c4d2b25f1870e1e6ba41
+Tag = 3abb337fdb097a7c061014020eac8d32
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = b29dfbb5057d3f0d9748c4202432a8ba81d3140bd53ce8
+Tag = 421116dcc81675d135153e2689d2091b5721dd1e23ec0d7a
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 2d0a9868896e1ef0e891a695e760f2616ac37b99563920
+Tag = 6b9299fd2f98c0ea7f311dd863e7ed15808e1d96dd82a08a270641c47bfb6b5f
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = adfabd8a0748414180979fd50ff9baa34479040d0544252832db595cd9caec9ed82f24ac94a115
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 0c6a58c292196e697066b1d9e4f6997334a4bfdac9d146c69622f810e4e6b8d8456c9d4fbf0a13
+Tag = b646fe49f40a086c
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 2e5c51069d4c1872eb4cc139426a4a85ad880531b93dd2b01fbaa043f8167f38596e95d90b621c
+Tag = a70f57d015bc8be61a567d4427210b56
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = cd76b1fe0c561fedfbf214bcca1fea188136320253071ce2056292d8ad2d309c7517d10f063faf
+Tag = 6f833fad638a3e94e2d1e62a40350954f4d665513b7f2508
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 9e1d19de588faa447fc02f19e1ec1595a3aa121966e741bb68a57839c98bd3cf38e9bc368b58a8
+Tag = 3a85d04228b0ef1a34aa284eb8ad5ca3d9602f71ee232d3e7be4955bbcff7ec6
+
+AAD = 44d566f78819aa3b
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 4cdd6eff9021b243
+Plaintext =
+Ciphertext =
+Tag = 062c4dd9ab2dfccb
+
+AAD = 54e576079829ba4b
+Plaintext =
+Ciphertext =
+Tag = d173d05933f76688911cad099cd8c15f
+
+AAD = 5ced7e0fa031c253
+Plaintext =
+Ciphertext =
+Tag = 3d9d99a18db85d2209b2ce485a73a6e032d58db4d7fd71b3
+
+AAD = 64f58617a839ca5b
+Plaintext =
+Ciphertext =
+Tag = cfb868bf8a2c41ded07cc4d93225ebdfe17d10e6fed105fe447ec9795a31fc14
+
+AAD = 58e97a0b9c2dbe4f
+Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 45d5f5373296deadf267cbd4ca73d4fc4aa1ebbf
+Tag =
+
+AAD = 60f18213a435c657
+Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = ca0ae0885e9e77a6049936db208441e28a6a36a4
+Tag = 2f12e384ea59d310
+
+AAD = 68f98a1bac3dce5f
+Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = 476fed2cf9a180ef23bd49e2709a6b1275e4b996
+Tag = eacfc69d5637df836fb013df48c64a4e
+
+AAD = 70019223b445d667
+Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
+Ciphertext = 47d0d6fc8c91061174c6f899b104c330a95480f3
+Tag = 480a478bf2067293a9c797527800458d3734334b4fbc6a3f
+
+AAD = 78099a2bbc4dde6f
+Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
+Ciphertext = f03187e7074057770c3c4bab6790ccb0dc782b38
+Tag = 317461fd42cbbf1e1d79a9feb320fa0adddca3b8884a663d3348fd7c82e8b0f8
+
+AAD = 76079829ba4bdc6d
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = 0fc535f9aa3afe956298a99c9045ca34dee7fb9271b7ee9a69f378ec0ca8c6f111dc3b81ec937b608efb8bd44f2fa5c5506b
+Tag =
+
+AAD = 7e0fa031c253e475
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = 0514bc86f4468f8955c44cd3660f903aa67b04256bd00d09e2cfdb2db4803665a069a501127c61faf4806a39587f86f77614
+Tag = 15887cc389f6bf34
+
+AAD = 8617a839ca5bec7d
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
+Ciphertext = 71376828dbf354c4f240bda3b134364c7b38a6ba1d8f4641c093d43f65ada2d404e061f8ff0fcfbb558512d69a5dfb807e9f
+Tag = 2376ff06eb4e6c89e6c508d3a7f97bd1
+
+AAD = 8e1fb041d263f485
+Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+Ciphertext = 5a24ba4f1e6f6714e4252d990a3ac98d2741431ff2866cc7e210f8dfe967e5d4d64821fcde0df9a2d5f47e999f013f9493bc
+Tag = 2d6f431606a78403c6158833845f8be1c5168f5c8bc43ad8
+
+AAD = 9627b849da6bfc8d
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+Ciphertext = 1eb64568609870c566654ef684cba33c69b47d4d31d3a88bfb60b02e06a413cf743e957cb43e24090924f4a8c521f0794d78
+Tag = 69a5188333b59a94199bc67a34b5100b396e1eed057f373e4257a8eeda6437d6
+
+AAD = 9829ba4bdc6dfe8f20b142d364f586170798
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa0
+Plaintext =
+Ciphertext =
+Tag = 05d90ca8d9fcbc1d
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a8
+Plaintext =
+Ciphertext =
+Tag = 72fc7f594a911df2b23c88803256d67a
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
+Plaintext =
+Ciphertext =
+Tag = 7dc8786259c0620d370a89b2dbfb1479e09d2c78e721cb18
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b8
+Plaintext =
+Ciphertext =
+Tag = a8c5cc1302ff465d72fa3eeb3f5c3c3b35b8c360e17980cddfff79750ba367f1
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b6
+Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+Ciphertext = c6a90c2c72cd38579093abe75a7bf7c87f3f50c954a4b736ed12051e5ce1
+Tag =
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe
+Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+Ciphertext = cc904c5afb2791bd80d36b5bee0f2a3b445c3ffba6dfd68493588b71b7f1
+Tag = cd346c1a579fc58e
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c6
+Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
+Ciphertext = 749cef1b1461a026b02958d9cdde1767ef042439ec552c758b8b22238197
+Tag = eddb7d04c5c0c990e41e71fefba58aae
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
+Ciphertext = df038280ef8c7569ac2ab3fb75b8466c983fb17e1a2d1eb11383224e5e73
+Tag = a209ed6d032508a1488a0497fe820f1a732ff8203ce55eb1
+
+AAD = d667f8891aab3ccd5eef8011a233c45545d6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
+Ciphertext = ca2f3e57c048a61a6d0f11d8068ddaae364b449a6c38f4d78f4e8c05e2da
+Tag = a4b7b2e4dead77b8c4c2d2c4a1a041b878303664da7da9b478ab61727e3b0bbe
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
+Plaintext =
+Ciphertext =
+Tag = e99479703dccc08e
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+Plaintext =
+Ciphertext =
+Tag = 2cae19e94e1cbaa73d417b0302f54220
+
+AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
+Plaintext =
+Ciphertext =
+Tag = c92c4bfd6b65861599feb15fa8b8fa643d262f0e2c3efcbb
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
+Plaintext =
+Ciphertext =
+Tag = 4c54434c1defcef17c035f1b4a5003b9b2ff88ad32ffd2489cc4026715a8892b
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
+Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+Ciphertext = d49dc019aa268da9791fde2d841b7203a843f8a79fbf035bdc7e959fb9dfd522a3b103e13ced4bc00ab46649
+Tag =
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
+Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+Ciphertext = 3f281bf42d9e55fef322b332c9adfbb249bbb6f200ff21afa4f675a3fdd46c7f5f5e7efaab66c77bd7055a52
+Tag = bfab283a60155584
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
+Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+Ciphertext = 01186f43b52ff617aeb1050082ec620977e440675421f1ce8e28885317b750ddb4b0ebae443b39a072489cac
+Tag = 96ef908dbfce2d3ac0107e100ee57a0e
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
+Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+Ciphertext = 6a5c03ab563f78bf1ff87c648fc059ad147e28b2c3169f43e048f614c92a410fd859609fc91d5c48a1b83ecd
+Tag = c61e08a3a33ef763ca6f44a2de62691835b2cf875bed8ee5
+
+AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
+Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
+Ciphertext = de6db0e7a85625a9893a48b2de428e510ddeec1b42c8dd6f3993bdc32f312f2c42b59818979b07b43218916e
+Tag = f14b9405611da03ccd7fd1dd632c61f207abd0f468531757f2b026220c74194b
+
+AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
+Plaintext =
+Ciphertext =
+Tag = 78db4b23706e5b82
+
+AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
+Plaintext =
+Ciphertext =
+Tag = 638e1f6afaed3c5fd73b67d9a6e6c851
+
+AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
+Plaintext =
+Ciphertext =
+Tag = c2e15647c05896411fb1885c45d4323de3fd120363d051fa
+
+AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
+Plaintext =
+Ciphertext =
+Tag = 52bcb73dd85f95f3b609d6fda83be04dcf1b1cad89403d16df3e11daf5c62b6b
+
+# initialize with key of 128 bits, nonce of896 bits:
+Key = a23bd46d069f38d16a039c35ce670099
+Nonce = 1374d536f657b819d93a9bfcbc1d7edf9f0061c282e344a565c6278848a90a6b2b8ced4e0e6fd031f152b314d43596f7b71879da9afb5cbd7dde3fa060c1228343a405662687e849096acb2cec4dae0fcf3091f2b21374d595f657b878d93a9b5bbc1d7e3e9f00612182e3440465c627
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 5a686e0c6d62a6e5
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ef3fce120647313b9b7f135c357ff192
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7144cad512b3fbf3c32fa6596ad03576fe7226fbd8fe97bf
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 52bd36047d30e8b19e1fb9ccbf4dbef9b3d68692cc15622c95700a7c95106a12
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 13acef3cc3
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 03731b76cf
+Tag = d5830dbe7266f0fa
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 763eeeb32a
+Tag = 7ee7f976fb42848bf44a9e476122da60
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = c3792fa2ae
+Tag = 96eda6b1e9a33173dc1303b89ca1f93436cd33847415a2c4
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 5e1da00f75
+Tag = dbc8e96b3f4d447e62c8d1343aeaec5fda69a10f75178c623b6abda4808e8ab3
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 27de5f4193b9ec0318b87eec
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = dc9daa2951f46f303d178b54
+Tag = e1212580731c99f1
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 09f669a01ae6263da77a5d81
+Tag = 4e2a9fe20cd8f7ce58bc47233bd1f2f9
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 132693bc7c3ffd2db5d610b8
+Tag = 753c9be86fb7654bec9fb8b7f9c1319e8408d3e9d8699448
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 3df09231ff759dd2d01fde5d
+Tag = 11c9ff0b46d33791e2a768243c32ac4762fb3bd59ac19994048d7bee2d9fc80b
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = a3bd685d6e05be37b64c8454556323149f2ce336012f9b
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 4b403bcc05b7c968caa9609b0283b9414ddcfd33ca2528
+Tag = 42510b3f172f2529
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = a0fc56210aa2f048059433430f9d362c559830755d21aa
+Tag = bc01f2aca02ebf17d093af82f8f032c4
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = b831a340f30d627c0f28d4af24bf72aa9c95a839feffd6
+Tag = 25867e752db96bd2ad4879dcf5bfa0415ba7af4fe4cf8c1a
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = be99946ac3b80df2fe19deca88effcc772c7579b6f5655
+Tag = b7ee7201f0f2dc6d2b155385c6db65425dcddb15cde4b8730ec148444f9ec114
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 9cf9633d61095c2754734e70ab9914c01444a8af7ade7daa7a94ada840ed0bdf813a08ea51250e
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 596bbb4e1638bf2efb4f01473c79bf6fbd565dddeb796be30984b997ff9ecb7550a87b7dd94e81
+Tag = c792bf8e50b7070d
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = b1b95d3ad101302fe47453c5ff0067cfe69b446076619cbcefe53e06b377a94f710528b0946703
+Tag = 01d2c64eac873c447c4a939e53460179
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = bbcbaa5bc4cc6017146155ac65ec28e48a3d20e80955466ff79b3a2913ddfc7ccd27edf34e9177
+Tag = c185c1f847262fd7ac77a60f7a83093431e7d8fa13c0e641
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 6ad082e3f8309ce4d10999e0bdbc3504471e2f1b0a0acab78d0cc43cc057fa2dee70febc2c2965
+Tag = e0b48ad39b64b09748eeb3da6bdd94a0fd960b6d302f58fe4366701866f96a59
+
+AAD = 44d566f78819aa3b
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 4cdd6eff9021b243
+Plaintext =
+Ciphertext =
+Tag = 80fc0e11b2776964
+
+AAD = 54e576079829ba4b
+Plaintext =
+Ciphertext =
+Tag = 4885d30c0460ca7ef0453e5ff3884151
+
+AAD = 5ced7e0fa031c253
+Plaintext =
+Ciphertext =
+Tag = 218849fc9366d54aff8ba1251f06a8c33ae3aefa0745ce54
+
+AAD = 64f58617a839ca5b
+Plaintext =
+Ciphertext =
+Tag = 4231903e6e8650a76ded60d09b6bffa9feffbe6c4053bbc6b6375866b78ab672
+
+AAD = 58e97a0b9c2dbe4f
+Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 498fb6f1bee9c08a84719af14b28ddd322566aea
+Tag =
+
+AAD = 60f18213a435c657
+Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = 00204e48f3d2e85db90a8a6633ef55afbd377dfb
+Tag = 1cfb09d2e898fa3a
+
+AAD = 68f98a1bac3dce5f
+Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = c476472809e760507d38815110670cbffd1405da
+Tag = 0248e50e5ae0e426c02866898212f970
+
+AAD = 70019223b445d667
+Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
+Ciphertext = ff3d8a261c9e10832c33a3ed62458312760dc6d8
+Tag = 29543461655d7fed421fdfa41773ad67c694659ed8e01d3c
+
+AAD = 78099a2bbc4dde6f
+Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
+Ciphertext = 8ef90037ce43475cd51804c307f216075931eb54
+Tag = c4c51d4dd00a732b126169d64837f7bd6adde499abb9578730da2f504a1b9f1a
+
+AAD = 76079829ba4bdc6d
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = b8f2e3e900bf0253b9d2750c927ca39fd879d2976b75077ff4995cd5a9b456978f636f5bfd31a24895b5c2d406a5a4bf2e41
+Tag =
+
+AAD = 7e0fa031c253e475
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = 965ab4502e55aaa100c9e0a1030b2730725acd86887a0a3da811a4479a2357c12733d7b17767286ce7a77c6e96fd572df4b8
+Tag = ae48a38e53be9300
+
+AAD = 8617a839ca5bec7d
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
+Ciphertext = 1a72a53b185e476d43cfd3d97efc8c67af3b4531a04ab559019390f76018970febbaa94d954083182646eeda066902236b9e
+Tag = c8de95f46e34a55ac9b4d886b65a942d
+
+AAD = 8e1fb041d263f485
+Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+Ciphertext = 882d6d5f37b1a2fa2fe8233d4a0ec85b7adec94c6ac6c2ff5d7b9af35980f9af4398e4ad357ff1706efe527d7025b51aa617
+Tag = 77db3999f5fa495358fe99849e9ad85e3cace7d857fe7dae
+
+AAD = 9627b849da6bfc8d
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+Ciphertext = 8f505ab334d6e5ba42f2ec1376355dd90e082a5032be63bcb67d01f81ccee0278b8ba8dcbc4a4bfbd70154180d27b64d2b01
+Tag = 2ec3a5c12112ea337d3bcb0a53e11315bf8189a3b5ad20e47c1f2bfb5a86bc6d
+
+AAD = 9829ba4bdc6dfe8f20b142d364f586170798
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa0
+Plaintext =
+Ciphertext =
+Tag = 3257e78b715a0fbd
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a8
+Plaintext =
+Ciphertext =
+Tag = 1ce2c4b79bff9b12c288cab366b28d5e
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
+Plaintext =
+Ciphertext =
+Tag = 788f36e74953ed889b78054f232a02d550a1f06b0ab5a222
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b8
+Plaintext =
+Ciphertext =
+Tag = 466fb87db92c9090946bdc041d5d216094149e92fef6dc7996baff8e4d2c66b3
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b6
+Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+Ciphertext = c7a8ef6a58b50706ca9ff27de41a466edc893e130482170dd3679ed1c288
+Tag =
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe
+Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+Ciphertext = ccd182779e21be688c6ca494662bc47702dd6d121f6eba59e0721ed2c07f
+Tag = 58b2f95edc12ae53
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c6
+Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
+Ciphertext = dafcc5c02f8b201ee0a24a6d63cc8a0a30dd6ac7ac332f3ad0d97e3df939
+Tag = b583f42120d13ba8608204fe22a9ea01
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
+Ciphertext = c7ff666fc51e3d89ad4dc213f59f65b9127116d10b72baade3c9e51606d5
+Tag = 74cc26879e1e3cce63a49f4c9b4aea59b9d5850f29bd100c
+
+AAD = d667f8891aab3ccd5eef8011a233c45545d6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
+Ciphertext = eead6cb784e8f0cd925f1a832db3944e407a0d7064fb6c7adce79f751475
+Tag = 0d1a4a6edf67916e38fa1037c6350be65e4534ff362c5ad60ac9c6c504797552
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
+Plaintext =
+Ciphertext =
+Tag = e2191197b77804c9
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+Plaintext =
+Ciphertext =
+Tag = c7f2c1c66e94c86640dd5ed6283f834c
+
+AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
+Plaintext =
+Ciphertext =
+Tag = 28f2ed85c415d3ccc2e08412fa6779df620329cbcaf850b6
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
+Plaintext =
+Ciphertext =
+Tag = d09104ffd899ceda208c44b471a3ac79d65398302ff23a53f6c39897532afb55
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
+Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+Ciphertext = 874cc6e6546a9be48cd043e70508a6d1070cf892fcc815b15dbc90ba0b48599e557b0563815de9af468ef58f
+Tag =
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
+Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+Ciphertext = 74e5981636e65c03a592381b4366d029e0816d6347c61597ef1258a8ebd061ccca2bcddba42b6d20ef0e90ee
+Tag = 80486d47f1c71ddb
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
+Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+Ciphertext = 72a9efa0a78cceda3c65f07f985835b950b8d2565a030d54cde7631ff5c5cd20aac5448004f8645e8e454fd5
+Tag = e473b2e785dfa779d64ee31021ca4e30
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
+Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+Ciphertext = 6b2943f4b2186fe699221b09ca1e0b1f27db409697c86eb0d976f8a5c58c405da08d5ba966e53d578dad53f3
+Tag = 0513216ccdc09d8aa4bca65fde363e8433193431fb1f7f75
+
+AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
+Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
+Ciphertext = db9f993fde1dd01739ff3dc133f3a01780dcf4d4c0edbc8f442aaa2f4db231c5a8a96b19336f3d779e75aae1
+Tag = 7e63ea3793977273f9fdbcc4ed1a97a26549d7f0b128cdbb40763f017ac45cbe
+
+AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
+Plaintext =
+Ciphertext =
+Tag = 3e451771ccfcce92
+
+AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
+Plaintext =
+Ciphertext =
+Tag = a82f02467a9af70481c45185aeb88b3b
+
+AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
+Plaintext =
+Ciphertext =
+Tag = d6b9b76a977b979da4af99d3adaa384fd57911b16c200713
+
+AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
+Plaintext =
+Ciphertext =
+Tag = e690f4696bd48cd5392910ba74b4f6ddfca118695021e08042cd6bea949cd692
+
+# initialize with key of 128 bits, nonce of960 bits:
+Key = aa43dc750ea740d9720ba43dd66f08a1
+Nonce = 2384e5460667c829e94aab0ccc2d8eefaf1071d292f354b575d6379858b91a7b3b9cfd5e1e7fe0410162c324e445a607c72889eaaa0b6ccd8dee4fb070d1329353b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667c888e94aab6bcc2d8e4eaf10713192f3541475d637f758b91ada3b9cfd
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 8cbb835a1d67acd0
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = eeee5454ab5614bf502f1cd892b163e6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d3c77fbe9fa9a99feaac1e5ffe92f04fc7f3a951e53f32e1
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = fe69c22bcf4147c946e0da5e2346802eaa364b76f816fb5bbf4422e82eab1b12
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 7760b50efd
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = b0dc1a1c4d
+Tag = bc08a919a13fbf54
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = e590478583
+Tag = a3a2718748d51ef0899c54e41cd14ebd
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = cad2acc9c7
+Tag = 35887022c618ef898b3023382f4b4c4ce85179e1f8ccf508
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 5f4362000c
+Tag = a8527b7ceabe3b75756e5c3e9fb282cbc5219855320fe95f4bcd72d1890b9f8b
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = f46b821b52c8d3ea709db1a5
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 6d7c1b63118266cbb9e1b9e8
+Tag = 65abcd602d0a6cf3
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 4779ea92d6a0b8feb071520e
+Tag = 8f293749ce9bd7823730f8704700e5fd
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 6fe91761006a2220d0f269d9
+Tag = c2475297af1963a073c5c0bb62902d9682eb5ceebdc045ac
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 7cbf00e4df2d558941d7c3db
+Tag = dc6a39e56d3a7f03d1b73fb421645d5803bb6e8444c134ada494f5bbc5448b49
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = d543bbe88c028a1c1b3d062845240ec827409c0cac4608
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 5a986f73e8ce418df4603e1589a4a9ea229e51ce4b98e6
+Tag = 3f32efbea1aa50db
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = f913bc1c8e89f93943bebe9a4d5bb1611354a683fade69
+Tag = cae40ad9f7c75cd954cba88290340e52
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = a51c59673a8680f216d1f42a27133149580121aa7a5fb1
+Tag = 988accdd465c765577e75ff2260c3e49f284167fd69c5186
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = a1b1c3ffd499c254a5bee4a76cbaf97704313416f65ae2
+Tag = 7afaf111746e780b506d44b33add8a751e12b98014a7a435cfea6f177f948090
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 34683ae09324615ef0906383f0d16e92bf1cb014cd20b6b89aaf08eb7baf8ed6d3bc2c652f0d76
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 1380cf8b141c4d963ef828e78408175b2d953cdcbd516bc0041ea72cc84b4bcc0e5872740fd109
+Tag = ffe1556d350320c8
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = d939d5d3480fee44af7820f191672ba35a511337bc35803ec4d90614a03f43b04444f390e5386d
+Tag = bef4c1380e02d5c5753341aa8d8f6503
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 03aa9d6f2281c3b20dd65971e1adeac9585c3773d01ffedefa6287b8ce2f52c942d3a93802cc04
+Tag = 3c1b3d5590e5a3c33a6b3bc0d091326e8e88019ed7d5c6ad
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 49ac6419f4ef6b26f5cff2dbf11406e6858e7011fcc70699aa1940a32fcbfe6a8313ac60f967b8
+Tag = 756382a6e872816b0f295cc158b46fd45ac866ab6d5c37c660f7dfcad6837b8f
+
+AAD = 44d566f78819aa3b
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 4cdd6eff9021b243
+Plaintext =
+Ciphertext =
+Tag = d4cbc9de27a6154c
+
+AAD = 54e576079829ba4b
+Plaintext =
+Ciphertext =
+Tag = 98d045e1554034b3a620dfe161b0aeda
+
+AAD = 5ced7e0fa031c253
+Plaintext =
+Ciphertext =
+Tag = e4fb2e680f9100f5aa3d1e21539455b88e2ad764dfd193d2
+
+AAD = 64f58617a839ca5b
+Plaintext =
+Ciphertext =
+Tag = 853fabde6e03c789c34220a1db5e6a1ede37a288ebf9f7e5cb1f30a6787fbb01
+
+AAD = 58e97a0b9c2dbe4f
+Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = d7c105c648c7404455565dc70a152fce178df003
+Tag =
+
+AAD = 60f18213a435c657
+Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = 4d242dc2c9906b5a9eba26e52c6fc5bd1b672e59
+Tag = 8e09d34b6a43ddf6
+
+AAD = 68f98a1bac3dce5f
+Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = d70715db40b4fd2b9f7a83a0282494c800eced32
+Tag = 038d52118bc684845ad1d4b85a58c5b0
+
+AAD = 70019223b445d667
+Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
+Ciphertext = b320a8716e319e1e1926358bc21a45309672d855
+Tag = aac3ad393ae9d07f501f4f5aca0ab241229ab23a05abe192
+
+AAD = 78099a2bbc4dde6f
+Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
+Ciphertext = 99241490f501912a1c0dbdad235a79c44be4be6a
+Tag = 59d5bf769cf478f73403131df332c0306d2097b44e6378ba9ebf8538e6063e42
+
+AAD = 76079829ba4bdc6d
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = f3c20d15ef7e567d57f752eb5200ce03e8129bb48eb2ef86977202aa93a13521e38a125a7bceb44ecb917c0d0514d9b41606
+Tag =
+
+AAD = 7e0fa031c253e475
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = 8cd40273030403c0dafc16aaf0b0fdbbe102e7daf2f45a6724c15da2a2fd7edc63a33c9d2385a92fd8d2ea44a5cc6f1b72e4
+Tag = 80eafad1d8d511c8
+
+AAD = 8617a839ca5bec7d
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
+Ciphertext = 7a33848c68719ab9c53836ab563d02dfe189659b0256ea2780b7e99ce9cf6796b664e793a62c48e22ee4ac12d708564df19c
+Tag = 6870d98201dd8b56b0f664ee6654e7e4
+
+AAD = 8e1fb041d263f485
+Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+Ciphertext = 019dc26ab6b3eae9ec11c27bdd31e3d5b360020ba8d757736172255e2be3ad1570b3727e4df72ddff734195288a1937b9af2
+Tag = bdfce6e6a3a490045631e968568dfdde1f3338ab451a0bd7
+
+AAD = 9627b849da6bfc8d
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+Ciphertext = c84992d6c75ecd6fee704dfd979cd2da9bc6abfb9072a95abe7838a581f31b877fa51ecd4ef9bc3a4deb905cfeed235ee16d
+Tag = a3c89806315c72e98f9334a4ee2c6fce15d34f63be8c5bad3aee667c71664c28
+
+AAD = 9829ba4bdc6dfe8f20b142d364f586170798
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa0
+Plaintext =
+Ciphertext =
+Tag = a050ed631a89113a
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a8
+Plaintext =
+Ciphertext =
+Tag = f96c121333e8fc4f335ab8a314f96728
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
+Plaintext =
+Ciphertext =
+Tag = 89a522680aa3bbdff515cdf93579022524dd2080bc8aa3db
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b8
+Plaintext =
+Ciphertext =
+Tag = c864688687dad46b9b99a5d5f0b2135084626b2f05dcb71d2c6f56d509389c62
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b6
+Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+Ciphertext = d44658a4a2cd6366ecb1c4e04924e84a49bd8b8d0b26056e7540f4f7d6f1
+Tag =
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe
+Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+Ciphertext = 16818be085451184f92f36b0d114f9111fd62a8d11f19d008b2de739d821
+Tag = 8ddfff945931ecdf
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c6
+Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
+Ciphertext = 544a70ddad580d60775f28ad8222aac9f58dbe8756639e0a59a7bab71eb8
+Tag = 8a0e5231c54177cbff7989a5872267d5
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
+Ciphertext = d7191eec553563a315c5363bc2363b2e0aa7160ee1294c4e7c1178cce2e9
+Tag = ce7e1520f9b8df4502ccfcf4f7f53c13334730449c67188e
+
+AAD = d667f8891aab3ccd5eef8011a233c45545d6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
+Ciphertext = f10fbb509106acbb6ea55312321d637a7925b4e79835c19051fb65b74f40
+Tag = 2e65b558be2522d8135be4ff5efb1d1976ac53cb9abfcb9b21ac9b74a287f7cd
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
+Plaintext =
+Ciphertext =
+Tag = 137dfe109d6521fb
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+Plaintext =
+Ciphertext =
+Tag = cb4dc877ede36c141507e54a5ebcc047
+
+AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
+Plaintext =
+Ciphertext =
+Tag = 76611c16527fad7ec998d73eded502eee0e5507778d5247c
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
+Plaintext =
+Ciphertext =
+Tag = c96faa794fb616f847f1acd2ba64d44896141bdec8c56f21ee318442d9e1c13a
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
+Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+Ciphertext = fec3f18d0b6cfd45224f34eeb9527098600fb86eafff33e3070b446e8b387855a4dfd09a69c7bd7120daa485
+Tag =
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
+Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+Ciphertext = a87f405dc5e3fe873c4b6538553c039229f7a9b0f84d3a7b693328a1e9bbff0358f65da28bb8c98a76bb7ab5
+Tag = c309df12f27d26e8
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
+Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+Ciphertext = 395aa1723397da50e450b4fd58ab6fdebb1155bb07e70c1cae823ca07b5e048200dca29049131313329cbbc6
+Tag = 4958058cffc9277fa3a52bcf2781ef45
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
+Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+Ciphertext = 7dd3cf99686d7e2683724d94abaf82acda420e8ba67d574043d4811e908884beb6b977ae6eab035615d9a94b
+Tag = b9a4c65390873f8ba320d10f88552164c4d18bea7c4410cd
+
+AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
+Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
+Ciphertext = 0b27077bf9064bf7f0520c626d67138afaf95c57738bfd698adb189274550adce43ab44fb674e98139e5b815
+Tag = b5eae367c79ea867419282a8855a830e034f1f23b07d6aa7ceebf5b1da05016b
+
+AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
+Plaintext =
+Ciphertext =
+Tag = 222b0ea9432f7bad
+
+AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
+Plaintext =
+Ciphertext =
+Tag = a25dfabe677eff1d92a5e646b1b0c458
+
+AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
+Plaintext =
+Ciphertext =
+Tag = 6ad8cc9f8f9a9cb666654d1d6bef0d63002eed997e8c4f78
+
+AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
+Plaintext =
+Ciphertext =
+Tag = 538b3bea41ea3f75fd7bdd6a68bfb76ce1d625ee536a73b7625078e6924cac5a
+
+# initialize with key of 128 bits, nonce of1024 bits:
+Key = b24be47d16af48e17a13ac45de7710a9
+Nonce = 3394f5561677d839f95abb1cdc3d9effbf2081e2a20364c585e647a868c92a8b4bac0d6e2e8ff0511172d334f455b617d73899faba1b7cdd9dfe5fc080e142a363c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d3
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = bdbce20db9fe79a8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c7f1baa2405cc76169ab747062d3dd52
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 743d337e170c68cf27246cbfbd53943a29273496ddf0cfcb
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7b10a954a16a25b93508964ac028870c634ebed9ba9eca39edf9e3378dd4e0a0
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = e01d5bd189
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 6074a98c57
+Tag = d1ff44ac6d477915
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = f7e8f19c62
+Tag = 734dd473d536cccff76e8dfc1e9e3766
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 12a1fa7a14
+Tag = 96960af729c81b2c7a1546bf349e3b66b2aa5916b9d2f2fe
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 84e36030bc
+Tag = 6b9d78cca4b76ec7fa5f6f0eb09bf89d20ba33caae45e6d50afcd8814830049b
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 2c88621a3ac28f956e22830a
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 47cd485c13fa0ea09a942534
+Tag = f766d1395124e695
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 2cb1d13b97f79810b9a7f227
+Tag = 950553e726684b100f8238a569626fe0
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 88915058c7daaa04db6726d4
+Tag = e1d37ec52e061970f03817185a9cc4d402703151b4c8ca36
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 6e0d7f25249c2715793b6aed
+Tag = cc1a053bebff9d6d91c828fd27224ddb718d64e6c42d34fdeb23c290a1a3388c
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = ae82aea99f30f3dabeeaec752971e746b6ba1d35160ab0
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 531d1e030b3f29148aa2b41acac16d3b1449782bb4ebe6
+Tag = 0df035115e562537
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 136512db5a7d854652afb993ad1237c1b5adc7b83c5337
+Tag = 28066c90cc3ebfa316716c22709fe78b
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = afb90feda3f1ff98b9ced13c683590fe14701e7be3de40
+Tag = e85b82eeb5c2d752be6e7451469df2826e4a468717d1586d
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = d8c4ad37ffe7daf4854408c4d2c39774b7b11b453f007c
+Tag = 550a785575c57eec8207a11d29a90d6042173877db27eaafccf334794bd88af0
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 39d88312d19d07958127daebeb10bd2d8f4164b3dd2462fa321131061156bb6c67b0cecc5ae8d1
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 92a2cef0b6221953303776d81788869f6e5bf2a4c442b42540c2adef715fec68c5730666e35fcc
+Tag = 1ee32242ffd6cdba
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = f9cd7bcdc5e83d2a296064b1d9ff9c3f6bc8fb59aa7c096edbfdc6cff89d38e6f7d478b08a6234
+Tag = 16b5735a3cba93ee2ca816b72f9f47f4
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 8e6a7626d99704015fbb61f36245eda1034a786f37f620cecd883139e65492035e2a08ebc790a0
+Tag = ed81fd3de45fef135bc05c92856d4c2125172dce71d06c71
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 557379c1555a0a0915a6f64fc9327bfea7f5a4bbbd5c893a1d53d2dbdfe31157c4cfbdfbedd3c9
+Tag = ef77368c65d0d73f0d6d4a98050a874c6286d5337e40ac29f1d05c75412050f5
+
+AAD = e67708992abb4cdd6e
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = ee7f10a132c354e576
+Plaintext =
+Ciphertext =
+Tag = 4beb07036c1070fc
+
+AAD = f68718a93acb5ced7e
+Plaintext =
+Ciphertext =
+Tag = 60705c79629b4341b7ec756efcc09b48
+
+AAD = fe8f20b142d364f586
+Plaintext =
+Ciphertext =
+Tag = be5b3fa772986bce240f73e2fb0d0eabf0ad1c17fa66a300
+
+AAD = 069728b94adb6cfd8e
+Plaintext =
+Ciphertext =
+Tag = 33ffd04548cf5dcff995921df46bc3537a78f8bdcd00562951e18a84dfe28cd2
+
+AAD = fc8d1eaf40d162f384
+Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
+Ciphertext = c64f502a9058dc5ffe1e9cf6249c1bb45c4a9dd3f042
+Tag =
+
+AAD = 049526b748d96afb8c
+Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
+Ciphertext = faf271a278aec77e12c24e0b2a98309c204e4dbb2084
+Tag = 79f8c81ec8956b18
+
+AAD = 0c9d2ebf50e1720394
+Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
+Ciphertext = aef22a36547824a0663730c2f55380b2a861e643e5d3
+Tag = 39f653c362aaa546fb38452e48f1a628
+
+AAD = 14a536c758e97a0b9c
+Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
+Ciphertext = e61af45db7132c9e38f2b37c8027d69f004317bde39f
+Tag = 7e66ff46cdc4e75528c47dc842a886e24faa15327ad553c4
+
+AAD = 1cad3ecf60f18213a4
+Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
+Ciphertext = e102a8fc25a8a399baa6d2b1af052ac079a998b0ac00
+Tag = 267514b85221bcda642fc26ccaaa8d43a92992bf9fca9e10630f20fae6007ef7
+
+AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
+Plaintext =
+Ciphertext =
+Tag = f2c6d2e0cfcf89ee
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+Plaintext =
+Ciphertext =
+Tag = 138bd6a251f432a424df778759eb11d4
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
+Plaintext =
+Ciphertext =
+Tag = e2e1c97b1b77849c1bef54172d2c4e5be11a38c6c8a4c6e4
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
+Plaintext =
+Ciphertext =
+Tag = 85ad61699473787bfa4035fb57da783cf7cae00aac873729047a1147e2a91057
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
+Ciphertext = 2ca7106cc0c15a64c7d1722d4b9c37d5a12514abef3c389aaab699d1805223152829
+Tag =
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
+Ciphertext = 2a99e10c4fc0367bbcfaf0dcf6c476f19cbc587d4edd51f1cefc6e9f2aef335f0dde
+Tag = 2bf57212d307c0e1
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
+Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
+Ciphertext = 05dcd8d5dac17a99ee9376627805e294ebda5560b7889a62b3cd1c7c0b8bd8f7545e
+Tag = 01f0578f966d45052fcb37685e02dda5
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
+Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
+Ciphertext = 5997890a7da21ecf3a63312aa0e37a5d5be515c13f3ef117b323d76107b97ee8c1b2
+Tag = 348a8c138d1471fa31489fb0fa68f63bcbdcdde5612e21dc
+
+AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
+Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
+Ciphertext = f8be750fbee8c0eb5717463bebdd241d307377d243c2f592e48a3b97fb8b94bcd709
+Tag = 15799d0c81a2f265693704e06dca53b0a4bff1a4d6a1c571c55381bb35ca27af
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
+Plaintext =
+Ciphertext =
+Tag = a21749f034c39f75
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = db2f973194f73b96ec8a1c37ad94b161
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
+Plaintext =
+Ciphertext =
+Tag = 90a3dbcc7ba07e13bd5d43143bc3c42bd6022a853965c8ee
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
+Plaintext =
+Ciphertext =
+Tag = 4dc660eb6667d5a7d32f91253c05bc3c8c20e120905c1aa1ac9a4e05ec4e23ff
+
+AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
+Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
+Ciphertext = e0e011fc88919158bc5ba297d2d69e30d35ca7533afd4fecee86c06ef80797205eafec7398652cb0cf721136645a03c159be
+Tag =
+
+AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
+Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
+Ciphertext = 7ea2af78b36c8d36bce0a75cc7941a807d165b6b4cbf0a0c5524969dc4dec71aaadc846d9e4ab97565176727bbe68eb07978
+Tag = 1a169dc37b4052ca
+
+AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
+Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
+Ciphertext = f3307f681f22d6530e62a92632509e008bc9bb59d771792e02785550366bb32ed173bbd348831d6239a198c8a65bc6508464
+Tag = c03b862ba790674d2cf3bcf71db8ee0d
+
+AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
+Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
+Ciphertext = a89c2578c38f7a5e2bae8100c4bfa3f09f20b8a846326505cd2f0c41efe5335a5bf87e4b106bd391f0c41ee93b7c162414ec
+Tag = 3866d89ad71141f60f6546326ccf83d77924f55ed33b058b
+
+AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
+Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
+Ciphertext = 8834f3a02194ed0689b3bfe23e72c02eab4a28e076b56cb81915e3b312edb3b357a3823fbe5ed0628705e97b6ea529310c8a
+Tag = 672db0d83ef3d5cc0529ca8b8a69dcf6d2cbe55991c0d620bb6f8df4cdc50de4
+
+# initialize with key of 128 bits, nonce of1088 bits:
+Key = ba53ec851eb750e9821bb44de67f18b1
+Nonce = 43a405662687e849096acb2cec4dae0fcf3091f2b21374d595f657b878d93a9b5bbc1d7e3e9f00612182e3440465c627e748a90aca2b8cedad0e6fd090f152b373d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a9
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 5bbe3056efe78b59
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ed7da3d5ffd6868f7d9a3cad5c3b6b55
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a94245bc152a147026b8eb7bf5066af7e1e409fcf6c22def
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = b8164d98bab7b47b09298e8a8633cb1cb13f2cd6fb57fe8454a11da2db6178e2
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 07a580412d
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = e793ce0085
+Tag = bcbec78e33261609
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 9e9c6bc8d5
+Tag = 216140c258aba5d8e0bd72eb9beec13e
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 2d7683521e
+Tag = 2f2af547d8a19e09fbd51a985767762dc7bce29215be4d1b
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = a5f2661398
+Tag = dd13b57e10d0e98856f364f2dc30c0a2327285255ede29a303f48652b31e8267
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 269743ac4cf7f0d1aa4f93a2
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = a0799d6e77db87e10658a786
+Tag = 72dc49e879329f62
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = bfda08ab5dd7d14c5163d470
+Tag = 0d9a8763ac660bf9de839dff7b9d3398
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = c8847fc0a34aa04a103217e6
+Tag = c681993c0d49730137336345b1ac2dd4d58bdcc1a5bf12d7
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = cd97b35faca4f1daad4f6896
+Tag = ea17eb1c1eb5a2a5da513ac7602631c97dbf6b23d756f93a496709d3044fa40e
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 0bb56c27b5c8d32ca0036b7f57bbf2957fd9f01e22a9f5
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 688bba1a6d69232d81bc1e9fc992a4a55150eec153bada
+Tag = ee467925b566d73e
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = f30ef0c0616a1d81c1608a6873bac0243eb2663a38c1c5
+Tag = ab6af91057e62599839ce4d36b334baf
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = c00a848cd7cea2c0fabee782024c34638e835fb6a3eed0
+Tag = ea321116285549481a2303ced86324c8a184467e824d6ab3
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = a87561ac9f6aa6ea791534ef539c26fdcd22dc4b1f91f7
+Tag = d715b1ccc20839453234d457612b7d087b7f2ac07ae18c171a060bf8a48d2625
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = a56636080ced6a50b0b915efc4d0ca64b9254124df777c369f086751ac2aba3bb0dae2728023ed
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = bbdf44719865d90c05be25c1877677c79bba171318dbcaf8f1b15b48e5360be53ebc90b35ea1b5
+Tag = ef1f34dc2b68f29c
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = d8692ad92b2785e8d36823d714b8fad20aed565fc0b7376b0a6a7513caed0f76bdf0ebed6f7593
+Tag = 0f55c7239cd881080c6db1e612c65e6e
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = a043abe2d7ccbf7681fea974973a37aa3f9c6e3c3511f9f3686dd4133d241fd2403df63024cd19
+Tag = 74dcd4e892b0c494c951469b0b42c354c1843c2ce3a66751
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = d7d3dfa9268f8d52cffc767b2e9a78e5bd7e748da40a8d7b16557cd068aabfbcb00d60bca11548
+Tag = d902359213d8d8ceeca677c6cb357e97904c7657f1c6ca5155a7c44ec6b0a149
+
+AAD = e67708992abb4cdd6e
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = ee7f10a132c354e576
+Plaintext =
+Ciphertext =
+Tag = 62fcb1d60a5dbaa5
+
+AAD = f68718a93acb5ced7e
+Plaintext =
+Ciphertext =
+Tag = 7b069886bee6e7c81cbcff423dcb7e13
+
+AAD = fe8f20b142d364f586
+Plaintext =
+Ciphertext =
+Tag = 2e3e1e4291edc62170ab007d49f68bc43204a11bb2948d2f
+
+AAD = 069728b94adb6cfd8e
+Plaintext =
+Ciphertext =
+Tag = eb845cde9358d437940946696a61e7a576424ec98a09e64f7985a2b3964fb89c
+
+AAD = fc8d1eaf40d162f384
+Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
+Ciphertext = ed50d186af626a4288611de1acf231ba0232ec228d8c
+Tag =
+
+AAD = 049526b748d96afb8c
+Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
+Ciphertext = 2e332dbd08e1b4de6c55eef7553318c3f0e4f755d15c
+Tag = 933749bbc1d83999
+
+AAD = 0c9d2ebf50e1720394
+Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
+Ciphertext = 725f172a062767ff798fe159116dfd303d4eb12c8ec0
+Tag = 2df742b6eacbe6b27d177540897e5f54
+
+AAD = 14a536c758e97a0b9c
+Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
+Ciphertext = f957546d247f21669c0db13b57c7d44443455b5b1032
+Tag = cfe7ecadaaf689f0666bda2389c32983da2facbdb1760e42
+
+AAD = 1cad3ecf60f18213a4
+Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
+Ciphertext = 0643058ece0d14584f26051441883d0c7e3fd970a501
+Tag = ecf55c6d2c4417e44e50ab925f9b3fdd253d69f593d2047278a10a1a23639185
+
+AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
+Plaintext =
+Ciphertext =
+Tag = a3f593c9d2a3b91f
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+Plaintext =
+Ciphertext =
+Tag = dd5e060ba931c23e309801a3bca036b4
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
+Plaintext =
+Ciphertext =
+Tag = 7508eb13a3a94d73c5898c3361a7ae4c273617e38dd11043
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
+Plaintext =
+Ciphertext =
+Tag = 07aaa7a8f84fdc883a250c76eb82e150f521c85ff0edd12e640373ec0f0242e6
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
+Ciphertext = 47928f22b49a1554a20f4318d3b45207ac0ee00d39d25eb52ff57053ee5b000f3581
+Tag =
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
+Ciphertext = 57792857a74446fa6a38064a457e18b045b535728b6be44208652de434b33e3d94a9
+Tag = cdec92c126180a28
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
+Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
+Ciphertext = 7c5552d22338e0dbf677027f011a3a4b5ca1bc67753c4bf0f1914e7c7bd39f5639da
+Tag = 5aa60294d511f088a80beb51d0c91f33
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
+Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
+Ciphertext = 5c8c3cf39b0ca57368dc7556b97bf705b89588007d0e183f7ef81266e23b9aa8b182
+Tag = 5c873087ec32d8d4099dd7ae862bdfdcb2e188c673ae94d1
+
+AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
+Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
+Ciphertext = 2a92e33b4930951081d812808c7e583ed7efa3fad0d141000cdea6994f504099f644
+Tag = 915ba59578f73b3c27aa15b513dd304323d9b81a677e070c0ce8b1683199b55e
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
+Plaintext =
+Ciphertext =
+Tag = 85132ebdb8bdea65
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = 5d7affbceb3a6581169e25281e611e0b
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
+Plaintext =
+Ciphertext =
+Tag = 3966b563ef3ddf934e720cd7805f6c7a55d1d7892b428339
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
+Plaintext =
+Ciphertext =
+Tag = d15476bb9718f32a3973b7a42823ef927bb0f6df6ca8b6bf7d0779ca4f0b19f4
+
+AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
+Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
+Ciphertext = 9f1ef776f07a9385566e60d077c5a2e5d6021a274eb5742c409cf5e6ee954c8d6e7ff6b86ff3a40963d7f0903737b1209ea7
+Tag =
+
+AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
+Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
+Ciphertext = 7a37ced5c11949c21bfa00d538baaa564be45eaebc36ee5e3715f20e92de7c68146cf8a28a2774bfdadb584bfe0c8882dc66
+Tag = bb588f119584c10c
+
+AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
+Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
+Ciphertext = ab941f07a782b76db1a95bbf23dddaa6a1e3173d6710a816416ac1060afe9b76f20f644b7cf331076bd8ff6b499a24d83bc9
+Tag = bb595cd2c7d12087961d2ede496f9aa0
+
+AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
+Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
+Ciphertext = db101d928228e17d2c05fb665a870b0bfa1e8979915909982198ce735b4d3cfd01dcc4518919e27b299ba13948152303dcac
+Tag = 4b91278ae197b6dd7cca31e6b472966f18d85a1ffee5cb3a
+
+AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
+Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
+Ciphertext = 074816336911211a675a6d3c8ee33e920326ca0c8d8133ea7a39e5c0a488c783967ef4240266559e9ae05f1ddca21c402278
+Tag = 68600a63c443e63f31e81620a26f45b550d96b1e16715edfa36620f015df38a5
+
+# initialize with key of 128 bits, nonce of1152 bits:
+Key = c25bf48d26bf58f18a23bc55ee8720b9
+Nonce = 53b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667c888e94aab6bcc2d8e4eaf10713192f3541475d637f758b91ada3b9cfdbd1e7fe0a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c9a77131beff6ea7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9235945ffab4e4030ff097e5b7960b98
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 55d6d886a9baf3b9cd2f65d3dc9ff7acb9274ecf08a3c83f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4b53f16c4456450a9cf7450b12ca82053331877d0ad3e7c624054c2bd45cf5b6
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 222709e208
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 3ba37b69ee
+Tag = 87defada8cb651cc
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = b5002b428f
+Tag = db97c666231642eb6be759fbc27a9814
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = f95e5aa38e
+Tag = bae6356f3fda549e737876dd31094f263d2d7b1e7c8a2e68
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 9148a865ee
+Tag = a14f5efbb50dc9f253fcd127ab90b1ae1e098b1543cf77b5592a5091b5e6c755
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = b879eab819bcfc92e8608df2
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 57ca5bbea4c3aa923a609ac9
+Tag = 27a3373e39618d4a
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 4a1d241d295976b22e24614d
+Tag = 8e2a78933156c3e3cd843496311989a2
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 4622f684646c6a8453702837
+Tag = 300d6c8315511e2be3730faf8ecc69fe1dc18280b29870b5
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = c0816f3687e8ad56ea95797d
+Tag = 4a48951f37e87f8b530ecb926148a6fff0142dd0442aaf92599eb44e3c9ecd7a
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 873eac1a9cfab77ece9e43d51c694829e09da4c20caf4f
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 9d377d7bced80845f9a14bd4260e18c2f01f2f0dc211ad
+Tag = b451f4acc3bffd14
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = ae1df422e36779cc059e422151bfb28f8d03ae717386c2
+Tag = c5861f19540a191c889720a800d26d68
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = b8107dc9ec704d9974f85219bec7c0fa896c01003f3c6f
+Tag = 54f8e8f8f0fc17350b6525531588901d3151bf8a13298372
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = cdf15ad1b8160a13591f6259e7c4ee0e6cd188fe6bb103
+Tag = f9fef1835eac3a788b4569213110a5ebc1aa1e87421b67ca3340d5c71b577250
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 5748248becbd75c146f0c1bb1af11dd56ba5a93225c9be3e34b8a97680b345e5914bef37cd1818
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = af34fd3b0caf844f90d40c8037c8f8e562bdd564e7d9f2bf94c1c4b1ddb11cfe0b346a811ea8b9
+Tag = 174c21811c38a679
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = f79e39c562ee1dfd145d5b3bda18e8d858e6c9c2a63a7f880162671f751351fb77b4ac54eb4e5c
+Tag = 9c93f5a15f8bb51d2d7fae0a4f1d3302
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 4d3083b3a6e04c71636c14c6f5ca90d9a3c86cbfda560c9ecf685c6126388c5b18ae8e65aab1da
+Tag = 4a06586df0e039c966179425e83618f0413c069887642985
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = e30281295f04cdc45237f4e93da99e8285994dfcbdbbc0f3e5fbae14a598a60e89036b5d7462d7
+Tag = 27ed3ef9a0c80cf0e5080df20f15a25e8de17bfed05f3d6f43e2e462da0b145d
+
+AAD = e67708992abb4cdd6e
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = ee7f10a132c354e576
+Plaintext =
+Ciphertext =
+Tag = 74a5d9cc59bb17ee
+
+AAD = f68718a93acb5ced7e
+Plaintext =
+Ciphertext =
+Tag = 3975be9d7123ea8dd17b09f50f4d0d62
+
+AAD = fe8f20b142d364f586
+Plaintext =
+Ciphertext =
+Tag = 722b9ae37a84d94ad3dfd416b28e8a78c675d5b251ae1833
+
+AAD = 069728b94adb6cfd8e
+Plaintext =
+Ciphertext =
+Tag = 8c884c7633c8d662d099509820a4b09a2b6e506da14a8b27c41587dc1b70185d
+
+AAD = fc8d1eaf40d162f384
+Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
+Ciphertext = 23957669f2d84da158e015d6e7f3e7c7ee6e049c489f
+Tag =
+
+AAD = 049526b748d96afb8c
+Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
+Ciphertext = e0d8bd2afca001c0944812bfb68e7ea0b3af9b2c4a64
+Tag = b4a614c46f6e115e
+
+AAD = 0c9d2ebf50e1720394
+Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
+Ciphertext = 0c50d4090d15e45ad328314e68164ae21c0cfae97655
+Tag = 0543e9fe561c7d52414c8d315a30cdd2
+
+AAD = 14a536c758e97a0b9c
+Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
+Ciphertext = 393d855318676fc5e77574c3216e76cacbd404b8894b
+Tag = 52b3bdedc69d5f77a2209ab85afd486b4c229fa329519718
+
+AAD = 1cad3ecf60f18213a4
+Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
+Ciphertext = 9d0e41199c3d4157a1482467032be52685704b594ffe
+Tag = 8499312b60d67a702f4759a54545520a4de912183eb557f71e7ce141227c4905
+
+AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
+Plaintext =
+Ciphertext =
+Tag = 68b9e8d52661950a
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+Plaintext =
+Ciphertext =
+Tag = e5c611444a6e35e0560bf2871f3d3fb9
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
+Plaintext =
+Ciphertext =
+Tag = d87ca71c9f321cc153a45d5c9a7f70dca7b0af7e841a8223
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
+Plaintext =
+Ciphertext =
+Tag = 9411cce7aea1ff835cbd1c9e6285fd3273b96c2d6d364900718211d17205ee33
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
+Ciphertext = 0a325a9febf9404fb77721d17555711235ec6291f5ffdb4fb820b3666ad385070165
+Tag =
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
+Ciphertext = 9bcb7ad754e25334906f43d59b1f72f0b21a1aa995234e2732f79435236c08358a24
+Tag = be8ca69bff1e8910
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
+Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
+Ciphertext = 6cddc150af6c838bb729e026a52b145a6980bea5fc9b8d6d4599e6ade94ce9ce1e4a
+Tag = 3db9ec1add8ae7a4c0fee46723a1cf41
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
+Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
+Ciphertext = af5083b8298ace4b7ac0f8859ce9d57699c70c2bec9a11573f048e1e6b9bfe7e68c3
+Tag = c724d993f596bb70ac0c8939c9e29b9ebf846c431c57c32d
+
+AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
+Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
+Ciphertext = 3c615844cce28a3f7877918ee72527cd6396c4b3eae7928f5c92aec0499c18eb4cdc
+Tag = 615ff0b9443cfeeb0cd498b721e5033d000a1531f08de1ab8cb03005832250cd
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
+Plaintext =
+Ciphertext =
+Tag = eed1b155e68437a0
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = 67a5d4b9bec0540bbe8a3720c6024ab5
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
+Plaintext =
+Ciphertext =
+Tag = a9e072fb57e305b1a211b0a5101dfeea4a56169de658c354
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
+Plaintext =
+Ciphertext =
+Tag = 1c90e975764944b8cba925e5bc58de0581147b0aafc1548d08313684103fc680
+
+AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
+Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
+Ciphertext = 534438da447e2067c10340725bdc1e2e773e6e0b487c1e0ac5852d1c3a2df02687901d60bdfbf4983430be2fa1fc85dcd6b3
+Tag =
+
+AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
+Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
+Ciphertext = 5cede84d7c78573f236e504e0a38ffb033ea79c7c76c1229eb1fb26cfb29f70a35c32484841761818cb27cf37a73d78f619a
+Tag = f0d49d5c236bdf4d
+
+AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
+Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
+Ciphertext = 58f46a195008e8e657b53a13506f77a2c2be03932e7a461445fba5e24bc4ab36465732984c050d39315c678cba25bf7e4ada
+Tag = 9831743efc823d4d119bdee88bdd6bf4
+
+AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
+Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
+Ciphertext = 12cb6d3c66cdf9dbb87c1e0fcb89920b2950250904cc6ce187bb34be2f64fdd3549a4ec5bdd12d9c6e73e87d1538aa77ff3b
+Tag = ddbd7755bdc22506cf64289dbeea8945c1d210b5f1df8315
+
+AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
+Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
+Ciphertext = 2bd818fddb47a0d60451f549ce2a36bac008fe540f7a7186e5442e844a31489c45734517cf9df09e68558e2a407a80b908d5
+Tag = dd63d9aad646d28a3834ab612fdf1fc7775c106c356b553edd620a4d107d53b4
+
+# initialize with key of 128 bits, nonce of1216 bits:
+Key = ca63fc952ec760f9922bc45df68f28c1
+Nonce = 63c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f455
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 517bb6750ce74e15
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 59312e6b1ac7bab102f8975afb25c813
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d113d78cd4ad33a9987db82d8dd242fa87fc8079c96327fd
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a1adf0802c5742f0b7b38d90d684999803eaae0a987872f0bc1db05fb5a6008b
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 406a50ec18
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = c1ec06af92
+Tag = 77241593b9e227ef
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 055a7d510b
+Tag = 922579428985e00056bbcd27aa3012ea
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = d3e978f92c
+Tag = b00142b26b25d9065665d6371e4bff62e0cde518eb06c57e
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 69fe677600
+Tag = 5b564585d25890205d043ec60162df08e366034af08c3be85cf050bfb1f6d593
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = c2e64d2ee371edf2c8d6fc47
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 79dbe5c178fa67f678e4bf12
+Tag = 100ac8ed1f77d7b9
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 002cb53f326513a7ac61373a
+Tag = f48fc9b6b2192827b91c87495bcbfede
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = f7b84c6c90475491295eafbf
+Tag = 867e6638940ee876766fa0947fcab5fc99f14265e90bd219
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 5d474b2604b76a5e34015aa3
+Tag = 6f8fc2fde9d151cd9527690702544e8a9788369e96c107a4218668f066acc469
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 9c28aadfd9331ce6a532090710853008fd21c2d1c402d7
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 703d1e5f851b5071806f0420dac7f1424b872f047695bf
+Tag = f23cb900812a070d
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 9ceb2b3c8e3678c7ebe4a24e7c24e1a0170739d6005e3f
+Tag = 22fc398d90276fe1fc361107718e821f
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 1bfad283fb9446d812502e18e3e900407476767fdd5e1a
+Tag = 58bbac8653ba83689cd384b5f6eaeca7cd99b8add19638cc
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = f05d75bbda5ccb9400713542632c0e55d4c3f9834f1b35
+Tag = 2b688af20f0959a56827c71cfa79fc91637a8685527bd0fe457d29dbed10fc3e
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 9745ca96e4ed5903c05b777cd9ed7d3a044d223e5fd6d41db1e48e58e777b9777e8815b082fabb
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 2a08e9d06d24c2db032bc5e23c0859a8a952d2029bb4ef53580fc77eebad3d0df45f4df42dbc17
+Tag = 6c58ec36d9d3bbe5
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = f126ff4a2d42b416cc5824b6c96b0e2f0b901f1b7b4045c34454b2d22228e7faa97eeb82c29f19
+Tag = 914b37985c69622c0a75ffcf0dcba59b
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 74df1108ad8fb37da0858e5ab4bc5752fd06fc9304c1491bb3a04de9a71df622b491a09311f776
+Tag = c6466f39cb8007570423fbebb6e31676cbd947093acd188f
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 61e1a6d20ed860d8bd787240a2622e974f8a0f003dd09357eb31f29730a6237f5e6dc0fd56785d
+Tag = 4a2f704dab65a3640eee4efaba60072e22ab71288c422acc303b6612871b52c5
+
+AAD = e67708992abb4cdd6e
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = ee7f10a132c354e576
+Plaintext =
+Ciphertext =
+Tag = 963b8f1b4c4ba956
+
+AAD = f68718a93acb5ced7e
+Plaintext =
+Ciphertext =
+Tag = baab6945f8dee5d1a1cb7ecc5a5bfc3a
+
+AAD = fe8f20b142d364f586
+Plaintext =
+Ciphertext =
+Tag = 742256032689966c732d2ec45ad8ccfddf084c34c3cef054
+
+AAD = 069728b94adb6cfd8e
+Plaintext =
+Ciphertext =
+Tag = ec775512b21ceafdad402a3b5c9732638980619db646e2835dacfc9e0d6ceb2f
+
+AAD = fc8d1eaf40d162f384
+Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
+Ciphertext = e17f35268a34b8e50c1dcfda886029fa3a8397f0c3c7
+Tag =
+
+AAD = 049526b748d96afb8c
+Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
+Ciphertext = bbd17ae6e0d41c834c4de236c13d2394b8dabfa41ec3
+Tag = 8600622d3de66540
+
+AAD = 0c9d2ebf50e1720394
+Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
+Ciphertext = fc747f1599c77bda5e74af50b59bded41be03fa6b69c
+Tag = b0c89839cfec87c769f4bf169f73775e
+
+AAD = 14a536c758e97a0b9c
+Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
+Ciphertext = 3e9d2b5188e6c6a53cf5030bd4599500a5cf9f1c0f10
+Tag = fabd0e88bc4b0e2891f09b54119023abf2057e895b18d493
+
+AAD = 1cad3ecf60f18213a4
+Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
+Ciphertext = 3995d624d0d05fb8c6ea74b995e38c465602f40fc729
+Tag = cc072eee5121dc677d3f7bfb29379f6975e039e77b90019f94cb38634e2f0634
+
+AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
+Plaintext =
+Ciphertext =
+Tag = fbb13ac80f048f48
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+Plaintext =
+Ciphertext =
+Tag = 76bf4a86ea75f629a24647c3497948f5
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
+Plaintext =
+Ciphertext =
+Tag = c36d79a4352e1699da77f652122dc4fcd78f8f59abf2dc31
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
+Plaintext =
+Ciphertext =
+Tag = 77518f95ea372df15246efdd7ebd4f72f9c12b415d7d3c74d92d733de206d3c6
+
+AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
+Ciphertext = 40f38fb1935b5438565f70da9e439d6f4b7caeb36c9d0da73b367f1b14865d9967e3
+Tag =
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
+Ciphertext = 212d19f557fc1505a18e97ffa8ad0dd71ab89892e27102670405c7ef0701b6d82615
+Tag = b15f1f1c8f4d35c7
+
+AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
+Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
+Ciphertext = 2529d74b424dfdc48fd1ddd1760d54c631062ec7a71d6dbda0d8cd91c11992999572
+Tag = ecd800a8bdc405a972a84a086bc37fa6
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
+Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
+Ciphertext = a1a2311172efcc9e1fc53665b277aa861379ff3213c04956d2c540c30a0f6aa800bd
+Tag = d12ed3f47b7e66c256dd36794ce4c0a40d4db611c97ef76f
+
+AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
+Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
+Ciphertext = 23c5cd8fc4903829747479915261b78654bc8631075be35ba3b689332d97a5a9ccd2
+Tag = 7f9dd289816dbd8748ac743354716292ec81c399d616c53af0f8a59ef04c108a
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
+Plaintext =
+Ciphertext =
+Tag = 9b7e4fe8414cdf53
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = 73891d2096fe95e113b8c96c10fdcf1a
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
+Plaintext =
+Ciphertext =
+Tag = 6eb6c8913e152b5af68175c1ff4c461c71c83f89a2416bba
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
+Plaintext =
+Ciphertext =
+Tag = 71decb11965b05e8d0861934a570140da494797aab7eeacad26f9d9ff71574d7
+
+AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
+Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
+Ciphertext = f76abc53e591ed31a1efa1249d91dfa253a7e27bdd072ae2a8e7e9e940ac8dd32a4ac5cc1fc267fab44980e99b258f003787
+Tag =
+
+AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
+Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
+Ciphertext = 04ec8c07eef82836373eb69b41826d1ad21c6924e4aba77209df4df96329bf25c9555a42e3048550b95251487d2a4eb735a0
+Tag = bf817ca8213c66f2
+
+AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
+Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
+Ciphertext = 9620151e271f710df5a4e6deb14c910ccb0361a20ffed79d1eb8b65e257692f7bb101f7641f463ca030c670c8b934361edb3
+Tag = 0853d4e7a6276f8ddf1f471319ead5dc
+
+AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
+Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
+Ciphertext = 3c171ed0c7189c9492d91528f901fdb1fe920762a4a3eb86a313884238c1584aa9916322caa75336aa52bbb9a831bcb74c3c
+Tag = 6562ff882423bb89667f2dbc84b162161887bc4f7298c5ee
+
+AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
+Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
+Ciphertext = 6ea079d914b0b91a55114cecbe1b7adabc303fb036ec1211a7a5249434563b9a4c2e56a32c00dbc8d8bd60d4db99efe79d51
+Tag = 26c586c8208740240fa4bb2db0897132c27e3c70874ac5af42544d2ce684da30
+
+# initialize with key of 128 bits, nonce of1280 bits:
+Key = d26b049d36cf68019a33cc65fe9730c9
+Nonce = 73d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 5f4111619cd1553a
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = bc8eeae299416a4727255804f374f84c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = bd49129b54cfb1e21b2d7042a307c36ac75ade06e18b4d2f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7ea1c20e889eef9b5e04ae3b5338f02ae7c9c80d07cdcd0ad37339e9aaefb6d5
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = fd2a0e4b4b
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 7d8d262e7c
+Tag = 82ff04794b500947
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 456912ba11
+Tag = d0bfc7cacf4efbdd0f941f92151589ec
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 1931e10759
+Tag = 95fa9610eb80b602e43ae14a1e7fc3d1088c4ab8de74167e
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 8b32fdbcd2
+Tag = 43225a535245272277691b4153c7ca55d26becc3425bc307f0a65dae7c58b30f
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 6f481310526b8a8b0844c9b9
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 7a3ca34f2c32248adeb4fa85
+Tag = 418427ea6c383b2c
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = f2fb50ae65eb6dc13813d6c8
+Tag = 4a844571c94a8a11c9696b6bc7df0ae0
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 82dcbe96870843940f820bbd
+Tag = 4a0c143ceb09c4a7cdea711eca573e6765a31f1f57cb1f39
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 2fdc92457a855ad1c2ce0e4e
+Tag = e0f236d3d5a0cce6a0b2058ab1c30a900e1da65e1bfc3c95d754cb8253c650ed
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 3125449a4fa3c7ebe156651accc579b4f31f9556a2ad45
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 82ab7550857efd719899ce14637ebe9989e816f2d6e26b
+Tag = bb63bd63af0a05ff
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = ec5ae11ead411fa769de8661c5fd5ba5890f190c57930f
+Tag = 98173050b6ce8da73b1b727a9f04e592
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = fdc75307b6614af182bf9656c7021b945a128ea28b5c9a
+Tag = cbdb90120887aec18f58743b8612738c649ccd07d6fb1710
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 75a6340d90880909ed9b8c694a5ba1890996c3d5cc8897
+Tag = 1f55584b10481541f3026b94dd9dd1585903ee432ade24bb30d2614e4c24e16e
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 758d378bb49b7a21e424d85661f69318b887ac9b098834d78ad2b14d6cc177670eb1720f24f851
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 4275d4fbc28b33ed2bc3f6ba65a9bd19334ddbe12f82633dc58478f0fb153620ec8fdc814cbfdd
+Tag = 67d6971dec8b79c6
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 21da8369e61305f240369f1a1e85574f0109b390500111c600abd3c572febca24e90c5b21d79f1
+Tag = 8e1ae3f1138a7bc53702ae4aceb8f840
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 6a9ced69bce3e60f20c35f88c62fc7d10c8cfcc39810d16304a2e8ded8c168d701c38c222ccb25
+Tag = 8ab10e43b188ecfda5ed9f4053029a233842ee1bb52c82e0
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 49678c911ada7cc99f06c755b2a7febb4d132548623731b77bf87788fd12f65145274a46aaa3e0
+Tag = c3ed2118f7328be094583aa8ff2b759bce5d259d715e5278816439b17c101cc4
+
+AAD = 8819aa3bcc5dee7f10a1
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 9021b243d465f68718a9
+Plaintext =
+Ciphertext =
+Tag = a71cf06c88cbc973
+
+AAD = 9829ba4bdc6dfe8f20b1
+Plaintext =
+Ciphertext =
+Tag = 9368317d41aab2269e7d94708d843a07
+
+AAD = a031c253e475069728b9
+Plaintext =
+Ciphertext =
+Tag = 80bdff5e3dc01cc2b13e6357f684df7a485bb73290d18f88
+
+AAD = a839ca5bec7d0e9f30c1
+Plaintext =
+Ciphertext =
+Tag = 687f2b8e8918b80788355b7de8ac8c344c2912d11b046355b604bdba9e77766c
+
+AAD = a031c253e475069728b9
+Plaintext = 7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b
+Ciphertext = 82aa30d01b72ca9baeb9707e43875abc1b84f57e7b23afc1
+Tag =
+
+AAD = a839ca5bec7d0e9f30c1
+Plaintext = 87a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+Ciphertext = 556fcc8185b12bc0167a879e744dc89804fafa6b01631c61
+Tag = de6740d406c53256
+
+AAD = b041d263f48516a738c9
+Plaintext = 8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+Ciphertext = f65d15bbc66527bc8ec309df5987772ee31db91d0c7bc172
+Tag = 1a0899f3d1b4265acb5b7580bc4cebb5
+
+AAD = b849da6bfc8d1eaf40d1
+Plaintext = 97b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+Ciphertext = 9cdba140217e734901c8414901a019e25f9ff4b138ff4954
+Tag = efc70c3485600a3b438791e9f0c245629a4419cdd09d8d36
+
+AAD = c051e273049526b748d9
+Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+Ciphertext = 203123fd38519bba35c7425c0e16b406dde4f4a04e15ed64
+Tag = f39f261a3efbd147e2b2bc4555dc469825006792cb9ff4f004505133740d5a58
+
+AAD = c253e475069728b94adb6cfd8e1fb04131c253e4750697
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = ca5bec7d0e9f30c152e374059627b84939ca5bec7d0e9f
+Plaintext =
+Ciphertext =
+Tag = 2468fe3d48670c94
+
+AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
+Plaintext =
+Ciphertext =
+Tag = b1081f4cec1ab6cd646be0ddc8d6aa92
+
+AAD = da6bfc8d1eaf40d162f38415a637c85949da6bfc8d1eaf
+Plaintext =
+Ciphertext =
+Tag = 1fed174acbe536ee21a4a269d551f0755a0ec5ac25a5f784
+
+AAD = e273049526b748d96afb8c1dae3fd06151e273049526b7
+Plaintext =
+Ciphertext =
+Tag = f7fa367b7196c77c78b791b6c288c02a96b625b846e33705643deff9dd4161e1
+
+AAD = e778099a2bbc4dde6f009122b344d56656e778099a2bbc
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
+Ciphertext = 69c0bf63df493c8130a29dddad9980fff7cb2166aa09361a4f190c73969142cb10100ca842
+Tag =
+
+AAD = ef8011a233c455e67708992abb4cdd6e5eef8011a233c4
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa020
+Ciphertext = be83d961ee14147e3cd6214d7e1e676fdc19a8ca7dad8331781baab147b604aa08f3f40927
+Tag = f463f98f6630f854
+
+AAD = f78819aa3bcc5dee7f10a132c354e57666f78819aa3bcc
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a828
+Ciphertext = 2801ce757e376d9a0152177c8496553949385f627bf95cb996e168333fd33993d080e44955
+Tag = ce8fe44c491d87383f5a7d53d0451937
+
+AAD = ff9021b243d465f68718a93acb5ced7e6eff9021b243d4
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb030
+Ciphertext = 4f23d5c00d433f82794bc66e4ab2d1f3c01125a9bac1f99d831472882e481d19af9dad0ad3
+Tag = 9ef415ed96e0ac73ecc3d6d30a019c933bc7becb1c8ec1d7
+
+AAD = 079829ba4bdc6dfe8f20b142d364f58676079829ba4bdc
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b838
+Ciphertext = 8dff6699a2607abf4051044e452f81620d64599eeded02351afb06cbd08a379a6209168dc3
+Tag = 249b371536e4061f78305c7d9689690dba5dff4101360461c910ba5ae99f462e
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e17262f38415a637c859
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a6afb8c1dae3fd061
+Plaintext =
+Ciphertext =
+Tag = 1e7d8c0ed3f00911
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
+Plaintext =
+Ciphertext =
+Tag = cc8862820230c5aaeaa5426ad1ece4a4
+
+AAD = 9c2dbe4fe071029324b546d768f98a1b0b9c2dbe4fe071029324b546d768f98a7a0b9c2dbe4fe071
+Plaintext =
+Ciphertext =
+Tag = c4fbbfdd62e0da97bc83f9ba603fceaf7b00e7a9eda51bed
+
+AAD = a435c657e8790a9b2cbd4edf7001922313a435c657e8790a9b2cbd4edf7001928213a435c657e879
+Plaintext =
+Ciphertext =
+Tag = 26db49a2f83ddfaf1966bccc08ee29a0ef5a80fc06f9c253c75f463e07a5a1ab
+
+# initialize with key of 128 bits, nonce of1344 bits:
+Key = da730ca53ed77009a23bd46d069f38d1
+Nonce = 83e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da3bfb5cbd1ede3fa001
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 72fc2aa9dfec5626
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = cb5671ddb1e46a714030d049bac4e3e6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 111337b2df5d4a0c20a472ef9e49ebaf275a3557008b5cd1
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = efa6b8dd73ec93732de560ba0ac36c7ab17e746b00c6d7ec3dde349f9a64f36e
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = f6e50165c6
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = a324348eea
+Tag = f764f4650f63e062
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = d692e0b7c2
+Tag = 55dd98902c7e70e478b74801c9b9e8be
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 035886516d
+Tag = a74ce36933a9b9884dca69d7329e78e76fd792a3295a8ef1
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = c74ed5f518
+Tag = 73a1c12b7bbb1da10f808bc57613662948599047fa8a098a63215445c8b0a992
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 35516e2598a48b7639c31a17
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = f04c072676d946ecb4275473
+Tag = 58caa361fa13d5f7
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = dc48388aae68cd5250061ba0
+Tag = 310cb30f7b0ac66e70d738fdab7fab0b
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 719f6f55785fe0dcb563a1f9
+Tag = cbb4551c2a83df8b33b98744d0314a48ec915fa9e3fdcef8
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 4748b698ada2a06ad9c3ba63
+Tag = a161d8867f08840a0550d0f91bcc0d9801fcc8941703e0444449be551ef6a51a
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 09c5084e667b5125461f2332f57bdbcccd56f259e3ccbd
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 5e88d356c6d45f06eec4e079b1c01f7603b44d8a4f6daa
+Tag = fdad68df4244f781
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 388e885dba0e6a547616edc32daece79308a218286ac57
+Tag = 7675543738e93034058d3afbac4e65ea
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 824d4a3b91b1a12222024354784a97b744da3bf2af22fa
+Tag = f7c760411695f920e4f2c4f547df712c2cc26c986b81a75c
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 93f0c49bc4f8fba2e8f640f11a22568556b6eca2e998c8
+Tag = 78704f99f4b85a06800c31a4ea37b9ad825fe5ae174eff6d88f7aa9266ec1135
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 333b2640ea152649d8c10563d7b7d7a4ae519b1872f2d25e8b5fb80124e7c13e14e05077f0f005
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 7725f24b4cce732e54734fc34ce97630c736a1c3bb337bfb56fa4f2281edc8f884e38b216ca819
+Tag = 28040c1d64171887
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 05d87c6ec71b18547d59be266efb8dae30f5d3fcc4a3c3481fee2f0e71b3d3ce6db4561fd582d5
+Tag = 866aff568d10353e19e1897747adc713
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = d354606ac33d4f950bb95e2a9babd3ab5cfcac3096e530f65d5d4fe17f750a64ebc4574732bd16
+Tag = c6debd8c79226f17ca9192b959a3698177899cca008cf911
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 4538042e140b9a616e4756482219cae23721e52e0a4027d0aec4010b116d6620786671fd4c6b8d
+Tag = 215489fdd7381fa99c0df68727f78081491d496cf68a2cf5a3e474cc480c4737
+
+AAD = 8819aa3bcc5dee7f10a1
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 9021b243d465f68718a9
+Plaintext =
+Ciphertext =
+Tag = ee79299bf39b92fc
+
+AAD = 9829ba4bdc6dfe8f20b1
+Plaintext =
+Ciphertext =
+Tag = 3bb2275e67c6c4224512649f8faaa476
+
+AAD = a031c253e475069728b9
+Plaintext =
+Ciphertext =
+Tag = 43aa46c80187f9598c09bf82941d3144192a004bca97dcc2
+
+AAD = a839ca5bec7d0e9f30c1
+Plaintext =
+Ciphertext =
+Tag = 070838eed9ef934e58ac03f99ff6fc9d663814f749ab942df3b86e89614c4384
+
+AAD = a031c253e475069728b9
+Plaintext = 7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b
+Ciphertext = 9f9cad8fa7c82175a43e395ed26ec70829f7f11d1565c5f8
+Tag =
+
+AAD = a839ca5bec7d0e9f30c1
+Plaintext = 87a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+Ciphertext = d1fa47053572153cd10de80a26e578290cefb8943543447a
+Tag = 29d1a1adc77bbf9a
+
+AAD = b041d263f48516a738c9
+Plaintext = 8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+Ciphertext = f74bd649e89228225563841e7c2641893e9b6cc24dd983d5
+Tag = 19eb819974feffce116446131ef05b64
+
+AAD = b849da6bfc8d1eaf40d1
+Plaintext = 97b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+Ciphertext = 7e18d89cc51af41909900ccb23478936d10dee1a93757702
+Tag = b5b8d7e93f2fcbe23151a016a264db0b2bde795663fb778b
+
+AAD = c051e273049526b748d9
+Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+Ciphertext = 86eac3782da4ae4d7ab2ddc893e9e5a3852ce0e90b07914e
+Tag = 4b76f11c70a7daeb21a31d5880e4319655cdb310817c7230e8e1a1dd2d82efff
+
+AAD = c253e475069728b94adb6cfd8e1fb04131c253e4750697
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = ca5bec7d0e9f30c152e374059627b84939ca5bec7d0e9f
+Plaintext =
+Ciphertext =
+Tag = 146d93d2f5d3e1e6
+
+AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
+Plaintext =
+Ciphertext =
+Tag = 094859713e48b019a6a08936d4c56b60
+
+AAD = da6bfc8d1eaf40d162f38415a637c85949da6bfc8d1eaf
+Plaintext =
+Ciphertext =
+Tag = 4e1132bca936e934287363b67191000df66a3df3cfd260cf
+
+AAD = e273049526b748d96afb8c1dae3fd06151e273049526b7
+Plaintext =
+Ciphertext =
+Tag = 2fdf1e5bf76b087a02c179590f0283c84257ce9605679b9001bd6a7b3d635d18
+
+AAD = e778099a2bbc4dde6f009122b344d56656e778099a2bbc
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
+Ciphertext = 251407b4a09952b44aab4249a33d1ca63a799ddb55938b15a6474c8f64dd62fcd7248e22e9
+Tag =
+
+AAD = ef8011a233c455e67708992abb4cdd6e5eef8011a233c4
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa020
+Ciphertext = cb9b42f3327943301fdc528f50489210080591688e391921a807ca98fbedd8f01a4a607496
+Tag = 6293bf3357d1e53c
+
+AAD = f78819aa3bcc5dee7f10a132c354e57666f78819aa3bcc
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a828
+Ciphertext = 9f3e4cea5037aab126783d9fb47d59ff4999678378ad6ee3781166c061f4da5dc53b1829be
+Tag = afab2eee6f87cb5416bad721a6bcec84
+
+AAD = ff9021b243d465f68718a93acb5ced7e6eff9021b243d4
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb030
+Ciphertext = f244c8d8860d5fc4743e140e0d27672a73f9fb99b3da5ccf073d69863455a1b47bcb3f74cd
+Tag = 9f0fb46999bee79f332f8d440c8dfb474a92c2569408a6a7
+
+AAD = 079829ba4bdc6dfe8f20b142d364f58676079829ba4bdc
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b838
+Ciphertext = 46a66a31fd419ff61ad94f1c6fe3854dfdba23f8d3406049104f776d9cb2946505f5b0c83f
+Tag = 1c9c1e5a93e913c127ebb9c97d54036b249704900f16bfa6b97711e1ba5f36e5
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e17262f38415a637c859
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a6afb8c1dae3fd061
+Plaintext =
+Ciphertext =
+Tag = 94e00b7c57ebfa0c
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
+Plaintext =
+Ciphertext =
+Tag = 499ec63e88671215ab71bb78cb993701
+
+AAD = 9c2dbe4fe071029324b546d768f98a1b0b9c2dbe4fe071029324b546d768f98a7a0b9c2dbe4fe071
+Plaintext =
+Ciphertext =
+Tag = c55829248014a5527684d51155c1d1d279fc2895590378bc
+
+AAD = a435c657e8790a9b2cbd4edf7001922313a435c657e8790a9b2cbd4edf7001928213a435c657e879
+Plaintext =
+Ciphertext =
+Tag = 5011765d32f5907f8324dcfd47c132b07c1f8bb0d3bdc0257ad33001e0c3e123
+
+# initialize with key of 128 bits, nonce of1408 bits:
+Key = e27b14ad46df7811aa43dc750ea740d9
+Nonce = 93f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9b91a7bdc9cfd5ebf7fe041a262c3248545a607682889ea4b0b6ccd2eee4fb011d13293f4b41576d7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4287fc16f83e7758
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = aa49fa00358fd747bca6bb5beea719d4
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 39ad9444737ceabd08ee68fa5f04518d3f0a7822ff67cc32
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e775bafc8fadb340760eedfe92093741ae96a13086487753b06d2a0872912572
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = cbe9b5814d
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 08833f527f
+Tag = 9da8081892c447cb
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = e6696ec916
+Tag = 3d63ac7e7982de43aeae250835e60976
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 01b63da71d
+Tag = 949c2b9f7f15802089ec8f6035e664cb17e897dc0e2b96ed
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 43e075fcdb
+Tag = bc41c4aac0b7e11355b804f7f83c85d350027011faf3b5bc0f78511a550afd0c
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 6285efeb06624f723fc2a1e3
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 9c8a3fd6573a9c30f00f9307
+Tag = 868a0d5c2a1bfa3a
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 952844009ca95705214e08b2
+Tag = 75a721d9bead8fc66f59fed89644ce74
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = a746a55f6525954b2cfd99b4
+Tag = 7f5972b57800cd74f6c9394b61f5247f02b72cff98ec709d
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 7937173673d928a71ca7b421
+Tag = acff90843d5fc6ab0d88f68eca4a0bf7ead77189efd3c2657f3785c3f50c9fde
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = be8febbe2173ba47a0e9784ee33cea39357ee7aa62108e
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 5f068487a3d5730f02d9c64b03de9f1b039b599da6ef1c
+Tag = 38b0610a2c9f6490
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 5062c8114152834c81ce32196a179ac27049eae4803a9f
+Tag = 3d5037c9e88ff50657a4c5d6eed26716
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 4ef64e180d5ba769c4faa851bb1b1bd807da65540bc27b
+Tag = 237b1c5f0caa59aab5cf2e0455d0f8fc18195a1222677ecd
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 150fdda3e0f6b6dee4a651cc6a48b01424b85b3a6bd6b4
+Tag = 9326d003fbe66b5be322ada2c23663a4e0dc67cc05b5e71cbf79387a280164df
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = c9e857458685193dc403b4ccb21464f6fbef41ba0d52b92ba4b262ce04816fdf2d3758072acb0d
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = ade1a05fc6da6bb56feaf822f0b90901a82f1a6c86d3bd7966f6211cc19ae5ca3960258358584d
+Tag = 4a0582ab4b646696
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = f97adb42fac458549f62ed513930a2c4b5a64597bb6f21c0997eb96f4fce77176ef555cfd7da75
+Tag = 04d57b95ddf39adb2f320801ad7325bf
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = ac47ab94e806ebcabbcc451e692cb8dec3b60d6a5dd9aff11fea97c948a5a4b31a56a3ca66fe0e
+Tag = 600fac3cc91e0d9288ea11087675b696d8664a6dcc3ba763
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = ed7390a2cf24c94779bd044bff3b456098527f73d2488d6ed1706cef9c65e6d82d8f4a7d350182
+Tag = 86ee26626a83a16d7332e4f48f9108af95711c201e9f483a32a294c6077d0c0a
+
+AAD = 8819aa3bcc5dee7f10a1
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 9021b243d465f68718a9
+Plaintext =
+Ciphertext =
+Tag = 604aac50511008d7
+
+AAD = 9829ba4bdc6dfe8f20b1
+Plaintext =
+Ciphertext =
+Tag = 310b38a622eeb807f2c57fc725ff6357
+
+AAD = a031c253e475069728b9
+Plaintext =
+Ciphertext =
+Tag = 68fadca05b09f8190ff790f8f5bab01904d2c0c39cd8ad10
+
+AAD = a839ca5bec7d0e9f30c1
+Plaintext =
+Ciphertext =
+Tag = b3939abad431e80940b01c13349644ebec775661623b7d9ca0bdd94db3d4dc4c
+
+AAD = a031c253e475069728b9
+Plaintext = 7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b
+Ciphertext = b0bded1ac0271160fdbdaa82f2dc7ed9d2938dffda38f256
+Tag =
+
+AAD = a839ca5bec7d0e9f30c1
+Plaintext = 87a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+Ciphertext = 82cbb73114eda1a91c0cbd4eab2a6ec4f67ffa7ff3bce214
+Tag = e132cc11e29f9ed3
+
+AAD = b041d263f48516a738c9
+Plaintext = 8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+Ciphertext = c04e351401427ac7bdc95cef3ed57ef142c1c43a4777df83
+Tag = 09d7df32e6967dc20330b9b18441537b
+
+AAD = b849da6bfc8d1eaf40d1
+Plaintext = 97b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+Ciphertext = 3e9c5806450fbfef0c910eb97a833e268611060d7c6d149a
+Tag = b817125f9da3121bed367df944596ec84c5aa2ef97235cff
+
+AAD = c051e273049526b748d9
+Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+Ciphertext = 013cd19122273e7f6064f66ddcd0a269018cf198a9c96717
+Tag = 0a9b6d3fc840de1834f921706388652165bbaa66fed20af57d4ba70a6142eedf
+
+AAD = c253e475069728b94adb6cfd8e1fb04131c253e4750697
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = ca5bec7d0e9f30c152e374059627b84939ca5bec7d0e9f
+Plaintext =
+Ciphertext =
+Tag = 87124bcec2990e17
+
+AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
+Plaintext =
+Ciphertext =
+Tag = 68310a99bbe5bcb4c71904c80de84a62
+
+AAD = da6bfc8d1eaf40d162f38415a637c85949da6bfc8d1eaf
+Plaintext =
+Ciphertext =
+Tag = 0fc952cf56a86d8ee7206debbaf0eb8434fe956662e92203
+
+AAD = e273049526b748d96afb8c1dae3fd06151e273049526b7
+Plaintext =
+Ciphertext =
+Tag = 26544c1c8792b6562826bb5ed7eb8981743baa309609919fdc492e1c792db207
+
+AAD = e778099a2bbc4dde6f009122b344d56656e778099a2bbc
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
+Ciphertext = 9465ef900f9d28e81418c572bb6aab32858e119a1b855e4c272efa9cce05636308e6f094c1
+Tag =
+
+AAD = ef8011a233c455e67708992abb4cdd6e5eef8011a233c4
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa020
+Ciphertext = 549929005139e7adc21862093a35a0d771fe17106c4f816df74e543127478ff7850d2ba241
+Tag = 5994e7ea2f8264fe
+
+AAD = f78819aa3bcc5dee7f10a132c354e57666f78819aa3bcc
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a828
+Ciphertext = 1942c07aa249ae11baa43b1a5194f15c4bf98ff9ab27fdab650fa55202d5e7798c77594aa6
+Tag = f9852bfbde1f5effc2d522f118b48ab8
+
+AAD = ff9021b243d465f68718a93acb5ced7e6eff9021b243d4
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb030
+Ciphertext = fce5bf3badf6f08d74dfd05fc2ff62a5abee30006d872cc498df19ad7f2fea21aef6ee7b93
+Tag = 7e7de7f423a89bad791f7d4edd1eaea3856ce140f7994d2c
+
+AAD = 079829ba4bdc6dfe8f20b142d364f58676079829ba4bdc
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b838
+Ciphertext = 0690f57ab9fa727f4bb2d8fb91b9f79dad64f832e9ed0a9ed5b86de0856c859cd8878b4eee
+Tag = 6bdc79bf57b0247e2667bfad87f2176feb2882f4e24fb1eade7f1b63491b38a0
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e17262f38415a637c859
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a6afb8c1dae3fd061
+Plaintext =
+Ciphertext =
+Tag = 00c11942e0ce5c31
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
+Plaintext =
+Ciphertext =
+Tag = c88ca1b82714b5f6941bebc538ce7131
+
+AAD = 9c2dbe4fe071029324b546d768f98a1b0b9c2dbe4fe071029324b546d768f98a7a0b9c2dbe4fe071
+Plaintext =
+Ciphertext =
+Tag = b155947eebee4b5cd7494715795daf3017d01a475b126f37
+
+AAD = a435c657e8790a9b2cbd4edf7001922313a435c657e8790a9b2cbd4edf7001928213a435c657e879
+Plaintext =
+Ciphertext =
+Tag = d60d4c8448df7f9aa90403b115918cf8da30d868ba96b8dbfd054060a47e37f4
+
+# initialize with key of 112 bits, nonce of1464 bits:
+Key = a53ed77009a23bd46d069f38d16a
+Nonce = ff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2beb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d9eff602081e2430364c526e647a8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e1f65ed4799ce0e96a16fe5686f85e3f
+
+AAD =
+Plaintext = 3b5cdc
+Ciphertext = 222aef
+Tag = 392beb4e95684dc5b97683af4c1c00d0
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = 77b7f5255aa468
+Tag = d3294efa2735eda5088ed7c06ee13ccb
+
+AAD =
+Plaintext = 8fb03051d1f272931334b4d555
+Ciphertext = 1a3fd59a68c58288ff2f9c40c3
+Tag = 3f61cdf406af73f623c1d20eaf6c34ce
+
+AAD =
+Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
+Ciphertext = fbd3f6e1c23e78b785790b9d655afc06a4735b2e87e2
+Tag = 981ea58e5bc51f084d72c6ba322b1751
+
+AAD =
+Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef
+Ciphertext = 4598dcdfeb2d51a78cf272e1c9814895f29b8ea62c0b320945dad6a5671026dd1f5f392e
+Tag = 5589beefc13695d2ab71d731c7947abc
+
+AAD = 54e576079829ba4b
+Plaintext =
+Ciphertext =
+Tag = d9baa1edbd2016587578749dfc38c446
+
+AAD = 69fa8b1cad3ecf60
+Plaintext = a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f1
+Ciphertext = f9b774839975ea54f4164cb0c0899c95da9f96cd82
+Tag = ef0eab96785e0c2823edb202a12bf560
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a8
+Plaintext =
+Ciphertext =
+Tag = 4d941d757e6097c8eff3bb12025d0ae0
+
+AAD = c758e97a0b9c2dbe4fe071029324b54636c7
+Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191b23253d3f474
+Ciphertext = a88c79f84d28437697ed846848ac183d7a4a67a0959bab6f2e23428e9c3530
+Tag = cec47b9f3d5054b5c42bffd66c88d0f6
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+Plaintext =
+Ciphertext =
+Tag = 0743090b18737818ed9e5b200d0f1f5c
+
+AAD = b142d364f58617a839ca5bec7d0e9f3020b142d364f58617a839ca5bec7d0e9f
+Plaintext = ef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5
+Ciphertext = c006a061d383e200f2ad353819780d2d63620beabed49c77fed295d6bff87fac20dff95c580cf6cc4439d67ba7
+Tag = 6cb093e95d6ab61af80dc6df1a463b69
+
+AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
+Plaintext =
+Ciphertext =
+Tag = 43e2f25ad278f48887e86d62a21152a7
+
+# initialize with key of 104 bits, nonce of1472 bits:
+Key = 049d36cf68019a33cc65fe9730
+Nonce = a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da3bfb5cbd1ede3fa001c12283e4a40566c787e849aa
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6a90200ceaf49bef422ec10f4b08640f
+
+AAD =
+Plaintext = 99ba
+Ciphertext = 08bf
+Tag = 1788ce3ae56024347ee4c389e014fbe5
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = c0d79c347b
+Tag = a4537af01d093470639cac46363fe882
+
+AAD =
+Plaintext = 0728a8c9496aea0b8b
+Ciphertext = ad5cbf19fb7f1d6620
+Tag = 3f66353cd96a4a0b8ad1780c617a6e53
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a
+Ciphertext = 50b505d2da5ce59eafb6371b96400b
+Tag = 1227fc67b00c6281b08490e8ce6ed714
+
+AAD =
+Plaintext = 85a62647c7e86889092aaacb4b6cec0d8dae2e4fcff07091
+Ciphertext = b198d0d1ccf782f6275dfef4a5ca0f2533a2890a72638b15
+Tag = 7c0386d87d936396ff04d40f1a8a34d6
+
+AAD =
+Plaintext = 61820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d4
+Ciphertext = 74fda61013e7646a8102f62787961d11e2af80c13aaab80be228a8edae9dfd31097e2a0c0bd3
+Tag = f1fe2b47b41526e89c9c733a456a24f7
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = e50a8af84f67f9d13e39d96b347c299d
+
+AAD = c556e778099a2b
+Plaintext = 62830324a4c54566e60787a82849c9ea6a8b0b
+Ciphertext = 8ea4a9aec57fafdd8015323f8cdbb1cbc7e8a3
+Tag = 480cd3e9c75be25392ec3c9b363cbb5b
+
+AAD = e172039425b647
+Plaintext = 1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191
+Ciphertext = 8f958b8b5d492b08d90ba7b5d8f54f1b95c7835c2738edb66adfaa71c8b8a2b138c3d9d2b1553dc90faa6e570b5687
+Tag = 86f4ea9714d2bc10c2ae500ae1dd8a1b
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 9f8764f4ee751f99cdd6ca3a504eff32
+
+AAD = 8011a233c455e67708992abb4cdd6eff
+Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = 65670a5d28946be4fc4019beee5efe818921c3846e69f2a3015e7db0
+Tag = a486be8700a19b469583e0bb98d39cdc
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = f6f4081122a75f898496b234e2c41ef5
+
+AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce
+Plaintext = c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d5
+Ciphertext = 81bf6a6746400b66264ba18606956d50d55d077bc2e0c397bf5b20acb7a620d418555b853b40462b
+Tag = a6b2a85539b769320d6c979764cecab6
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = ecc433ec167cc9fc16bb58f2bf9192c9
+
+# initialize with key of 96 bits, nonce of1480 bits:
+Key = 63fc952ec760f9922bc45df6
+Nonce = 41a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9b91a7bdc9cfd5ebf7fe041a262c3248545a607682889ea4b0b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 28a524868cfeb34ea90ec7826f337c5b
+
+AAD =
+Plaintext = f7
+Ciphertext = de
+Tag = ee4555f7341372103ab71c55535bdf91
+
+AAD =
+Plaintext = 99ba
+Ciphertext = ff9f
+Tag = 4bc0ab83549588db26252d140c6094d0
+
+AAD =
+Plaintext = ddfe7e9f
+Ciphertext = 1f277bb0
+Tag = 5cdf45253d3c028fd184558810d05846
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = fae9a85b882b8f
+Tag = be5e59244750a36f1307beeb3ad0dd5c
+
+AAD =
+Plaintext = 4b6cec0d8dae2e4fcff070
+Ciphertext = a78ae059f47f0e07719dcd
+Tag = 711a5cb5c29fd02ef77c3f69b19b3ea8
+
+AAD =
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
+Ciphertext = fd03713013c8e04d6cf2f710340fae5869
+Tag = 0b5b4593a64aef67c0af2e05f6c2fed5
+
+AAD =
+Plaintext = c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 665834855377354a8862594b83c3268bbab64cd2692943ec1815
+Tag = 1377aada741f277657edbfb7b8c4ae86
+
+AAD =
+Plaintext = a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9
+Ciphertext = 958314a613ec7a0f529184d3220df37eb332ad3ed06669b5c6907424dd7d454f07b6486d6cc17a2d
+Tag = e6d130d4993ee850b2f0a57bcbfff903
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = 16c1b00d915be6e35de375ab24047582
+
+AAD = 22b344d566f7
+Plaintext = bfe060810122a2c34364e40585a62647c7e8
+Ciphertext = 627d8c6ecd1dd9affd6a3e5179f8ba28ec08
+Tag = 733d8903e514acb20778351e2671bd3b
+
+AAD = 3dce5ff08112
+Plaintext = d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2bab
+Ciphertext = 53009fca1f7cd34253e5b44507dd34bb80a9a35206d7640033ee589a8ce656d264b81c83485adb17f55dbc159c
+Tag = 113f22cf20eb5d5c4dbdad32d8f89c49
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = cb4b7d9aff15027753f5acf81e0df0a6
+
+AAD = 3acb5ced7e0fa031c253e4750697
+Plaintext = d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e36384
+Ciphertext = 1c80b2634d0d7c7beb8c1a5950a1697556d1b28953844e27c94d
+Tag = d501234924a86688b32ee02699d2e19c
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = 8e2058a292f7d459c92f586f308a5072
+
+AAD = 9829ba4bdc6dfe8f20b142d364f58617079829ba4bdc6dfe
+Plaintext = 3556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e607
+Ciphertext = 7d9d405ee2daee5ac4214484edfb499e2214d413467e164c7e3158b49c11ae588631d3fe
+Tag = 78f852770b66d60e7839982c01fe2328
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = 3d519ddb47fbcd09c435f1e3a9c6844f
+
+AAD = 8213a435c657e8790a9b2cbd4edf7001f18213a435c657e8790a9b2cbd4edf7060f18213a435
+Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758
+Ciphertext = 0d51b1d0b43e70e0a552121c60ae6fcb24da6120ac2604208a4a6a76fc75077c103cdec9a6b4bc62a9e7827156f204b0c397
+Tag = e58fdde4564e883245bcf9315e1062d0
+
+GlobalTag = 1e7c6c56424f8c1fe0bd042d03da3a1e

--- a/tests/kat/testvectors/Ketje_Major.txt
+++ b/tests/kat/testvectors/Ketje_Major.txt
@@ -1,0 +1,8088 @@
+# # Ketje_Major.txt
+# # Algorithm name =  Ketje Major
+# # Test vectors obtained from https = //www.github.com/XKCP/XKCP
+# # The test vector file format hasbeenadapted to fit the format supported
+# # by libkeccak's test vector parser.
+
+# initialize with key of 76 bits, nonce of 0 bits:
+Key = bc55ee8720b952eb841db64fe8811ab34ce57e17b049e27b14ad46df7811aa433bd46d069f38d16a039c35ce67009932cb64fd962fc861fa932cc55ef79029c2ba53ec851eb750e9821bb44de67f18b14ae37c15ae47e07912ab44dd760fa84139d26b049d36cf68019a33cc65fe9730c962fb942dc65ff8912ac35cf58e27c0b851ea831cb54ee78019b24be47d16af48e17a13ac45de7710a942db740da63f37d069029b34cd66ff9831ca63fc952ec760f9922bc45df68f28c15af38c25beb64fe8811a
+Nonce =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 93578302626c584b87e55643162def7a
+
+# # initialize with key of 76 bits, nonce of 200 bits:
+# Key = 039c35ce67009932cb64fd962fc861fa932cc55ef79029c25bf48d26bf58f18a821bb44de67f18b14ae37c15ae47e07912ab44dd760fa841da730ca53ed77009019a33cc65fe9730c962fb942dc65ff8912ac35cf58e27c059f28b24bd56ef888019b24be47d16af48e17a13ac45de7710a942db740da63fd8710aa33cd56e07ff9831ca63fc952ec760f9922bc45df68f28c15af38c25be57f08922bb54ed867e17b049e27b14ad46df7811
+# Nonce = a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f3
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = bbe5e399a19e2bc46a043f681199c4c1
+#
+# # initialize with key of 76 bits, nonce of 400 bits:
+# Key = 4ae37c15ae47e07912ab44dd760fa841da730ca53ed77009a23bd46d069f38d1c962fb942dc65ff8912ac35cf58e27c059f28b24bd56ef8821ba53ec851eb75048e17a13ac45de7710a942db740da63fd8710aa33cd56e07a039d26b049d36cfc760f9922bc45df68f28c15af38c25be57f08922bb54ed861fb851ea831cb54e46df7811aa43dc750ea740d9720ba43dd66f08
+# Nonce = 5abb1c7d3d9eff602081e2430364c526e647a809c92a8becac0d6ecf8ff051b272d3349555b617783899fa5b1b7cdd3efe5f
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 84a558f21f3a59a6c682c4590d27a31e
+#
+# # initialize with key of 976 bits, nonce of 600 bits:
+# Key = 912ac35cf58e27c059f28b24bd56ef8821ba53ec851eb750e9821bb44de67f1810a942db740da63fd8710aa33cd56e07a039d26b049d36cf68019a33cc65fe978f28c15af38c25be57f08922bb54ed861fb851ea831cb54ee78019b24be47d160ea740d9720ba43dd66f08a13ad36c059e37d069029b34cd66ff
+# Nonce = 1374d536f657b819d93a9bfcbc1d7edf9f0061c282e344a565c6278848a90a6b2b8ced4e0e6fd031f152b314d43596f7b71879da9afb5cbd7dde3fa060c1228343a405662687e849096acb
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 0407ae8dbee55b240dd16834a0000da4
+#
+# # initialize with key of 776 bits, nonce of 800 bits:
+# Key = d8710aa33cd56e07a039d26b049d36cf68019a33cc65fe9730c962fb942dc65f57f08922bb54ed861fb851ea831cb54ee78019b24be47d16af48e17a13ac45ded66f08a13ad36c059e37d069029b34cd66ff9831ca63fc952ec760f9922bc45d55
+# Nonce = cc2d8eefaf1071d292f354b575d6379858b91a7b3b9cfd5e1e7fe0410162c324e445a607c72889eaaa0b6ccd8dee4fb070d1329353b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667c888e94aab6bcc2d8e4eaf10713192f3541475d637
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 7f90f9047a5a91d81c6c4d9dc4b9c4a0
+#
+# # initialize with key of 576 bits, nonce of 00 bits:
+# Key = 1fb851ea831cb54ee78019b24be47d16af48e17a13ac45de7710a942db740da69e37d069029b34cd66ff9831ca63fc952ec760f9922bc45df68f28c15af38c251db64fe8811ab34c
+# Nonce = 85e647a868c92a8b4bac0d6e2e8ff0511172d334f455b617d73899faba1b7cdd9dfe5fc080e142a363c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e14202
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 62e07ec02db8f7caed806b1e3500cca4
+#
+# # initialize with key of 376 bits, nonce of 00 bits:
+# Key = 66ff9831ca63fc952ec760f9922bc45df68f28c15af38c25be57f08922bb54ede57e17b049e27b14ad46df7811aa43
+# Nonce = 3e9f00612182e3440465c627e748a90aca2b8cedad0e6fd090f152b373d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6e
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 8a34b6e167cd342950d4cc8198e3fdb8
+#
+# AAD =
+# Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef
+# Ciphertext = 046c887cfdf2062edb84ea63771b7f289e8ac8bad182ebc3bdf2649c97f7aaa2aaf09b5b
+# Tag = 8a4bb30e51beb36b62975ba5e101e50b
+#
+# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
+# Plaintext =
+# Ciphertext =
+# Tag = 34214632bea9ed43d46769058acbdccb
+#
+# # initialize with key of 336 bits, nonce of 40 bits:
+# Key = 41da730ca53ed77009a23bd46d069f38d16a039c35ce67009932cb64fd962fc8c059f28b24bd56ef8821
+# Nonce = 63c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d7
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 144a990a573dce2d601bafd071507477
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262
+# Ciphertext = f6fdaf27e9da2d15aff5b7a17760a47e6ddba120faab6c975989c281b5f6fa
+# Tag = 25d555cc575b30d1f1a679b06251ffda
+#
+# AAD = 6afb8c1dae3fd061f28314a536c758e9d96afb8c1dae3fd061f28314a536c75848d96a
+# Plaintext =
+# Ciphertext =
+# Tag = fbff145373bb5e0189f6fe2b0820e2e9
+#
+# # initialize with key of 296 bits, nonce of 80 bits:
+# Key = 1cb54ee78019b24be47d16af48e17a13ac45de7710a942db740da63fd8710aa39b34cd66ff
+# Nonce = 88e94aab6bcc2d8e4eaf10713192f3541475d637f758b91ada3b9cfdbd1e7fe0a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf40
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 80af6610c416327bd88947a1fab735b9
+#
+# AAD =
+# Plaintext = c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+# Ciphertext = 75784025c1aed92ce4b310cbe8de95cde9267c256aedd82a65e6
+# Tag = ee83df8556ab8bdf2aaa99a7a32a5285
+#
+# AAD = e273049526b748d96afb8c1dae3fd06151e273049526b748d96afb8c1dae3f
+# Plaintext =
+# Ciphertext =
+# Tag = c19c142f7da4ce00ed27d169505b0ac1
+#
+# # initialize with key of 256 bits, nonce of 20 bits:
+# Key = f79029c25bf48d26bf58f18a23bc55ee8720b952eb841db64fe8811ab34ce57e
+# Nonce = ad0e6fd090f152b373d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e74808
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 0135daca621b16cdf3179e2d401e2f23
+#
+# AAD =
+# Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e9
+# Ciphertext = 65ddfd8c4b065178f6a8d44619b7c0a89dfafb75cf
+# Tag = e2c6bbbc891f2c00f0433ed1060e6c96
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40
+# Plaintext =
+# Ciphertext =
+# Tag = 687287251aa6a97c58a6c5bc858d40ab
+#
+# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70
+# Plaintext = cff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
+# Ciphertext = 25bddb6f9bd5782537229dd52ef787e8a809209e6abc0190272b0e22d8e10f959f520cbd07fc044eec0e74c0edb845ae
+# Tag = cb9605d5693a1e7540f15d9a7f30fa5d
+#
+# # initialize with key of 216 bits, nonce of 60 bits:
+# Key = d26b049d36cf68019a33cc65fe9730c962fb942dc65ff8912ac35c
+# Nonce = d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = d133938ac5f2f6e2ee1c7a704b4cc156
+#
+# AAD =
+# Plaintext = 75961637b7d85879f91a9abb3b5cdcfd
+# Ciphertext = 03de093cdddf6c6c82612e5e3669de10
+# Tag = 5490155541fc88a8208f450058061d7c
+#
+# AAD =
+# Plaintext = a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9
+# Ciphertext = 0815b63d5ad612100cad9bba77b1f52d667c5c637b4bf0add14726941ba40cf0458a5a2afdbccc43
+# Tag = d931d1f617ddd7b7500ab6aa9798e8f0
+#
+# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+# Plaintext =
+# Ciphertext =
+# Tag = 73b88935e03861da9d222740597cb04f
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869
+# Plaintext = badb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce
+# Ciphertext = 899e4fe02d6506ae8f67f936ca04e530a942ec6e544ffb87c0a6ae4c62b8418dbb4439674c8f34a0
+# Tag = f30f894edcef80ac350eb5adcc1eb389
+#
+# AAD = 46d768f98a1bac3dce5ff08112a334c5b546d768f98a1bac3dce5ff08112a33424b546d768f98a1bac3dce5ff08112a393
+# Plaintext =
+# Ciphertext =
+# Tag = 9be57f0a67d11df3e8e76802ec8680c9
+#
+# # initialize with key of 176 bits, nonce of 00 bits:
+# Key = ad46df7811aa43dc750ea740d9720ba43dd66f08a13a
+# Nonce = f758b91ada3b9cfdbd1e7fe0a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 266848eabdcee983c4ba7a6e41c8f24a
+#
+# AAD =
+# Plaintext = 4b6cec0d8dae2e4fcff070
+# Ciphertext = 5f6d0c8404e0813f91ba49
+# Tag = 539ca100934ebeebc9b6b1554cd722a5
+#
+# AAD =
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+# Ciphertext = 3ff7413bd9e4022790036f32bd4f99a441acb9ad9386e083b8c725
+# Tag = af8bf947f279a3f9ef2579a22b8d1b80
+#
+# AAD = 64f58617a839ca5bec7d0e9f30c152e3
+# Plaintext =
+# Ciphertext =
+# Tag = 316290822e5c0995e942e940cc1da6e9
+#
+# AAD = 8516a738c95aeb7c0d9e2fc051e27304
+# Plaintext = 4768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d757
+# Ciphertext = 4e457c12057857f965216a524ac3cbb8d6eccedd86d0b66d416d5c8e1ae97a669c
+# Tag = e5854765170979069898b9eb65dfc593
+#
+# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+# Plaintext =
+# Ciphertext =
+# Tag = 4e5fc382485ce1b6e612574bfec5aeec
+#
+# # initialize with key of 160 bits, nonce of 16 bits:
+# Key = 6b049d36cf68019a33cc65fe9730c962fb942dc6
+# Nonce = 399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2beb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 9c0c0add92fba0080ffb98784a1d134f
+#
+# AAD =
+# Plaintext = 0728a8c9496aea0b8b
+# Ciphertext = 126a43acc824c6d2cf
+# Tag = 2d9925422842a56ef8af1284efe033b0
+#
+# AAD =
+# Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
+# Ciphertext = a4fad825b5e5f132abad990324ab40af8a0f10d6ea64
+# Tag = 08af7c227c124d202a1e58ea5ceadba4
+#
+# AAD =
+# Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e
+# Ciphertext = d0178c6e0edfe80a1ed2f6c757e8f89376cc402feda5396c5548cd086a078c6378cfb97cb84b4d2fd29f
+# Tag = 8a350ca21a334ba34f6d0644239bfc24
+#
+# AAD = 20b142d364f58617a839ca5bec7d
+# Plaintext =
+# Ciphertext =
+# Tag = 63bc41c7cf9c2211758cdc076cac247f
+#
+# AAD = 3ecf60f18213a435c657e8790a9b
+# Plaintext = 5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4e
+# Ciphertext = 92ec93172c15e1f4f0b03c23108c86ce24e5cc7df85160950fd5c620b252
+# Tag = 1ce55cf9e62e5cfbc764b79558a98d77
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+# Plaintext =
+# Ciphertext =
+# Tag = ff0900fb38e572ef096969874433ef2a
+#
+# AAD = b445d667f8891aab3ccd5eef8011a23323b445d667f8891aab3ccd5eef8011a2
+# Plaintext = d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6d
+# Ciphertext = 0d75d18f23a5277ff28fd2e0d7693dd522b6ea5df905d1db801adb6bb25808b86b7bd664e17d9aa7da69a806ebca4f5e
+# Tag = 3c945d5ca3e18f428ef1502acad51ff6
+#
+# # initialize with key of 144 bits, nonce of 32 bits:
+# Key = 29c25bf48d26bf58f18a23bc55ee8720b952
+# Nonce = 7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9b91a7bdc9cfd5ebf7fe041
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 8886656aa52038498fdcbedb99273347
+#
+# AAD =
+# Plaintext = c3e464850526a6
+# Ciphertext = 385aad6803dca3
+# Tag = 84d72a9550c382c2e73a2d065c039241
+#
+# AAD =
+# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
+# Ciphertext = e05c31a49979e67837c73f91a0a363a8b0
+# Tag = 4298b04186f0cfdea42bb2455ca13108
+#
+# AAD =
+# Plaintext = 95b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425
+# Ciphertext = e01db73a57bf5e479bca494ed24d9d46d41f7da014ef22347614b70b09b09ef8
+# Tag = d3c14904dac4f05ec3e3448abe2a670d
+#
+# AAD = dc6dfe8f20b142d364f58617
+# Plaintext =
+# Ciphertext =
+# Tag = 41c145336443f9dd02637144b29ab6fb
+#
+# AAD = f78819aa3bcc5dee7f10a132
+# Plaintext = 77981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+# Ciphertext = 5d116dda7ff03701b2e1f4691a2bfc422bdea8755c0055d32de288
+# Tag = 099287daf4520c19ca15071cfcc8cd62
+#
+# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+# Plaintext =
+# Ciphertext =
+# Tag = e183b5fb834705ed4a1c19ec7e62b9b5
+#
+# AAD = 27b849da6bfc8d1eaf40d162f38415a69627b849da6bfc8d1eaf40d1
+# Plaintext = a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdc
+# Ciphertext = 9f4fb229efc3d383be35c76ff749997b9cd3cb491e71bb5adb76d196163addaa1a5d649b5d6b07795c6fb4
+# Tag = bbeb40acbab1b2cb0a7dcc85bcd4fe70
+#
+# AAD = 46d768f98a1bac3dce5ff08112a334c5b546d768f98a1bac3dce5ff08112a33424b546d768f98a1bac3dce5ff08112a393
+# Plaintext =
+# Ciphertext =
+# Tag = 5dc8f44711df0ebd9b0bb5bf2dc45d13
+#
+# # initialize with key of 128 bits, nonce of  0 bits:
+# Key = 32cb64fd962fc861fa932cc55ef79029
+# Nonce =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = c257270f5307aead
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = a3265d5ead58b8622275267c01a8c375
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = fb9a01210b12b8065ef9ad1868a55b8a844de3f7f4a800ce
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 7242ba58fa98cccd789e6562f1c9a6026188f2da49f0bd7d68dea8fd1bcfb2cf
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 1536764dba
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 79dfa059ad
+# Tag = 2ae9e002084aef01
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 88d71b45cb
+# Tag = 35b9397b21cd90c1f455a7e5099cf370
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 7daedf33ff
+# Tag = 8432f093a48b2ae39f7a3f9a3eaefd4d4aa3254a443c9622
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = bcc4e409ee
+# Tag = 7d08db19ae102c32342eb0c76d5f9c304484051d796acff11ab108968eeb7fab
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 45deae65e7f59aa351079641
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = f027a40a925f88f55ec7de89
+# Tag = 41889fe2629fc818
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 93d4d881359a85248718737d
+# Tag = 839412743c1d4edfbd922cb94e922ce5
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = cf5c50b0a059299b9f01062c
+# Tag = 6b39b2b3496c7fb1eae353e27c0bc066c1821cc69dc18043
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 9d9bbbbacd607a6ccf8f8006
+# Tag = 6c470e7aad8469e7cf6867c186a72b2933b71180dc1a687fb9209017bb533619
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 1ef93fe206d4d2aec70c994706a2d7681a316a28e15e86
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 1dc2988e1acec91adb7eafc50a0532f5ea54316b2e9f09
+# Tag = 2a593d89fe00d758
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 71f23b8768f5e0a44902e071d7be1c6db318ee05996914
+# Tag = 65d23e307c00e2daab356ef595a90981
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 3e1c59ba869e1a103687cf01795c48f32d7a734fa3101e
+# Tag = 5583839d9500aa19073fad2d87279c89dffaabc3dfd50512
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = 6ba468e423c5aa880ab0a090f27bba454580bac9e4a426
+# Tag = 445d2b3fb29ab6a7d97489cba3c33af8232b61a17849c8bf83e40148edea2de7
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 6b617b841f6e2fce85cc8e637c613ab7a40306991ecb7bf48fed146447308daf80382a34cbba14
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 23a7570c6e8878f932cc8ca5b58b988956afdbf5adf618156660c66ae4ea828b0450694c5fe9e1
+# Tag = dc06457af296de87
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = cec732f7a38772d2578ececa7184d4c332652d09f95833ad31774dcc0c8263aae520849b4a883e
+# Tag = 0e744f554afa4eafde0741d95e07fb5a
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 3bf74e6bddfd3286993c88bdb2f674c02adcf0e4f237bdbf809dd60319f185277a2c5cb9fcfb48
+# Tag = 8f58df391f0561eb9855d4ae0934accbef65fbf79478fff4
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 701f9b30efcfbd0f228f9ec80913a203e31f4775bc5a1f432f974da5b5452fb881dfbcfd3772a3
+# Tag = e6f1227113211ed73bcdd78f9878e9471f661d03ffe4c5d636cebf9b121381bd
+#
+# AAD = 5eef8011a2
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 66f78819aa
+# Plaintext =
+# Ciphertext =
+# Tag = 36b2ee5662b1ed45
+#
+# AAD = 6eff9021b2
+# Plaintext =
+# Ciphertext =
+# Tag = 2e5eb96356b14595583a984393e90275
+#
+# AAD = 76079829ba
+# Plaintext =
+# Ciphertext =
+# Tag = 23ab68933e746f944f1b197b96b0e2d54e94659e5ebc9f8a
+#
+# AAD = 7e0fa031c2
+# Plaintext =
+# Ciphertext =
+# Tag = a3020de3c9c45233cf88eff8d76100e2fe40173042e454a5f4ceff5fb1214b30
+#
+# AAD = 6cfd8e1fb0
+# Plaintext = 2647c7e86889092aaacb4b6cec0d
+# Ciphertext = 3dec13c04189c388c698c25eb5af
+# Tag =
+#
+# AAD = 74059627b8
+# Plaintext = 2e4fcff070911132b2d35374f415
+# Ciphertext = 1bc3b9600705413fd9f748f2d2b7
+# Tag = 623a213b4d9271df
+#
+# AAD = 7c0d9e2fc0
+# Plaintext = 3657d7f87899193abadb5b7cfc1d
+# Ciphertext = 22d9caf523b4c108c903654a7be5
+# Tag = 94149f06dc63e50a40338e6e39ed566f
+#
+# AAD = 8415a637c8
+# Plaintext = 3e5fdf0080a12142c2e363840425
+# Ciphertext = e3cb6adbfd6570d7f1ff844ca397
+# Tag = d57e82d84379b160acecac0ffd8abe5cfa5985df1e874408
+#
+# AAD = 8c1dae3fd0
+# Plaintext = 4667e70888a9294acaeb6b8c0c2d
+# Ciphertext = a0901513a06ff02ad24cf8a6d496
+# Tag = 6bc348822731af9d854ae4227470e5aa73738115b45ca427d5a43ad13bce7c81
+#
+# AAD = 8112a334c5
+# Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+# Ciphertext = 4d354307c4ef987fea92981ee5aa989332f5553e8464ea905382259ac422a8fc79ac83
+# Tag =
+#
+# AAD = 891aab3ccd
+# Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+# Ciphertext = b02dada9fe16df8f207673f8f34e172d9af28b43d3bf21145c4db6f55e21d61c5b96a3
+# Tag = 77048c08aae8c255
+#
+# AAD = 9122b344d5
+# Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+# Ciphertext = 2b4a0d10a70f3f3a63c03608b39eefd6851ea5135f68c11b5cc415c7ab3a29aae040db
+# Tag = 0e592c4bdc035ee28c7ea27ad173dd59
+#
+# AAD = 992abb4cdd
+# Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+# Ciphertext = 5faa1793ae497f67d881f79cef5faf45db3361e6681a1d55f4e86f7d065d4dcf71b155
+# Tag = e288d43e688704f7e216da4eb592c55adaa88a3e51ca0945
+#
+# AAD = a132c354e5
+# Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+# Ciphertext = cff79e4b4481053319300509395f2041ea9cc675638da74da140ab86801f664128a29a
+# Tag = dc5f6bfaf5bdf1f39e569b3e8bd2cb6944dc23efa2bb4310f0c771c601599073
+#
+# AAD = 2abb4cdd6eff9021b243d4
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 32c354e576079829ba4bdc
+# Plaintext =
+# Ciphertext =
+# Tag = b3a7bcca57a8c4c6
+#
+# AAD = 3acb5ced7e0fa031c253e4
+# Plaintext =
+# Ciphertext =
+# Tag = 4b70e798c3bfdf8807a093eb8959c5b9
+#
+# AAD = 42d364f58617a839ca5bec
+# Plaintext =
+# Ciphertext =
+# Tag = 52d4192788f4c9224b24ec20f28f4d8d601eeeb56a783da2
+#
+# AAD = 4adb6cfd8e1fb041d263f4
+# Plaintext =
+# Ciphertext =
+# Tag = a540c44e47baaea2ae4fe73c470dfeb707d8aee365459cd8cb7f28c2c0b29c8d
+#
+# AAD = 3ecf60f18213a435c657e8
+# Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+# Ciphertext = 0206a65d46bfacfe110455d449ce130aba7540c3
+# Tag =
+#
+# AAD = 46d768f98a1bac3dce5ff0
+# Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+# Ciphertext = 3a5cc5bd5078f4c8c980fde2f8daf24689101521
+# Tag = deba21df9e6b4228
+#
+# AAD = 4edf70019223b445d667f8
+# Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+# Ciphertext = d98224d5b02c1bb56d2328592aee4670a3680da0
+# Tag = 127863bac302ea62eed3568a762ee0d3
+#
+# AAD = 56e778099a2bbc4dde6f00
+# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+# Ciphertext = f9f7c256d997ff9b73e123f2780b86f1c816c03d
+# Tag = dc36190e64613afd16f4090eb1406ff162b4529340ab4231
+#
+# AAD = 5eef8011a233c455e67708
+# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+# Ciphertext = 6ebdd377525d35001b3281fe307984dcd450c9aa
+# Tag = dba9770c64d91ae1c6d62db6cdd3ba0b921cc0ef52e6fdfa95ee9deb020986a6
+#
+# AAD = 5ced7e0fa031c253e47506
+# Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+# Ciphertext = 9eed607492d06d9c28e52d644b81f4f632497ad8f3dfef67d05560bf68986252b3466d27d2ed5e1a57a729c9458982be6559
+# Tag =
+#
+# AAD = 64f58617a839ca5bec7d0e
+# Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+# Ciphertext = 51689f764341213689791a95f6c6ab93b7bb0572843ae2c5aedeb70ce2e87e06b3f35b1b87f312d61cdd8007d2fd81ba3e88
+# Tag = 4a25dcd4435deb42
+#
+# AAD = 6cfd8e1fb041d263f48516
+# Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+# Ciphertext = a80908eb657fd52d85ae6c8f65eadfdbe3a2daf3d98b6bea4124e4e7830c0b710dfedb8fc278a0a0a0e72f75fac95b50694d
+# Tag = e7eaac443892c88c3dfa714a4409426c
+#
+# AAD = 74059627b849da6bfc8d1e
+# Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+# Ciphertext = 81178a81d446ac7744ca63ae8f8e732fe4741d415a3629b038973fad935bad465f241f24191cebcdac890fe75c8894ed4163
+# Tag = 840a3ff26cf166840103957502c35542e9b9470b3bd789ac
+#
+# AAD = 7c0d9e2fc051e273049526
+# Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+# Ciphertext = 4bd8f6c6c26154c1e4ee257332811f86f8baf78c7d0093ab4372454a50bb05559f694058a4bcb702861c2c82d73029237485
+# Tag = 25bf5e634d3d1e30ba3539adde66dfc02f396ab0d41c2a853fcaaaf56e56f50e
+#
+# AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+# Plaintext =
+# Ciphertext =
+# Tag = cab1947792104cb4
+#
+# AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+# Plaintext =
+# Ciphertext =
+# Tag = 902b12f2b7c59362296d2f142ddea000
+#
+# AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+# Plaintext =
+# Ciphertext =
+# Tag = e0dee1833900febb7b9fc53f4f3f1f1e8f6622b7e97cacba
+#
+# AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+# Plaintext =
+# Ciphertext =
+# Tag = 2680ff11985d5e8f46f92acdbcfbe1cddc0ed470bf8d410daebd89cacf245060
+#
+# AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+# Ciphertext = a8461f54d39b094ad4f68806548667bdefa2b7722daae773e70279af
+# Tag =
+#
+# AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+# Ciphertext = 5f67bacbfc72afe2590c14fc1905f294ad2721ad86764513ad98526f
+# Tag = 09b50ccc9da054aa
+#
+# AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+# Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+# Ciphertext = df903ffc4014962e50221b92a1cc72824d9c476cfee7b9844afd3118
+# Tag = a7ee3e5e90af86a02d8a54c06ead4231
+#
+# AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+# Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+# Ciphertext = d96b6fe59d9cf286ce5da946a13c3dc2823772abf2428caa42d93b33
+# Tag = aa7dd07546aec6e06a91264b0e2e923895679727c0183e15
+#
+# AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+# Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+# Ciphertext = 52f1528781a74988b102b86b5c511170d21ea911ed35bfb7ef33aa5d
+# Tag = f78d4d64ffda574104581159fdca73b10d8649398d9af0b9b32b6089495da775
+#
+# AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+# Plaintext =
+# Ciphertext =
+# Tag = c9e994c45382f79e
+#
+# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+# Plaintext =
+# Ciphertext =
+# Tag = dc52c03855ff0a884bd3297659ed1aed
+#
+# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+# Plaintext =
+# Ciphertext =
+# Tag = 96d9aeb87ab14dd390355dddd668a8a1a0d120bc046c8bef
+#
+# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+# Plaintext =
+# Ciphertext =
+# Tag = 66cece3ada2732f3b5929293c173e765720ffc2ec85f46b9310bccf56a322b39
+#
+# AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+# Ciphertext = 8c76dbed0f043fe68284996a146ad66fcd863019f96ac4ae9448faecd63d874a5a9ec511461214
+# Tag =
+#
+# AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+# Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+# Ciphertext = 20cb5a62d45a52cb5f765b3c9a8cc2a3ec14892ff388c87ef58ecb489e08c78ecc51efef539243
+# Tag = c52c81fee99b8a79
+#
+# AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+# Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+# Ciphertext = 03cac0b456f7401aa38e13e837d98dbea9f1f3dce9f37eab49c8df431270e2f448afaeff7d916f
+# Tag = ce332a2ccdeaa38c1f302ecf74f177f8
+#
+# AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+# Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+# Ciphertext = 79bc7d19961d8ddce9bb2ecd0ca78325b3f40a8e4a4145ac02f170aedb85dc411fe65b245baec5
+# Tag = 8c7a01ff63a38aaeb305772fd070f4dbb22d951770b0527b
+#
+# AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+# Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+# Ciphertext = e6c82d9f049d85417a81f3a6c1e06f4da68313e87fad40281dc863e3abd3fb6c021cf448e317d5
+# Tag = 57fadb6f555e5f5b004801924f61981123e45087b3e1d693cfd1ca268d58dc1b
+#
+# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+# Plaintext =
+# Ciphertext =
+# Tag = a8043d065e854f8c
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+# Plaintext =
+# Ciphertext =
+# Tag = 46f020350801815c3fb636917b1efad4
+#
+# AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+# Plaintext =
+# Ciphertext =
+# Tag = bbadac9f062ef1af3c95d7556a604d2b5570dcd190820d34
+#
+# AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+# Plaintext =
+# Ciphertext =
+# Tag = 9edc390a828f46559ccbbdd5ae61af2a6d8504e69a48674dfc9ac3c7795a77ce
+#
+# # initialize with key of 128 bits, nonce of 64 bits:
+# Key = 3ad36c059e37d069029b34cd66ff9831
+# Nonce = 43a405662687e849
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = c573c668db9a2cde
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 49a5804e793672df058c223218eda8a9
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 3e520289e4410dd64bbac098f84373f5a13799a93b4cff8e
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 1462f86d48360f0f75aa8116f6dc7e2b9693b5a5acb654413db300c686b12b87
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = bba7129444
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 8391224c52
+# Tag = 1f3a848a9ba389df
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = ea22e3836c
+# Tag = 1e337624239888f553f66e4b7dff2c40
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 6bbc8aef21
+# Tag = 415f8a207858a94e571a2bfda5ed280a035459593d67c036
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = db43029828
+# Tag = 4cc94d738799dab1349f6b95c60b3193f35a74295f2ca22bcfda544b224b237c
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 28ce9dec611ddcabebc3238e
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 9ecfb7663894f03ccaf84f0b
+# Tag = c8d14b9c946db692
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 12e624e4d147980570b80955
+# Tag = 91fbf17455d8984e1549e8691d6ead48
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 71bc91cd08c052d43a8d5bf0
+# Tag = 4177b11d3282717652f331b82aeb9156374ca22e05affd2b
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 2b4416219aa4a008af0436d3
+# Tag = 84afab4a839306ebe27e5dd8ed28fc160d8c760ff87a58cdf03dafa6a12b2d2e
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 0227b76c1f04d51e0904be270a864fd360d7fa98bc222f
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 94944b7ac542e82368e5fad4147f1cc7c40d28858fd782
+# Tag = 08b9648e7eda5c45
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 418b8c74daecb6ff9bff4a4d485ea8f5f3fd3fe69b8974
+# Tag = a470da07888f08c96902a88e63e03ea0
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = bd4ae91ddd48102e7554f52416364d89ef00a3fc7f65ab
+# Tag = 8a0b8d08f74fd475b183fcf3d0d69ab972e3b17884973972
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = b4e86dbfdf8f55108c46f4bf6e0e7e3e6269f6b886cddb
+# Tag = 28feca673322552f8198cf1fc7e8e3e23ab464c2d2a8df62602ddc05e170ad5a
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = ac6a68b52e4abd416b9abeda553ed24563cba6b6f9c3ee38e8183af40224b020822f813dc2ffe9
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 2099370162f199e32c59198619fcf9d03c5f23ca62e9ceae94bcd4564854959de229c9c6fa43d6
+# Tag = c897b557338c1ef0
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = 07a97204e88c9a9cb9921cf9097930e002a3fc50d364dbea014c4cd74d05ccef1cb4bda48e0254
+# Tag = a5e3e29ec24258b8f50127a73b8ba819
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = bf721016121d2c99fe532fd02b2aee9ca993232968d93ea4b83e7f0aca2a18c2e4c8fb48df7377
+# Tag = 8b91f0e9f4b454c7a4132e76d6b6d391654bdeb899733f7f
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 743dbf795a4d9898acd236d98df514cbf76fa8a4fd1f28ae8f609a476ee04fd076a2bac09b70c7
+# Tag = 054827132710f3649787818ab92c63fd1eea84f086bb4fba0071f35ef15264c5
+#
+# AAD = 5eef8011a2
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 66f78819aa
+# Plaintext =
+# Ciphertext =
+# Tag = c7015bba4d8e2b0d
+#
+# AAD = 6eff9021b2
+# Plaintext =
+# Ciphertext =
+# Tag = c3ca67db5a366800128cb16bfcc2d619
+#
+# AAD = 76079829ba
+# Plaintext =
+# Ciphertext =
+# Tag = 541a746b262465d66bfd46b11663711c0d0a6d99523ea788
+#
+# AAD = 7e0fa031c2
+# Plaintext =
+# Ciphertext =
+# Tag = 4e31633765ad386a57ae21fad661a54445ddc60d62817331477b064f9ce2dcab
+#
+# AAD = 6cfd8e1fb0
+# Plaintext = 2647c7e86889092aaacb4b6cec0d
+# Ciphertext = 901199708970911f0b437f72abdb
+# Tag =
+#
+# AAD = 74059627b8
+# Plaintext = 2e4fcff070911132b2d35374f415
+# Ciphertext = 38f83ce83bc0e8df0571dd47dafd
+# Tag = 007d040d02599afe
+#
+# AAD = 7c0d9e2fc0
+# Plaintext = 3657d7f87899193abadb5b7cfc1d
+# Ciphertext = 0f52b34f45657d31b40ca0d152c2
+# Tag = dddc87ebaea140b3b3193f2eae23d3ae
+#
+# AAD = 8415a637c8
+# Plaintext = 3e5fdf0080a12142c2e363840425
+# Ciphertext = 94d6c7fb56cf26e1ee3e79b96bb9
+# Tag = 09ffa07a977e64007e0088dfb680a5b34768ed04b835d0d6
+#
+# AAD = 8c1dae3fd0
+# Plaintext = 4667e70888a9294acaeb6b8c0c2d
+# Ciphertext = 5abc35ee82d84eeec5bd64030d18
+# Tag = a668139b031344833b43896d6730379a7c436b85e7abc4988dd4041021d130c7
+#
+# AAD = 8112a334c5
+# Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+# Ciphertext = 332e7242a34f4d2a3a793ff792371f7f19a1a4b404c98e0b2b79a8b54cc9fff4a5d190
+# Tag =
+#
+# AAD = 891aab3ccd
+# Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+# Ciphertext = 8f0cd16b164da3fc37c51fd5ed48e78ad0b663db7266038751d1214e59adb11d9dada3
+# Tag = d4e321ab327f6b55
+#
+# AAD = 9122b344d5
+# Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+# Ciphertext = 5586ac97bfce4eec9389db476d0f7dcb1b963fd863608c062551cd801bb2ad99619003
+# Tag = e3a05acabf5929ff98ab62f30cf3a29e
+#
+# AAD = 992abb4cdd
+# Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+# Ciphertext = 9628f3b8273f375f069444b22bb178307d563a9373d40e47129468c0ebdc4ac4630ff6
+# Tag = 84674da9be31c6bc75b0d52b34c9d1daaccfd348b42a1a7b
+#
+# AAD = a132c354e5
+# Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+# Ciphertext = f43321d40d605a351789132778ec4ddbfe2eb9f50c426d84b245f5816dfaa87a184873
+# Tag = cf54cdd4955d6c6c4896f7892a261d7b7e9dc400dcbd0030f86fd3c5429c5dbe
+#
+# AAD = 2abb4cdd6eff9021b243d4
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 32c354e576079829ba4bdc
+# Plaintext =
+# Ciphertext =
+# Tag = 12354cc75633edf0
+#
+# AAD = 3acb5ced7e0fa031c253e4
+# Plaintext =
+# Ciphertext =
+# Tag = 5c77010dab4820d7a7aedacf0015ebe6
+#
+# AAD = 42d364f58617a839ca5bec
+# Plaintext =
+# Ciphertext =
+# Tag = bf803e85954b76712604c790a45f79e10dd7e9ab0f52c869
+#
+# AAD = 4adb6cfd8e1fb041d263f4
+# Plaintext =
+# Ciphertext =
+# Tag = 60a325f3974cd0369f2d3f9befdb313813da5a631e51ef98686513379be67428
+#
+# AAD = 3ecf60f18213a435c657e8
+# Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+# Ciphertext = c1d0707ac5ed5d045196ad51b5b17c87ea3aeeb1
+# Tag =
+#
+# AAD = 46d768f98a1bac3dce5ff0
+# Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+# Ciphertext = 17c9e112056f4cbdb4b90ec97122a1afb6273c68
+# Tag = 42e3eef1ef27f836
+#
+# AAD = 4edf70019223b445d667f8
+# Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+# Ciphertext = 7ac94af5965e971d7bce0ade73af17ab9483eb25
+# Tag = ea3a52d59ae27c6a8d91ae5756cc0dbf
+#
+# AAD = 56e778099a2bbc4dde6f00
+# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+# Ciphertext = f07a2cb30cf16af25b63327f5b41e790f4ddac61
+# Tag = ff1259225b38b5ebc48b5537d3a26bac81b868cc12d79083
+#
+# AAD = 5eef8011a233c455e67708
+# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+# Ciphertext = 86a38441e5400bf9247cd79f11f349e014e88dad
+# Tag = 9e4490846a0bb8e9833292518408f8c20f8cde6f62b750b6e2ba346aab8e2782
+#
+# AAD = 5ced7e0fa031c253e47506
+# Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+# Ciphertext = edfdb988245eb4ebf5abb9c7476b47076c37ae18559bd3d6a7dba12e99073db363608ea0c2dbfe52a3c2c835cb902ff3e773
+# Tag =
+#
+# AAD = 64f58617a839ca5bec7d0e
+# Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+# Ciphertext = d4e7b7534bcb39321ca3e1f5d947b5856a54decc03743b2214853e67345170a9543ec279ddf555d5920f43a9ca2b8726d39c
+# Tag = 41b4cfa9ee4f4f1e
+#
+# AAD = 6cfd8e1fb041d263f48516
+# Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+# Ciphertext = 444ef3909e42fc7975423dc913d16258b4571565a16f09fbcaf02660547cf98f633c51a1a48c0b0251481ffc10d0d9c69105
+# Tag = c62bfc0ad8d1c17e52b607e106b519d2
+#
+# AAD = 74059627b849da6bfc8d1e
+# Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+# Ciphertext = 074cf9d5991a47686f27e964139fc9ed429c65765afcfb92816b09b2397e33cc33eca03b45179be90c4223e2b419cdec81ac
+# Tag = 8f159958db825f91c369e0828b98af5791b6ba2b52c8b9f0
+#
+# AAD = 7c0d9e2fc051e273049526
+# Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+# Ciphertext = f72d2c35ee563e3d12116e5e57b012ac0ee9802f8d9b5980fd8a6b83fb1ba476920c5646e029cdff2a32901ae36c6da30b2a
+# Tag = 8ab9b32a8bd02e41ecdcdb480495540ef1a98e38188beea71c59f83a5d3fab74
+#
+# AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+# Plaintext =
+# Ciphertext =
+# Tag = fed5f9442eab657f
+#
+# AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+# Plaintext =
+# Ciphertext =
+# Tag = f56dd58f778d3cb827491ee97d778f05
+#
+# AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+# Plaintext =
+# Ciphertext =
+# Tag = b5c3bf1bf8220c4ad5821422c308fcdff09cec9bc32a32cd
+#
+# AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+# Plaintext =
+# Ciphertext =
+# Tag = 72527969077c44b56e7f606b8c558c41e997e0e2e94bef92852a78c74f836476
+#
+# AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+# Ciphertext = aa35d8d1c3c497d160818a7bea345a6fd6b570161d19586567ba9b53
+# Tag =
+#
+# AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+# Ciphertext = c735063fafc2f9182a48d51766e5d55286b245d59772875f68c134f2
+# Tag = f19e9e7796343464
+#
+# AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+# Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+# Ciphertext = 1dd5fb71639af22b3e95efbe49f4b5f99186618101a4e7a9cb29be5f
+# Tag = e627e774ce97b963120a9be4e6cb7094
+#
+# AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+# Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+# Ciphertext = 6c542540d2b25b6ec8a5ab8adcc320ef235895caec25f16fae947114
+# Tag = 05f5e23aeec52199b2d81569605d8b47d2775de217c99eb9
+#
+# AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+# Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+# Ciphertext = f312506614208f2878b15fcd1877f3109b1cf3115aedd6bf9097fc39
+# Tag = 1a0948f718583f284de252043c916e35764223efc7df327a22160c2d7cf09cd1
+#
+# AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+# Plaintext =
+# Ciphertext =
+# Tag = a68fe52f5c9ab1df
+#
+# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+# Plaintext =
+# Ciphertext =
+# Tag = 4b6ad1f60a60b882065c91a6637b907c
+#
+# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+# Plaintext =
+# Ciphertext =
+# Tag = 66bfb808c4ff6bc4c98bebdd10b04dcc8fc57251f39c523d
+#
+# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+# Plaintext =
+# Ciphertext =
+# Tag = df0c0b6b9dd6ed0d30326d641dfd14c90c51d1cb11fc9cd5d7760eeb541aac3c
+#
+# AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+# Ciphertext = bf31a38b08ad11ec8b63e5495422d14695556c01303502d0216d6cba2f7051e545db62458467d0
+# Tag =
+#
+# AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+# Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+# Ciphertext = 088e87b83fa45a11644cc538e5a0e23948b857f6854ff70086de482ba5287524c6a5a529ef7eeb
+# Tag = cb0e80bbf1166cd4
+#
+# AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+# Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+# Ciphertext = 00d26600fa1a1e7ca99b894c1f346fa7b25b8fdb7dcedde364937461031aec413a02177200b2ac
+# Tag = cda56e0d87855622c289ffde95a161a4
+#
+# AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+# Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+# Ciphertext = 478e36aade320ffe032a78feea6a8ac395b9133c46685a41dd7b7a30325734c59213ed57ebc50e
+# Tag = d8a9e962427494404d2ca13b2c4dd815c378a5c8e1c5b35f
+#
+# AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+# Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+# Ciphertext = 799f6fe70703d63674bd1a6313816fbaa699c85286edec43c9c8c733b70efb5d4beef0ec4468d0
+# Tag = b31990acf77426d6f722f0a14ded00fdd3c93ec41cb186d47e10de8ad22680ee
+#
+# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+# Plaintext =
+# Ciphertext =
+# Tag = 5894b487dbc95146
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+# Plaintext =
+# Ciphertext =
+# Tag = 2ef165935539576aa9f184c02ea17718
+#
+# AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+# Plaintext =
+# Ciphertext =
+# Tag = a23085aac48ec1ecbd1676d468c3bed02237cfb50c5885f5
+#
+# AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+# Plaintext =
+# Ciphertext =
+# Tag = c6bcaf17d8b8678e9d48669beabfbe469f562eec532b2d5b52efa87c449cfb59
+#
+# # initialize with key of 128 bits, nonce of 128 bits:
+# Key = 42db740da63fd8710aa33cd56e07a039
+# Nonce = 53b415763697f859197adb3cfc5dbe1f
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = f01de38c5b735fb3
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = d5b6c0aa25c2847186a989df1b987ff9
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 87cf1e801dd4f5f338bd878642b209bea5216f16614da576
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = a3c9756a3d9fb78f5553575c57c590e4d31e06fbd72e41d27baa4a00f3873c94
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = ccbf98112c
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 6b5a4ec120
+# Tag = a99938c40dba7435
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 46907bf76b
+# Tag = 627c1d6fcbc266d920f1b0795d115add
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 7c00fcbc92
+# Tag = 5d06ac15c8d823b2b7eb26f98659916d0121bbe97a1a1fd1
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 2e3f9db491
+# Tag = cdbdcbf2863dd35d3c43b1c50a49b52d3ee11edf0aae210ae3cb560b0866dd4e
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = abcde4c398c3b761bbed9d1b
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = fecbc4ed172e789940af03f6
+# Tag = 16406b3367485c7e
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = a0ce9342721a70a90c667dc3
+# Tag = 58508c833afd4e01e0afa87223c80ea8
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 1fd541a0482e7ebd512f9440
+# Tag = 21a1c3f4d06a58a51a1a442162646c192d345e85a6d04a1c
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 98f2b52d6be9232ab8575818
+# Tag = 0207a1a039bd4e4384d12117e60536707ac9ffa1fa582e314614372ce2583f1a
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 49fb9cad51c7e92d859b674557a75c88c3d1fd7572cc7c
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = b96460ac9cb4595f14443d79acd0ef181c1abe6cb0f658
+# Tag = 0786d352a10a1b25
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 42c458451f12c3709d44e36d2c8d8b7fe5e637be526fbb
+# Tag = 170469b41bca1dcf15db479e66f7c915
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 5b1eb8c37d0a9cd5113b02a87417d9b5ddb4238dcce56f
+# Tag = b8e6965d7635a2fad3bb97aa51b038c9adce7963106cf2d9
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = 36e11f9cb68e3da538619ba973885101c7979d669c8d68
+# Tag = a46925acdcde5b8545e18512fd23d2003449415eebefb84edc370ef0a08d9f7e
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 6f4625c1878c6cb2dfd60a082a37f220af0521f1c6ece37bd67862f7ada6e603b4fa51fedadffa
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 20e9bcc0c8d4fdcf66682d61e9694a63d9bccf552220b9290c2269c4af57172598ca9a0b37ec6c
+# Tag = c59997244f2438ce
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = 402db5fee89ba59384bb57d6ce01ab12eb562a95b40d5ad86ae7cc7a0aa597202c6d5588eb1b8b
+# Tag = 130920a0597ef972058c8a1370f99d06
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = e3c0a4e28e9837d6946770c3fd0bcf0fcb30b4d49bd61a4aa4416b88a83cfd764198a3931c7bb7
+# Tag = ad335b876bb7766036c7597a785e60cd50bf830ce5150d65
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 4152ef9317983bdc31e51e1948362ae1b66451c68934f29c988e73ba96512222ad85b011f401c4
+# Tag = 3aab47470d3f4196fe0b912c4bb97858ddf594405aac5ee04438d5b0f9608ed0
+#
+# AAD = 5eef8011a2
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 66f78819aa
+# Plaintext =
+# Ciphertext =
+# Tag = 864465e910bb6f22
+#
+# AAD = 6eff9021b2
+# Plaintext =
+# Ciphertext =
+# Tag = 7e5b3ac40ffa3c1c9226056cf0774bbd
+#
+# AAD = 76079829ba
+# Plaintext =
+# Ciphertext =
+# Tag = ad5fc9751493a28e886073b4c4bc988c545d86a6ffc70db7
+#
+# AAD = 7e0fa031c2
+# Plaintext =
+# Ciphertext =
+# Tag = 70f25d2ede47f2cf4df63d62842427f7a6a92a8d30419df49a39c5737a35707f
+#
+# AAD = 6cfd8e1fb0
+# Plaintext = 2647c7e86889092aaacb4b6cec0d
+# Ciphertext = 81fde86151462a3cb478af8e47ee
+# Tag =
+#
+# AAD = 74059627b8
+# Plaintext = 2e4fcff070911132b2d35374f415
+# Ciphertext = 941178eb365991c5a91d1978f1f4
+# Tag = 5911a8888f045974
+#
+# AAD = 7c0d9e2fc0
+# Plaintext = 3657d7f87899193abadb5b7cfc1d
+# Ciphertext = 4fdad42e51078f251690f0d25ed6
+# Tag = e8b20f223a33623f9f1250ab17b471bd
+#
+# AAD = 8415a637c8
+# Plaintext = 3e5fdf0080a12142c2e363840425
+# Ciphertext = 0e6f03a74dd33b8cc2d90a181ed2
+# Tag = a21685b3c127deb18d7e07ce8bc4a04f5ca2fd8bf0ee365c
+#
+# AAD = 8c1dae3fd0
+# Plaintext = 4667e70888a9294acaeb6b8c0c2d
+# Ciphertext = 06fa46a34e5b68bb5842dd2f550b
+# Tag = 39e1303de8938846aed77273936940831610363e82228c11ef3e6f60fe9bf201
+#
+# AAD = 8112a334c5
+# Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+# Ciphertext = 54190c5e51edf97feb6ae02cd8a58bd81273222f302f8ca00fac16cb6db7355b6aa0fd
+# Tag =
+#
+# AAD = 891aab3ccd
+# Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+# Ciphertext = 28cd29dfea7a6c47b3a581a127d71f5319c650d0ba151e667a9a61646a7fbf8fadde84
+# Tag = 5c7f2445eb156621
+#
+# AAD = 9122b344d5
+# Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+# Ciphertext = 305e20e4bb35794b4d70507a9be23c4bc1be0b9ae0f4766a1d8c726b5e9d9b7e9d8cb4
+# Tag = 5726dcbe930b1a75accdf44ace9d7819
+#
+# AAD = 992abb4cdd
+# Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+# Ciphertext = d7aa36133b0e1ba190fa42993093173e256db61aa124e0057633231c707b936d9b3296
+# Tag = 6158f65704de932fa093cf1c0bf57f4c242582a6ee0a5d09
+#
+# AAD = a132c354e5
+# Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+# Ciphertext = 8e7898a8d3575c019307d4efe609ce0717b8a1bc68507d0f5b5ab65fddbd67e37f6e87
+# Tag = ba3edc080c91cc234c0beda88a257ad96de0af3fea4e51e67a917efd896c5069
+#
+# AAD = 2abb4cdd6eff9021b243d4
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 32c354e576079829ba4bdc
+# Plaintext =
+# Ciphertext =
+# Tag = 4e570238bd11eaa2
+#
+# AAD = 3acb5ced7e0fa031c253e4
+# Plaintext =
+# Ciphertext =
+# Tag = 64587fb1293fb8e146a67c1badae7fcd
+#
+# AAD = 42d364f58617a839ca5bec
+# Plaintext =
+# Ciphertext =
+# Tag = 8a3f1852ed0e4de2d4959208bc5a57b5e871139f292efa79
+#
+# AAD = 4adb6cfd8e1fb041d263f4
+# Plaintext =
+# Ciphertext =
+# Tag = 9d5c83a916f935c1c11429080a6b2cca5166f5ba13dea1715a6878651bbc197b
+#
+# AAD = 3ecf60f18213a435c657e8
+# Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+# Ciphertext = 67fd9c22f8041a49c45995f438c5510f07b88b06
+# Tag =
+#
+# AAD = 46d768f98a1bac3dce5ff0
+# Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+# Ciphertext = 0cf6566aa858d796c394db94d61f86f31c12ad33
+# Tag = 07e011ce81326d87
+#
+# AAD = 4edf70019223b445d667f8
+# Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+# Ciphertext = 879ed7c06fb02397cb533ef2d245f63d28cad418
+# Tag = cfa761ef76f4e3e6287930308e78fa0b
+#
+# AAD = 56e778099a2bbc4dde6f00
+# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+# Ciphertext = 6b55228d76dffbe0fc89856a5853afb7df77e302
+# Tag = 7a241bad2f9ffc92715956a4385d8c03a3c57f06773faadb
+#
+# AAD = 5eef8011a233c455e67708
+# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+# Ciphertext = 1e6910aa6187a4414226798d065fcab8dcc48c74
+# Tag = c854d5356604a0cf3f5dbdb06cd640b99ae235544c3bd19aa6173265aa64fe97
+#
+# AAD = 5ced7e0fa031c253e47506
+# Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+# Ciphertext = 975ebbae0a4366225cc784ed34160f3892fb43cdb80b372b4c29a9b858e274e0208647a07cc4e7f82f0b88f426ba2591761b
+# Tag =
+#
+# AAD = 64f58617a839ca5bec7d0e
+# Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+# Ciphertext = e07e4e961713de115d537a739aa4d4da0295c351be19da34c585c4dadc2db3a53f902f03a3d4668f5723850346de2bec035c
+# Tag = ea5c28ab883369a2
+#
+# AAD = 6cfd8e1fb041d263f48516
+# Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+# Ciphertext = d2b045f1bc359baf02d762470663c4c642dc4d5e5655215a1cc57e57b9c29877fc153ef77865f5b70acf52f1d2adea99da7b
+# Tag = 096604780770de73b6ac9b42c3f68fe5
+#
+# AAD = 74059627b849da6bfc8d1e
+# Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+# Ciphertext = 7a80e3335667fa4ec2ed850780998bcb33c53dd35677a7960535f912ceda869a053c3c29c92e2c706b62314ef0cef5ff559c
+# Tag = 6b78fe154d77f7e20ad8a880ffae3a268e5615fd187da453
+#
+# AAD = 7c0d9e2fc051e273049526
+# Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+# Ciphertext = 945c9830513f2de1802a4223479653e74022dd6ec359a6cb9e2f8fd6b3f4ef30078757d7c90838b9408837f093d496e075f0
+# Tag = 99e28c7a09caf792bb6197b2f8e59a0650a1b64c8894dbedf9f23a8851a6c64e
+#
+# AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+# Plaintext =
+# Ciphertext =
+# Tag = d85536be6605a09b
+#
+# AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+# Plaintext =
+# Ciphertext =
+# Tag = d7f56fd8a18a907a248ee32e16c69d6d
+#
+# AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+# Plaintext =
+# Ciphertext =
+# Tag = 2aa6b125e018c070f923fcaa28882ce96b7f11fc4dd9efa7
+#
+# AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+# Plaintext =
+# Ciphertext =
+# Tag = 1c7c7563f0ff06f27ee1c557796026a7fb8ed2eff502988411df3f70e61a862e
+#
+# AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+# Ciphertext = 579e2338f901bd405e4becbfb02c2087ea8174b32145fafa189d0452
+# Tag =
+#
+# AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+# Ciphertext = abc014e2583feb0cc5ff795364b05b5d9e07eecd76d367a6e6aff318
+# Tag = 36d475d41adaa0f8
+#
+# AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+# Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+# Ciphertext = ed529e35862473f0c289d4446974139e093f183573de2206553bb05b
+# Tag = ea9c440235433adf412051041eecd2bf
+#
+# AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+# Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+# Ciphertext = 4a749c17d277e8e183ae670ea2d9758715f57d1d57625e8e570a7fd2
+# Tag = b1bc4d70e3ab206e55fcb90c26a6e6f6f00615e4c638d337
+#
+# AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+# Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+# Ciphertext = 41dd6b31cdfa6b9614c183a6a1b85a689b0ce954cb621fd13b5a321f
+# Tag = f4e1f035025c91934bf8937f2f5ae76a6fcf40f9023b37cf4a7668059b55f5d3
+#
+# AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+# Plaintext =
+# Ciphertext =
+# Tag = 36cc5d3c9ac3964a
+#
+# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+# Plaintext =
+# Ciphertext =
+# Tag = 278a3a8d8192209243de0a30a1439433
+#
+# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+# Plaintext =
+# Ciphertext =
+# Tag = f12aaa04ad45b5d4be440a15cabaadc02a30c2b29709a0dc
+#
+# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+# Plaintext =
+# Ciphertext =
+# Tag = b88321c856864a79dbb2c3064e85040da9a90284766533bb755cf89d6d7ec45e
+#
+# AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+# Ciphertext = f6d7e5117119345049edde892207f49c492cde9f7ab06e22870ddaf20798abc71c121c9296b917
+# Tag =
+#
+# AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+# Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+# Ciphertext = bdc067759d881b19cb7a355a2ea5b3860fb020496473437cf9db9d997d7c19161d054234ded319
+# Tag = f9270b4596c4e115
+#
+# AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+# Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+# Ciphertext = b0b86b4d85ccc9248573df04d880df9a9fb9f9ea47efe3fe58eb627f80759fcad1b2b1edcbaba8
+# Tag = c641c221e317a40d4378151741f15b0b
+#
+# AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+# Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+# Ciphertext = 43ac00b42ff5a94902f8b7ca0a18e359d4c6d597880d12fac2050da367e69b6bb42df7b5a976d4
+# Tag = b20d55ed33bee294e8781c97170e087ef5172face14802bc
+#
+# AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+# Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+# Ciphertext = d0903161726608dde2ad445f3ac017fee13c6b894f8fe2b8b743d43468cbc50063702430efd4d1
+# Tag = 1b442200c295a02a64b1a31f9eb6644aac518d243de096fa1dc5f200b604750f
+#
+# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+# Plaintext =
+# Ciphertext =
+# Tag = 00dedfeb15275248
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+# Plaintext =
+# Ciphertext =
+# Tag = e4fa7e13aafcf199af09df9c0d6524bc
+#
+# AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+# Plaintext =
+# Ciphertext =
+# Tag = 6c6eb3f9222cd98e89eadc5aaf685c980f15eb0036c0a5b7
+#
+# AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+# Plaintext =
+# Ciphertext =
+# Tag = 2a69d16663196738753f42de5bb4f082038bdc4a9e4f72e366488ee92e1e209a
+#
+# # initialize with key of 128 bits, nonce of 192 bits:
+# Key = 4ae37c15ae47e07912ab44dd760fa841
+# Nonce = 63c4258646a70869298aeb4c0c6dce2fef50b112d23394f5
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 5d9cf1a04120cd48
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 3a3f256e7e6b754299de8dfceca4b0d6
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 891b7bd6878ab1bbe707740d415aaa3e1b8363d942441c26
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 365bd8e6490d578e204c93a0088cfe47e0b38cc56882773cba1e742dfe21b77c
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = f9b7e0c2ba
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 5856d3f8e8
+# Tag = be4a85f723669be9
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 09a411660c
+# Tag = b2d2b0fb22829e9e4fca1a1618ff9971
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 57fdc06bbb
+# Tag = c273bce1a25df2d0920c99bd786483f1c94ce8e8ffe49716
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 7a60cd1fe0
+# Tag = 898642dbacc36fc1b52167f23fd59fd9cb38c025d7fbfee6758633601bd989ea
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 7a8e03245262f46872980346
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = a5db2340dba9063d4034388a
+# Tag = abe584316f8724a6
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = e219fe7b037461490e52f256
+# Tag = a852afd69dc636c7c50ff440b277c701
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 7bd14f10746d87c296b31703
+# Tag = 6648cceba2be7d7ae8270e4428b590513b6eabec4edce28b
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = f093e30763727722ec97bf22
+# Tag = e4dcfe0def1895a263aed90a5ff926a132d8f97aa85ac7070f1472c57a454aca
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = c2ccbd6f42bddb9435fe2c4a97bfb679a8c898da1187c2
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = b82c070ad8c00df0de3a801bd8a7b8f35afedc4ea99dc2
+# Tag = 7613e9db87e4b839
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = e42305dc5ac4314a548d1eff9e78b20b631a90890234a0
+# Tag = 4c78b5c1cc208c02fda9688692f46064
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 91b418b493600d02f4ab3ddf0dd9e834395ecde84c3963
+# Tag = a517d3017015ef74c6990954eb8dd38a1cd02d20646555e2
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = e50db89aeec8e83477a210c94042869a5ac3d959f3d0f4
+# Tag = ec08938e92ccab6b633ba276c665d3000d1241ee41d4969785f9f12ae1a32a44
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = e879c0344953db3f51756fa819ce33a94d8f32b2762f000c024fa141ac9494dee249845fae3b07
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 7d8bd79cab9fae137f32669df7792d1f4e0fd173888499b1ee7527b9a1b31fc691fe8b026e0847
+# Tag = 1afb1ac8277ff6f5
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = dad47b79240216a136c2a2f939872d4a8902a6d5f7e45afe1e0c681f7f4af3f7ce55fea0e23e88
+# Tag = 56efdb0d526bcbd43bc3dd64d96c3ad5
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 4251a236cd83c7331ed29e962d7c276b764f6aa0036c4d92240f38bbbd9a81da98d8a23a01518e
+# Tag = 367eb7a2082f45ce7e843e810fca6fda00fdbad6db0f2c4f
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 4694c0285290fd545a4a585b9d8965434612ab8c2b48e30214631b9dfa71879883fd2df69372d6
+# Tag = 08cb6a7a2fca7cf59803a3d446e19dc8ef876496771ffd6fbb480095a11d0b2a
+#
+# AAD = 5eef8011a2
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 66f78819aa
+# Plaintext =
+# Ciphertext =
+# Tag = 3c3d4f47164fc01b
+#
+# AAD = 6eff9021b2
+# Plaintext =
+# Ciphertext =
+# Tag = 991b19e728c79b4526a87ca97fac9fb3
+#
+# AAD = 76079829ba
+# Plaintext =
+# Ciphertext =
+# Tag = 6430d665d34e2d62719d6e41be67236115e7bdf02a311250
+#
+# AAD = 7e0fa031c2
+# Plaintext =
+# Ciphertext =
+# Tag = e2d514ff12117f9dce6cae7ee77e557ec1d8a0a2ca08d43cd5065a574726f515
+#
+# AAD = 6cfd8e1fb0
+# Plaintext = 2647c7e86889092aaacb4b6cec0d
+# Ciphertext = 9be1fb814b18d9ab1058fd70842e
+# Tag =
+#
+# AAD = 74059627b8
+# Plaintext = 2e4fcff070911132b2d35374f415
+# Ciphertext = 37d38c41a86514b70612d54d965d
+# Tag = 6c3f47cc571ccee7
+#
+# AAD = 7c0d9e2fc0
+# Plaintext = 3657d7f87899193abadb5b7cfc1d
+# Ciphertext = 4949cafdb36d48b2ba21d9607939
+# Tag = 9909096fe46c52262bfe70cdbeb619b6
+#
+# AAD = 8415a637c8
+# Plaintext = 3e5fdf0080a12142c2e363840425
+# Ciphertext = 28736e5d21e81dd91af7cab41d57
+# Tag = 1873ec3a7a7bfbed18cfad957297f2ad5a8ff4cc13fdf298
+#
+# AAD = 8c1dae3fd0
+# Plaintext = 4667e70888a9294acaeb6b8c0c2d
+# Ciphertext = 9091e155a60f5df82886c75ac714
+# Tag = d8f719d5f8bfd062771de1b6daa540a0ab8662a48104274b81b797256b20728c
+#
+# AAD = 8112a334c5
+# Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+# Ciphertext = a822beacafa73ca8ba0dfb3c6ceb6a62451bdd6ddcbeeddcabd1164a61300f212836f9
+# Tag =
+#
+# AAD = 891aab3ccd
+# Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+# Ciphertext = 1ef03fccd83aeb58765898fa93ffc7b8dfe1f434610a381c14bca46d6a4283a3e7731d
+# Tag = 6695c68c1a8d2393
+#
+# AAD = 9122b344d5
+# Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+# Ciphertext = 2cb00b41814ad79b83105d7cda712d15af16d6eee2af9ef38b817ba1edca8c1724bc98
+# Tag = a0d91236f9382be295d806aaae062b74
+#
+# AAD = 992abb4cdd
+# Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+# Ciphertext = c7af492b410b4209f40cdd1a7e341be6d2d621c41ed257c3e165ba1bd5afe9b6e0c11b
+# Tag = eeb66a917f3ba8ec5d8a4db217bb77945a7fd712aa1f10dd
+#
+# AAD = a132c354e5
+# Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+# Ciphertext = 51f215e0079bc38a2da9a9ec76059ce1e7b46300c08517af37f457599981cdf3cb51a4
+# Tag = b3780aa11e8a3394435eccff3d0f69887aa88816f33fd766c56f740935b21a72
+#
+# AAD = 2abb4cdd6eff9021b243d4
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 32c354e576079829ba4bdc
+# Plaintext =
+# Ciphertext =
+# Tag = b16a5ee2f7ca6eec
+#
+# AAD = 3acb5ced7e0fa031c253e4
+# Plaintext =
+# Ciphertext =
+# Tag = 12ae71447494005aebbb5c5b5a80d1f8
+#
+# AAD = 42d364f58617a839ca5bec
+# Plaintext =
+# Ciphertext =
+# Tag = fff6b46274083e16e4b04c2fc4470b52c8d8c4d043153edf
+#
+# AAD = 4adb6cfd8e1fb041d263f4
+# Plaintext =
+# Ciphertext =
+# Tag = be9d80d82a45ff7e77e9535f9b08a5516d5222c001d2437b8906bc48a76fd026
+#
+# AAD = 3ecf60f18213a435c657e8
+# Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+# Ciphertext = 67d178a120fb450da7c99717e062e0f346f30609
+# Tag =
+#
+# AAD = 46d768f98a1bac3dce5ff0
+# Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+# Ciphertext = 64fcd0b67205358381464830a8c039b4755b6b4b
+# Tag = d037acb17ae8cfb0
+#
+# AAD = 4edf70019223b445d667f8
+# Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+# Ciphertext = 5cdead6540223a0bd34c23d8a09458fe4dcb90f8
+# Tag = a78223ea699aff53a370d2fc83928e48
+#
+# AAD = 56e778099a2bbc4dde6f00
+# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+# Ciphertext = d1789cac538ff960254a6ee8fb64768aaa1f8a73
+# Tag = 585acfb1452b3a11184876b3cef13d5b4062c3f480e07353
+#
+# AAD = 5eef8011a233c455e67708
+# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+# Ciphertext = 357918e31730ab2524abb8b40b28d3b7aaa8b2c5
+# Tag = 3f2aa72ba4b245b36fd761f4fcefb4652d527795e650558fec9e92b111d546e7
+#
+# AAD = 5ced7e0fa031c253e47506
+# Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+# Ciphertext = fa8fa69e7b126eef5cde5b9c2c709a3b4c71732343564d9078694fcfbdff4b6f89882053dc9e652d510ebbf95e8367c2e5ec
+# Tag =
+#
+# AAD = 64f58617a839ca5bec7d0e
+# Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+# Ciphertext = b8b0d0e53afa91f36711ae9a50e7f58565c5a3ac7ff6cd3086610aea7f31241883d5a454665ebd2dd485beca76d4d1c4e1ce
+# Tag = b5d533f11a905cd9
+#
+# AAD = 6cfd8e1fb041d263f48516
+# Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+# Ciphertext = ec865ef9555cd6e157c16ce50f371bc4d46bb57e63df480634c17fd4fb092c982eec5560f75d9e17350ecba8af24aca795c4
+# Tag = 057835dbe4a9d36796a671a53ba4d636
+#
+# AAD = 74059627b849da6bfc8d1e
+# Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+# Ciphertext = 8cb49c33bb3a7912503737c7a99c35242852e5e69b4b28b901b20ce5b83f4446aa18da3d90df5bcd313f49f5daa42d07f8a4
+# Tag = b25b450f0d1c291c70bcd980467524ba0f4c4914b4ac8101
+#
+# AAD = 7c0d9e2fc051e273049526
+# Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+# Ciphertext = 3c9cd1dc604701a1034e89d01b6ed741eaea2791dfd3e3ac7eec51cbf8e782ff33e83b822a27f062ac1065f2060a56ba737a
+# Tag = 10b96effc8c6df792443f24d7a3020a8fd929f59672abbffd9af6acad752f4a9
+#
+# AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+# Plaintext =
+# Ciphertext =
+# Tag = dcdb07a03cce06c0
+#
+# AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+# Plaintext =
+# Ciphertext =
+# Tag = cb16261513f0c66d38c858a43f36a404
+#
+# AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+# Plaintext =
+# Ciphertext =
+# Tag = 94221a06f04750141f3e3fa92c85394c196998ff3aefcbfc
+#
+# AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+# Plaintext =
+# Ciphertext =
+# Tag = afa0e7bfb1ef40107c368c341c2e1d6441b6f8b73405155d6827cee309cba5ea
+#
+# AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+# Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+# Ciphertext = 835268370835c02cf7d0aff668deb992da3e1b4053127bc7e8a85c06
+# Tag =
+#
+# AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+# Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+# Ciphertext = 5f131583ac0902eee3d7a1fc6547d89c6c47689de66a77281ea0c1d8
+# Tag = b71ead7e40538487
+#
+# AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+# Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+# Ciphertext = d4cdb4ea88a33482a535631a52f8eeb1067b1386da02e90b96363632
+# Tag = 2c58522f1c4cbe65975a766dac36580d
+#
+# AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+# Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+# Ciphertext = d9c7bfcbc34d2dafdbf28bdff08cbd3ef44455f43781a70cb5077be9
+# Tag = 2b369d68f37f33d2e5783fbf54d0bd6761afdb1f6eb8d085
+#
+# AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+# Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+# Ciphertext = 0aad1378ae47d665823096c057256c03d178988b6ebabcdb67fc9723
+# Tag = 210c21e4597623303773b1783edfe3e900c6e017de51f3a364d092c7ce7fa318
+#
+# AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+# Plaintext =
+# Ciphertext =
+# Tag = 80d50d3000048bb4
+#
+# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+# Plaintext =
+# Ciphertext =
+# Tag = 7b443e9c36d7510c639356b5200eed28
+#
+# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+# Plaintext =
+# Ciphertext =
+# Tag = c518ecd02f96d441bbd6bd80c5fb3747f50780408f2d9b7b
+#
+# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+# Plaintext =
+# Ciphertext =
+# Tag = b342703337a1c4dbe5c76bb21b9eef97ce594f35993a249c9fa153c5d1a4d309
+#
+# AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+# Ciphertext = f793e0b7305345349c6ff5fe5b91477fa1ff5bcc33f60d636940ce215edfd0acb85bc728e049dc
+# Tag =
+#
+# AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+# Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+# Ciphertext = 480b42a015bd4a32d28892b6628d106c7f7c47d99e7b9abb5327e07792929eb0ae4f32db0496c6
+# Tag = e508e9d57d293a87
+#
+# AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+# Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+# Ciphertext = 33214e912214095dc2a77b841e065b396ef5d62923217f9969b4df2897a26465da5f69cebcf89b
+# Tag = 88fe9a32263e0729ee38cbc6797e7df4
+#
+# AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+# Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+# Ciphertext = 33be45fb86e8916407ee5b467d875104c30f99aadc79f2038c7ed6f0db9b1c575dd74f26140645
+# Tag = 8ff1d969eb75f3eb599308eee9ca8f8986496b4b7e9fa0e1
+#
+# AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+# Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+# Ciphertext = 3e93da072de4e5f8822d302986836c318b3ada4a1635d3a14589ff5db20cb796969e9ab216a1cd
+# Tag = 94459906f4ac2fb8124950bb34b1523ae382e49337629250254e30c414a54152
+#
+# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+# Plaintext =
+# Ciphertext =
+# Tag = a0003c2678b72299
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+# Plaintext =
+# Ciphertext =
+# Tag = 16d89e1a94bbceed3bd6671b8973d9d8
+#
+# AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+# Plaintext =
+# Ciphertext =
+# Tag = 7b9109ca8ce27af66ddb1a984f6eddad81970b2179838c60
+#
+# AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+# Plaintext =
+# Ciphertext =
+# Tag = 777f84396a2af2c0f910cd4106e3e1e9d9df8b7a30673d1d6af3a9eb4e3c83d1
+#
+# # initialize with key of 128 bits, nonce of 256 bits:
+# Key = 52eb841db64fe8811ab34ce57e17b049
+# Nonce = 73d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = ec3f9d4af684fc30
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = b5677631be872409ce3b5e90e68e4af8
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 3949b3fbe718a3659d1ece3bceeb3bf16f0166cdf55b10ba
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 98679078026a8a57c7c864b5096e8bcb0ebc76ba0cd57130d2daf9590e90b590
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 5bdeefeee7
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = d5f452950e
+# Tag = 1fa70d9164b76af7
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 55be83e3a6
+# Tag = e111e701020fefc66fa5012329abe291
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 6e1e3612f8
+# Tag = c3b186d5d8586f14d0907cc5a2c3ce525ae37f9f36a5b98e
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 3ffc3d69de
+# Tag = 4e4944c0ea5bfa9acb68ded84f121bbe38d9c048fed61c3b3262510d0e633c2b
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 565684b8098058f5abe724c3
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 5d428d3b53d42604adde7eba
+# Tag = 568a0f025a682d7b
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = bfaab6b19838ebb9fe4aae88
+# Tag = 03bc4fe9fc625ecee778238251a31e2b
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = bdc84948297c6cc2706619b2
+# Tag = 2b0abd5e5d780b6e1baabd86478967b79da4cdeb9d1b1a02
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 4e6276d92f9def56625d85f2
+# Tag = cf33aec3b17711ace84e38915490214c8174d1cf38d1607d17b1a9e00d132661
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 1715925d3bb7251daf8cb668b7bb1ce75c7def6b915f46
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 945385f1afb37d8c114324474e068cca76470c92a6172d
+# Tag = 5ab6407cb916f91f
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 5664a2e1580b4d530b30edfed9d0b17afb0089aa9e34c9
+# Tag = 6241ab653d5720529fc26b858e400131
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = ae94469f2603334d7cbbd48c99674256251b43e7938ea4
+# Tag = ce939713384dfb3e0b466ca17fd069c3e4f51533ca4a2301
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = 2b1b043e8563bf1b58b8866536bb01cd256f083198fac3
+# Tag = e7a5c603aff7fbe357a6de5be7547a5b7fb10eb71a81c8e67942c4970ca08a7a
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 5727e96de9dc5f364ac84c04c8d275cd0773bd935725547c66e33159556f82e1b036df43a1990d
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = bbddc30fbca9dd94ded431b51c9c728f94ad3c6c7855a85e22697b6991d1cffdaf7684f7ae8afb
+# Tag = f6c0f142c1affde9
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = dd48f3255811289ceb2ad0438d2e6340d2cd8c54be53cab4dbe703c210ed7187fec47bcfa29c6f
+# Tag = 0a919ab65615c048f69e140b3499a318
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 4a114b0a0299a22b4cd02261d7f660ad76024bc8a25cb9b6562e0eafbf113b484a0e2eb9702c0d
+# Tag = 5ce96860a4e27c827baf02b9c8dbd1eb2bf6620c4ab9ade8
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 7bbbc8adf730c86da4d2b89a48462ade68c4c373ff1deee525bc8730245fd44d0943d78b1735a2
+# Tag = 5c0e61374a3409722b7e3db0d2c26cb96d59e34c9171e98341f4c14b9abccfc4
+#
+# AAD = 009122b344d5
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 08992abb4cdd
+# Plaintext =
+# Ciphertext =
+# Tag = 633ada10e19d0e95
+#
+# AAD = 10a132c354e5
+# Plaintext =
+# Ciphertext =
+# Tag = c19c7c32ddb929662e01dc603897bddd
+#
+# AAD = 18a93acb5ced
+# Plaintext =
+# Ciphertext =
+# Tag = 32d1b20ca05c82bcb0073472babb200a58c057d21691522b
+#
+# AAD = 20b142d364f5
+# Plaintext =
+# Ciphertext =
+# Tag = 11ae3b92353c2148120b944e4ef0623af6a4b6d114767e365370bfb9129bd01f
+#
+# AAD = 10a132c354e5
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+# Ciphertext = 446cf8f9ef4c89952dce894f6bfd25d0
+# Tag =
+#
+# AAD = 18a93acb5ced
+# Plaintext = 73941435b5d65677f71898b9395adafb
+# Ciphertext = bf98f647e020671f789c24a436251581
+# Tag = 61d14fe682f075b0
+#
+# AAD = 20b142d364f5
+# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+# Ciphertext = 2042e7d79add4dc5415116a94dcbffc8
+# Tag = 7a6916e877d555e43d3059e5246ea8a6
+#
+# AAD = 28b94adb6cfd
+# Plaintext = 83a42445c5e666870728a8c9496aea0b
+# Ciphertext = 67fa98704ecc6d28b53c2105b8cb7744
+# Tag = 64c89b8734f7be9301a83a6b1ed55a7b774146334b916e62
+#
+# AAD = 30c152e37405
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+# Ciphertext = 5c2df6eab54a2f6c6be510589b667d70
+# Tag = 942af8ac0482d01439aec934816cc827d7ff9c6a9885df738ba01eb15b368093
+#
+# AAD = 28b94adb6cfd
+# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+# Ciphertext = 8a7b52eb2704716b3f7befaec3755f116e80f456c2864aed8d9ea1a0eb674da2512efed1e067077d
+# Tag =
+#
+# AAD = 30c152e37405
+# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+# Ciphertext = cea7d8c02d11cc9c6c7435bba1dc7f162aa6b565a70090055dc90fa133f5c13986f5ae647c34cdc1
+# Tag = fc27cd9a225e9aac
+#
+# AAD = 38c95aeb7c0d
+# Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+# Ciphertext = 91a69d72e2bf41ab6ea30ff092f4b94cb2d26702e55982570077b12895f329cae218669a9e9d20f8
+# Tag = b1678967e65fec170ef86c973d62fc3a
+#
+# AAD = 40d162f38415
+# Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+# Ciphertext = 92d1d82c9af7ee2b3e68b7b923dea7bff481d677fff9738777220cf3a3d4e523a9527f4a18b98f7e
+# Tag = 8e7f221b8bfea7c07715428af7276c4b6f8f929fdb80fe5f
+#
+# AAD = 48d96afb8c1d
+# Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+# Ciphertext = 2f5626ecc1edfe26e2110f96cf4353d88917302a084aee9450b10c55421173941ddacccf6fd4074c
+# Tag = 4ac40ea1a83c8b43564d02b3112819d2da2a31b6dfcf30ac248953949bf30760
+#
+# AAD = 10a132c354e576079829ba4bdc6d
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 18a93acb5ced7e0fa031c253e475
+# Plaintext =
+# Ciphertext =
+# Tag = cf04c2d861dbac8a
+#
+# AAD = 20b142d364f58617a839ca5bec7d
+# Plaintext =
+# Ciphertext =
+# Tag = 487ac1a9ade8492bfa3965bf8f6cff3a
+#
+# AAD = 28b94adb6cfd8e1fb041d263f485
+# Plaintext =
+# Ciphertext =
+# Tag = ae1f3511477518c57bbbbb5ca7b9fa507228aa60655881e5
+#
+# AAD = 30c152e374059627b849da6bfc8d
+# Plaintext =
+# Ciphertext =
+# Tag = 6eaf0b2af0de1b47d1d1420aa16729d2b4ff0433d152ccd284ece73bcee422b9
+#
+# AAD = 28b94adb6cfd8e1fb041d263f485
+# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+# Ciphertext = af19d4c675e79ea3d7bc2dbd9030fc2732b3acbf3e8411b6
+# Tag =
+#
+# AAD = 30c152e374059627b849da6bfc8d
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+# Ciphertext = 447289611d625f0b672d402e7734fed7fa0eb114bca114e4
+# Tag = da97a33eb8b85b67
+#
+# AAD = 38c95aeb7c0d9e2fc051e2730495
+# Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+# Ciphertext = f6716111439219a0258f7e4f8be15b3f3d5b55d19706f3f5
+# Tag = d6fd768a99c68fb5c9328c92269c1443
+#
+# AAD = 40d162f38415a637c859ea7b0c9d
+# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+# Ciphertext = 81a647add0b3b0626b3656665e5fa58be89c3523d3883606
+# Tag = 73ae026412abf0d1d57abbcc0b004f5afce1b4f0e3756b62
+#
+# AAD = 48d96afb8c1dae3fd061f28314a5
+# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+# Ciphertext = df39cd3fd8cff12a212ae6adc2907c7b211774d9e5034714
+# Tag = 7d266042b3499f9668619d258868ae29ef8a1ae5d3078d20af9d12681d0f18ba
+#
+# AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+# Plaintext =
+# Ciphertext =
+# Tag = 300ef30f9416e1af
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+# Plaintext =
+# Ciphertext =
+# Tag = 26c08b700224ce26edd193cd4a304239
+#
+# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+# Plaintext =
+# Ciphertext =
+# Tag = 454d90413ae61aeddc059af247e02f948cca8ca7f2f7e048
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+# Plaintext =
+# Ciphertext =
+# Tag = 94214f9ba55c987b37f8a66fb8efdc9fc1ff685a0d23d2c9ee4a23d7f48dbd9b
+#
+# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+# Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+# Ciphertext = 1e961bf5039442ddef30e97efc6d3006bee03946889893f691d47cb15933f733d859
+# Tag =
+#
+# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+# Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+# Ciphertext = d3e7012bba9bf695fefdbd01ef5a4c51432847eb189b7269e154c153566c7a9c2789
+# Tag = d3077531f1893b4c
+#
+# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+# Ciphertext = 90501b5a13bb93278ad58c4625301e4f54527ae772fab9fefad969cf438629f63feb
+# Tag = 64ca5ea05b4e5afee3377a11fdc913bc
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+# Ciphertext = d5f7e55308b1a328d6ca2e798f738bb690128263ab4d9ffb3d4832aac522e16832c9
+# Tag = 48d5a8dd5a750907a4889bf360256f842459bf86991f79da
+#
+# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+# Ciphertext = ebed339ac83122e1c47aa79af3a4e13ab0f24f43c00b0d5cd9ff9a129315933ba381
+# Tag = ca38384a722ab520af59a1af3995bea58ffd730c5b30defabecd948719638dad
+#
+# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+# Plaintext =
+# Ciphertext =
+# Tag = dab67d70c586b854
+#
+# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+# Plaintext =
+# Ciphertext =
+# Tag = ab2350219956b07d02ab0f9da46fa035
+#
+# AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+# Plaintext =
+# Ciphertext =
+# Tag = 0c07aa05775f046a5897a7805a3e52a5df0ccecbd46d76c1
+#
+# AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+# Plaintext =
+# Ciphertext =
+# Tag = 2fa40a1d66c7812246fd3c9ee7ff28f777efb55eea0a6a8341639845efe7ae5e
+#
+# AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+# Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+# Ciphertext = e66aa6cec08acdceba9b1e6538d9fcdcd58bfa05a704bba6fb185ad662c1a1bd764c460fdb041fc91fb2570ac321c9ed
+# Tag =
+#
+# AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+# Ciphertext = ed5d9eb35f61a03e893a0b14654f4778912de4a00ed675da6b3548538ef18b5a0d144e359cf40fcfb4c47868d93f0192
+# Tag = 6d6abcdf34312faa
+#
+# AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+# Ciphertext = 3c937834e46ad473c35e14c35a628fc6f9bb8c60277717445352d1399339314651b84b84c00e27bfc5136c5cd028246a
+# Tag = b8eaf56d0e68f82ac7ab7854fe5f1a93
+#
+# AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+# Ciphertext = 9197c92446a8f15c29186b6998d49bc54a6e0616fee5c2dcbc199a537d785231290e0ff14cccfb199eeb74a36c4555dc
+# Tag = da54a12c6c78d24c9b244dacf94379628db6ccca9dcdab1e
+#
+# AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+# Ciphertext = 66aa91f0e3e5b76796567f23a3e14d7131601562c88043d1752501e6cb9ee22c92fcb54a8cff22c3070d1d215203da9b
+# Tag = 5bce7dc98f773c642a07a84d453136dd1c897822792e077f152c34624f331568
+#
+# # initialize with key of 128 bits, nonce of 320 bits:
+# Key = 5af38c25be57f08922bb54ed861fb851
+# Nonce = 83e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a1
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 33c6886a75558470
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 317e3a631888a56aad4c1ee482ce89ae
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 580873c91ad3f23190e91dfaa7c0fac13a84f78825010ccb
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 1f4248f1b764463a3716e752acb84fa4b653e3609ec7bf71904144604e5ccc53
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = bdda3298dd
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 5c4c9c28f1
+# Tag = 075aa59b618cec47
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 21914c7cfd
+# Tag = 1ac5d263af357a1a819559cfc838957c
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = e670e37036
+# Tag = 5a6e023ae43c7ba27b80da673e8da5ebec5cb78e52869065
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 752bf9072c
+# Tag = 5d7ac8a32f75b3efa871eb4dafcc46080d057d2565117a035b86551ea465cfa0
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 88ce16c77c1dc5c155fde9a4
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 20beaeac25cba8284de4e12a
+# Tag = 8f4560e157dc76c2
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 4b8e7f9a343dc6facbe7109d
+# Tag = 0f0bf50ede1ff1845b431758f9fc4c37
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 130958faaa50a03f4e45fded
+# Tag = 0abcdcb6721e63d55de64880ff813cb1d9a51f279305ebc3
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = c18a95d7f05a8d083d5464e6
+# Tag = 3d9a8cc0f7dc0ae00c4abbbe163d53705ee1c90ceeee94c3b3abf3ebc5f6f0d1
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 2f98a72d459d2acbaa45d50f1706a1bcc1151f15b1ac39
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 62898f252d32784126eed963f5fbfa9fabe23c63a180c1
+# Tag = 581820f2774ec539
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 8fd95206b34ac713ae730a525020588cc0797dfc1d0e50
+# Tag = 4366d564edf5f10a9e7dd6b7a19893e6
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 0a3541d8492008fa8b4e7b847d6f9dd88c31baf8e95df3
+# Tag = 46129a971085e56b4b0c6049dcc31cbd169f4996153ecf5d
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = 2f4ea9dafc472204ea45af4566aa1f81382244944b6cfa
+# Tag = c93886f11a528f088e203940eb7200258e924eb0845d5de39b91d9f577a82bca
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = ed8070ae2d13cce235e9195f39cad658367994edef0f99827cea1dcc26126e713f709fe6b30e46
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = fa8ba14e87e9a76f281104423b240290ac3db5eb53bed893d13b2dfc79d281b12dbaccb9689c55
+# Tag = 7b1d463602c4f47b
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = cefa642470d48b0bc07ff5d3095d9a02cf69f5cba4456f804d1f26e6cf757b2698349370dffd68
+# Tag = 2b155898f7f6cac331a7a4434305456e
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 6f83aa1e58b5904051262ae78868cd4b950fb179c34b8d15dd75b27a633fd5b828226f20e69f3e
+# Tag = f8e640ea6b2ff5c605bbda8e1d92d81ee56f90d79cefadae
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = f17bf45efa7c8104a51d3b32f1bf89477baec26bcae6efebd90bc06a96a79dcb0b5b16989d182f
+# Tag = db91d29cea7dc3049a0e324c31d6d1a391b5e6c97043521c9c8bd2f02ab4961e
+#
+# AAD = 009122b344d5
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 08992abb4cdd
+# Plaintext =
+# Ciphertext =
+# Tag = 9c2bfea21d84095d
+#
+# AAD = 10a132c354e5
+# Plaintext =
+# Ciphertext =
+# Tag = 3654a996b299267bdef2ee6365fb8458
+#
+# AAD = 18a93acb5ced
+# Plaintext =
+# Ciphertext =
+# Tag = 52c8fcdf77acaeed1346d2fc75a31237af581a0ad1839f15
+#
+# AAD = 20b142d364f5
+# Plaintext =
+# Ciphertext =
+# Tag = 308a18912768ad5a02cf30edcdfc5f1c1a1c444a47db7165246192ad1854ac01
+#
+# AAD = 10a132c354e5
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+# Ciphertext = 8bc00291fa7b0585282241056af9b07f
+# Tag =
+#
+# AAD = 18a93acb5ced
+# Plaintext = 73941435b5d65677f71898b9395adafb
+# Ciphertext = a0c0e8d2f58b582b167a00782137fe3d
+# Tag = 7f5dd38259fcdbba
+#
+# AAD = 20b142d364f5
+# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+# Ciphertext = 0b9698e76fc95e74c17875278ab6bbdb
+# Tag = 122bcd16c6e8d5cc7b7395eea6cd3863
+#
+# AAD = 28b94adb6cfd
+# Plaintext = 83a42445c5e666870728a8c9496aea0b
+# Ciphertext = dbd205ba35225a79ff1cf5b67c95ecbd
+# Tag = 4f121807e73fec40c80190d54a44b8f2b3ccf3712ad0b846
+#
+# AAD = 30c152e37405
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+# Ciphertext = 24324cb20f33a884205be98266c73bea
+# Tag = e8851d955d79962e52405269c41274b1b6e9f436e2029cd63df0a0de12e8c486
+#
+# AAD = 28b94adb6cfd
+# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+# Ciphertext = 94cafb7bece73507f3d4651e3e38a44861a71919c2c9a40da6b7d6e81ae3f5cfb8d0c9f4ba6c8609
+# Tag =
+#
+# AAD = 30c152e37405
+# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+# Ciphertext = 1a787ec69cf48434a1a9ddaea5b2ff13115e7c587756b3146f79a90b90a225a122ee46822de04339
+# Tag = e2756cfd5e2d3543
+#
+# AAD = 38c95aeb7c0d
+# Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+# Ciphertext = 1ed653991d96a33aa66dc9021dc8c91507c505caef2322b241387ca20d7008ab517fe0c96c76559d
+# Tag = ca0c357a43f49f58b98ad6538e818375
+#
+# AAD = 40d162f38415
+# Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+# Ciphertext = febf40050e7d6b2750f9cf6346a8196580f16ebe72c0b2cd7f8b76755036aaa5c478a935f7282f44
+# Tag = 0ea19e4e7c3158cd617d6e5e58ee0684867dc50f4f65ab19
+#
+# AAD = 48d96afb8c1d
+# Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+# Ciphertext = 60a27e48774bd7944d283f375e703803ab90aaa49206248109327b50f52239061b4eabd1a5f45429
+# Tag = 35a9626b6c5ab890a6f1ddb51fabce072284177485bb6c4396c22c16651b5eaa
+#
+# AAD = 10a132c354e576079829ba4bdc6d
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 18a93acb5ced7e0fa031c253e475
+# Plaintext =
+# Ciphertext =
+# Tag = 37ce2a4766d4f600
+#
+# AAD = 20b142d364f58617a839ca5bec7d
+# Plaintext =
+# Ciphertext =
+# Tag = f911b2515fd2b355baefbbb6bafe380e
+#
+# AAD = 28b94adb6cfd8e1fb041d263f485
+# Plaintext =
+# Ciphertext =
+# Tag = f4676e080c21abaebb9f41058f92ad646858d805ad10e5c2
+#
+# AAD = 30c152e374059627b849da6bfc8d
+# Plaintext =
+# Ciphertext =
+# Tag = e3c152adc177ffc95a1a8a1b0480189bdfe67cbc6eadb2694a7d5f420db83868
+#
+# AAD = 28b94adb6cfd8e1fb041d263f485
+# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+# Ciphertext = b19dc93693416101902ce076b7e91627c9b4e902828f6369
+# Tag =
+#
+# AAD = 30c152e374059627b849da6bfc8d
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+# Ciphertext = f388ed4470a0ce45d1442bb9667b48c0b1ef1695c4809491
+# Tag = bd781d2b3d2bf51d
+#
+# AAD = 38c95aeb7c0d9e2fc051e2730495
+# Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+# Ciphertext = 64888c085894b42bd22bf1b0ebf00f1630b9a37d3011edef
+# Tag = b91b97c8d8db75d73a7b32d424574547
+#
+# AAD = 40d162f38415a637c859ea7b0c9d
+# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+# Ciphertext = 39ecd0e89eee9ad862263ca0d1b7476068d1be0fcdf5721d
+# Tag = 6180425ec307fbbaaaf882972571a09855dea06cd5ca3402
+#
+# AAD = 48d96afb8c1dae3fd061f28314a5
+# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+# Ciphertext = b1074a6c95232cf26cb192867e473cb757cbbe9e659ab3f5
+# Tag = 1cf6d4e8e888c69d1c4bb987bccda34aadd3c3076c1872f686a5bd12ca6b3c65
+#
+# AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+# Plaintext =
+# Ciphertext =
+# Tag = aebd9cf884f74757
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+# Plaintext =
+# Ciphertext =
+# Tag = 0d962653b4ae7abe67b1107d02ec4262
+#
+# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+# Plaintext =
+# Ciphertext =
+# Tag = ec26c17d22565218fc93518ad3162d8a40686674fd7f3296
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+# Plaintext =
+# Ciphertext =
+# Tag = 60c4b9e709b8bdbb5f40e11e65876c248962685b5e1f447dc331a1e22cbea2c6
+#
+# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+# Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+# Ciphertext = 0bbfcb099e0b51c45bd8cef5ac667f869a9ab37bb5806941c34d4835913babdfd1be
+# Tag =
+#
+# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+# Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+# Ciphertext = f9fc9fd9994c2c07450d234b702c94760e478db02daefa6da971a58ba80e27ec1332
+# Tag = f717e153396f6d35
+#
+# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+# Ciphertext = aca9ab8ffc23e0fc59f2b3b3c56a12237319595006c23e2339c8a28c1eac1d668682
+# Tag = 33106fccbe6dabfe1c404decafb70163
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+# Ciphertext = f230fab4b5caea8b23aafe2c0bddb834315cf19425769da3561ea428b96971f14e24
+# Tag = 4529511b9a0f1e1d563cf098e518b074284cba7cfa697a46
+#
+# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+# Ciphertext = b0f27308679344eddd009ee7a34797266d24654b5f0256c0241e5df2943d56037ac7
+# Tag = 73a222bd7571c507fc9d57b8bd467d4838ab600a587a2801aa8f09b27d4871d4
+#
+# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+# Plaintext =
+# Ciphertext =
+# Tag = eff98cee9f0d33b6
+#
+# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+# Plaintext =
+# Ciphertext =
+# Tag = 1677f99114a5b2512c07f2b3630c0cc5
+#
+# AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+# Plaintext =
+# Ciphertext =
+# Tag = 24708526b7fc02a0e9d860317c619983151f11d5445ecacb
+#
+# AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+# Plaintext =
+# Ciphertext =
+# Tag = d58de5c577649c65cc5e70910be8102223e0fab6b45294d242c2cdad1b4ababc
+#
+# AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+# Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+# Ciphertext = e0750abe2ca1a6916bfcff289a5fafab3b5ca7ff1a0af7c610755a035100ecdf056c6f1ed7e575a7aa51522e1cfb4711
+# Tag =
+#
+# AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+# Ciphertext = 5e468462de8df190a0ae118794cd5b5060691fbf6c72e6c43d19681a4dd8ee6dc5c12ab761115491f98b4da40480c746
+# Tag = 5e6f0c7569da4969
+#
+# AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+# Ciphertext = 96fcd6af42e60464054efbfd398f4167c63258c7557ae4e1867ab49ebea19ac258eaf6e364942b7fb3d644868e65799b
+# Tag = 48d02a5fa9eee22b2ca24cc058002552
+#
+# AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+# Ciphertext = ce9e3b8a23271c857e0c83b70419a3f3857fe5cd9281ba5b66533fd7029d7e1903517c48b71fa8a21e4dc00e76968a0f
+# Tag = a03f35ab5b3cc1e4eef8cf7f3417f840215caaab795d46fa
+#
+# AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+# Ciphertext = 60e96cc6d9316a0aefdf3b78e9a5dd40930e7a1b3c185339b1270fa0ed79e8c31d809b6742b4505a038783977a763465
+# Tag = 96bb15d078716eb3825fc993f9a0550236a23363a04852f5c71fcf73db02ce4f
+#
+# # initialize with key of 128 bits, nonce of 384 bits:
+# Key = 62fb942dc65ff8912ac35cf58e27c059
+# Nonce = 93f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b51677
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 571313513bd4262c
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = de6083c874a85dd899452412fdaf07fd
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = e5b166a31961513a09fc22fc129bbb1000126ba9f40df139
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = b6c882262055a78a773bb4b6c313381d32f3566ebe736ddee9b1f4f6e7c16fb2
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 5dce2896a0
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = f8646ef4c4
+# Tag = 197acc5cae6bf7c0
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 208b24a97c
+# Tag = c283bbb8d77b14f25e36235f860dabea
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 383068884c
+# Tag = ce9bf97b3c22ce2e8e9c4f9a17bf91e393e480a7de25098a
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 8cd6fa0a49
+# Tag = ac6df31c36a94d784d50331e3923e1000907e5d1f3a228215c7262de3b0941fc
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 8d443fa2b4320b6a44549806
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = f51d37020cc24e65c2376d1a
+# Tag = 93de418245e33671
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = cbcba4f882709cee93e9f37f
+# Tag = d852dc36025e92ba08d90d9c8025d9fe
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 168e8f47f2e209a2b35f2d59
+# Tag = b1b4ae787512ee83ee240120ced75a265bb06e81f1e07849
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 2dbf65e63e9065e35777aeb1
+# Tag = 9f2a94d42f1b274904e44a3749dbd7159ffa5321a6de03a44c50cd81cedcf2ae
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 6c6f2c5e1a4f580d0cf864c5ecbd0dcf37cda8dc3e2aca
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 3844c4fd2f14c1d9697411097d3742b8f82f17e9d2dada
+# Tag = 18f33fe8e1c28393
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 3202c93475c720f5e55e565a60fdb5c8c45694f8b99fe4
+# Tag = 73215e3aade83c700ddb16c8abd43c65
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 6a254459419e8151227829772fe3af83634df20f6df4d1
+# Tag = 4c0a7aacdf0d52138449ccfd600416e03b73aec612f5ddda
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = 131c3a5c1707d2a4917fc8b23e8095129d7529c6f97340
+# Tag = 7e1f74c26479cb2165aebea892f90d8bfeb34e318d0e18f8dbb9d3a045b6cc37
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 6effde99cef27db4b0e61974f02fd4f6da8fb32186b031a6d7240c44dc28a889aeacd06218e5b3
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 0c2fbfe9e3a9843266ec035fa18b8c47d8deb200aaf79ea929035339c13ef43a583bfbfced0bcf
+# Tag = 60fbda8ba378104b
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = f9adeaba73e9f078ba884ce0addd2810de4cb1f382bb10d9258297410534c4334200d5ed0095b5
+# Tag = 7f2b6be7fc815aa25917fef343f4adf7
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 6748e417c5442bdda9f7222a863284787123e49215d4c6fcffe7e5bb4915a19767ff267acd13a3
+# Tag = c7a083621308bc8bd5913446de4b96a07f653130740eafdb
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 35f7b6ce274f780cdf1cb98f2f89aeabd18dc17b5a2edc27505e45895789c2643fa29cdab46127
+# Tag = f50073c04086248f0dce842ec7dbd2a9da2abf037210c32d49cc06b193b9757f
+#
+# AAD = 009122b344d5
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 08992abb4cdd
+# Plaintext =
+# Ciphertext =
+# Tag = f5e4675a3f53158d
+#
+# AAD = 10a132c354e5
+# Plaintext =
+# Ciphertext =
+# Tag = c38f82e37699c876e17fefa7f787bd2e
+#
+# AAD = 18a93acb5ced
+# Plaintext =
+# Ciphertext =
+# Tag = 064d9b4fac9682792fd36cc0174a0aae72a86921d7a22877
+#
+# AAD = 20b142d364f5
+# Plaintext =
+# Ciphertext =
+# Tag = 53e0bea2ba4a71b762e03121160912353e81c0d975fc300771d960897f1f32af
+#
+# AAD = 10a132c354e5
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+# Ciphertext = ac5adb532f7d9e16772cdddd58e1fd45
+# Tag =
+#
+# AAD = 18a93acb5ced
+# Plaintext = 73941435b5d65677f71898b9395adafb
+# Ciphertext = ffb12ceb64e0ced771fd03ee31cc2554
+# Tag = f5ce95f53ce55519
+#
+# AAD = 20b142d364f5
+# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+# Ciphertext = 17b0678aabb70d6bad68db105a3d3f5d
+# Tag = 4a2b60cfa63794771f4ad7a0cb0792f5
+#
+# AAD = 28b94adb6cfd
+# Plaintext = 83a42445c5e666870728a8c9496aea0b
+# Ciphertext = f5c779f93a1799c7cc4d7ee5cefaf07d
+# Tag = c95c2e0fb4d7d13eb61f3b075194e5c4485d2d399bc45db1
+#
+# AAD = 30c152e37405
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+# Ciphertext = 80beb3540e10b10e13d53ea9ac4b2a53
+# Tag = 76edb785ec99c8f9116cdeac1bdef646cfddba96d88e64c84599785b00af49cf
+#
+# AAD = 28b94adb6cfd
+# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+# Ciphertext = caa8307da38712ba141b0aa3fa61b496b4b81cb5fa966b33e7d7725fb58160e3069b010af355c8c7
+# Tag =
+#
+# AAD = 30c152e37405
+# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+# Ciphertext = ea224ec7bac4f317bfdf5a728e3fbf68cfc71005e649ccadfa0b4614ec19880f30fad129a910389a
+# Tag = 2a70c062a8a80c14
+#
+# AAD = 38c95aeb7c0d
+# Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+# Ciphertext = a15f68ed18b5a313b299f763a2b0fb6bc55b43ed3a61731f6ff9756e6096995604b54b2e5f43e7e8
+# Tag = 06e3984d53e8588daaf211f5d918662f
+#
+# AAD = 40d162f38415
+# Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+# Ciphertext = 45807d264008a91cfeda84d58ddc562c17151b80f57d8f8c78ecdaebccf6535e731eb8c6c9b37ef6
+# Tag = 2f2c98d89caf21b014800841d0bfdfe1f6f458d1ace3b94c
+#
+# AAD = 48d96afb8c1d
+# Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+# Ciphertext = 8e6367b8e319f5304c3cb8551c472016a3800f42384c336f9b21ef454938be8183b736006b922f19
+# Tag = ae42584e785e9904e4032103dd6d01873f59ff7c878b6096f89518a5e93776e8
+#
+# AAD = 10a132c354e576079829ba4bdc6d
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 18a93acb5ced7e0fa031c253e475
+# Plaintext =
+# Ciphertext =
+# Tag = 4fc8d21cdb08e4b1
+#
+# AAD = 20b142d364f58617a839ca5bec7d
+# Plaintext =
+# Ciphertext =
+# Tag = 966792d102b8c89b4381d07c570efdaf
+#
+# AAD = 28b94adb6cfd8e1fb041d263f485
+# Plaintext =
+# Ciphertext =
+# Tag = 7277214a93d5b83f2349388aa8220b10d520d07f83adc041
+#
+# AAD = 30c152e374059627b849da6bfc8d
+# Plaintext =
+# Ciphertext =
+# Tag = bc820ae6ad83cbcdd2b13232b5641c06483c27cdf8cdc2cce5555717f3f7c84d
+#
+# AAD = 28b94adb6cfd8e1fb041d263f485
+# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+# Ciphertext = a10667884bd3d1d47cdae7ca2ff2ac8fbcd24ed2522dac87
+# Tag =
+#
+# AAD = 30c152e374059627b849da6bfc8d
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+# Ciphertext = dc17b6e4d5bc1632999e960ac529259499c8553c4b9951c5
+# Tag = 98df3eed14cc7ce6
+#
+# AAD = 38c95aeb7c0d9e2fc051e2730495
+# Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+# Ciphertext = eb745c48e9c4a6fc0fea561dc411c3ddc6a868f23d3dea08
+# Tag = 200eee9cfca4ad4783dbfcb0bc724cc5
+#
+# AAD = 40d162f38415a637c859ea7b0c9d
+# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+# Ciphertext = a5840630e35bcefac8c47c7e7fab453dc973534d18007726
+# Tag = 36d70c77add47fc614a1883581d6df8267d16ae3e4006827
+#
+# AAD = 48d96afb8c1dae3fd061f28314a5
+# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+# Ciphertext = e1648e6c2c3e1433fbef56276ab22f99e79110dc386e1f17
+# Tag = ca9b407a3d0c64f5c76a239be3c71305548cea53360bc118b6fb726b6e43303e
+#
+# AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+# Plaintext =
+# Ciphertext =
+# Tag = e05105d4024e23e2
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+# Plaintext =
+# Ciphertext =
+# Tag = e499e7abe08cf101aec2191652a86d44
+#
+# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+# Plaintext =
+# Ciphertext =
+# Tag = 25fa5d8c08d2d10e3076183add992efae277260fdfe258d9
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+# Plaintext =
+# Ciphertext =
+# Tag = 4f2418966f2b7a018485e06fc68a5973708759a3876969daf577fab7310e0bb3
+#
+# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+# Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+# Ciphertext = 47744da4149b82b28045c3badf3b78e4b0f758efa8ee9fb158263c17a216cad89e9c
+# Tag =
+#
+# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+# Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+# Ciphertext = 648598f0e8a4832526b12d039729945fd90fb7e04af9d257977c7cf659cc66caf159
+# Tag = 572aaab24f5d697b
+#
+# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+# Ciphertext = e0fd6e8dd069f90ced363ac631f74c6376475c205531c7c6b93548692d5eb305c003
+# Tag = 341acdc2245ed5a48a39376e1d1797a1
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+# Ciphertext = 72ead0d8e021004086e3a7081afa467bdd5c15899ec8e8fa1c52050082460e405355
+# Tag = 8174a3d3a31572ac292fc0e6834537ef55286d3b6b20fa0a
+#
+# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+# Ciphertext = fff4b85e7c94e8820122010e33f054638b9c43176df032b04bdaa580b44c3174a77d
+# Tag = 25074507d30bdce23686d795eaeb4a0598e616d71a9a7ad1264f46654d7743e6
+#
+# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+# Plaintext =
+# Ciphertext =
+# Tag = 0c9e39aec40f615a
+#
+# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+# Plaintext =
+# Ciphertext =
+# Tag = 5ff55d0b20d2ac202a497122e618f6e2
+#
+# AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+# Plaintext =
+# Ciphertext =
+# Tag = 16c9640f019e79c303ff6b4315ef792a39d6692ded4eba63
+#
+# AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+# Plaintext =
+# Ciphertext =
+# Tag = e2219b9966890eeb6b9681a5e249a84b7adcb1911e985770ce67c2e3cadabb59
+#
+# AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+# Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+# Ciphertext = 1098281fb1e09cc24f4447c94f6e252f658779e1349b5dbb3a5fde9d02c4534aa92fd057ecf17d89c7340d32eaf63870
+# Tag =
+#
+# AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+# Ciphertext = 59e77313463c9e9a01eb729515a1317a1203aa4c31aaa4aa6d62df3636e03a895675ebdd151365ce5987a64012e600a6
+# Tag = aede2eec0b2b61ba
+#
+# AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+# Ciphertext = 6f38f841f42bd75936e44213eaad82f0b4bb6d4321ce21bf04ccaba7edf7fe73167bd34408ad5bf007f520677e6ec487
+# Tag = 18642b8b7282a97e5d19accd18ec5b35
+#
+# AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+# Ciphertext = d139bbc47afb30f6a548d853dcdc104c6eb17f8774d2a283fd4ac42aa421e3d6bf603e7cfeb0ffa3f496a386dca9edd3
+# Tag = 43ab79ce624a79978d4052b61e409bbbc0243d07567dec21
+#
+# AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+# Ciphertext = 0c7e8cea9fa41ae007a889bb894075d70c3c37862b1ee12c0879ad23163d8c7d593b33892d88c2d445238df1309d5268
+# Tag = b86d266de6fd520d575a0907d2e80803d89979f9f34ac6538216ee828e24e8f4
+#
+# # initialize with key of 128 bits, nonce of 448 bits:
+# Key = 6a039c35ce67009932cb64fd962fc861
+# Nonce = a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 08ff1d91194dc1aa
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 0224ef0d359339fb1fed06779ba113b6
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = a6f5141f46eb2e763641af3ff2aa7a0d3a3c164b5d1e714e
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = aa51299dc97d4732a453488e9fc78a0c6a4b1d5cfe2b14c997ca743529d7045b
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 27534e46f6
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = f2ca63474b
+# Tag = 1f1504028eaf581f
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 10fb31de68
+# Tag = 9e074c80f64633dd2ce07bc9997269eb
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 0d681ff46e
+# Tag = a1f2366973045d7403ce9719a6391d2ef095673a2badd664
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 84abff25aa
+# Tag = 07bb8752dcfba3a846706cfdc84f794a2f5e0e33a369c61e2f82c7e1e9a40bcd
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 3ea90051c693049dcb87b9a6
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 8ad2cb42984c740079859cc4
+# Tag = 36bd6e615cf481b7
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 38319286958daf0c360de893
+# Tag = e1db2cdfc4a9d04cd2ae6d2aa0d7b41c
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 653cde5fc6d52cf264b0f406
+# Tag = 3e070ba358bdf0c25eac3b31b23c7730efdb272c032eceaf
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 20a5850a9254d6d5aff1e67a
+# Tag = dd522ba2a154f282eaa7c2bca4aa674c07ce207e5aea83da069c1100c4eab2a1
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 483819fd19e5908846944acb1e8f72c8956b05b7abf712
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 28ea1bb87d7f1cccaa333534799b8cd495c76471c19821
+# Tag = c2e4a346445b54a7
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 9a37b61b7972d0ab9eb3a7703451d416556c2b21955418
+# Tag = ece568fff70ddb4ba42eb1d56c1d37db
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 24e2282581d1a1c7338fe4621fba695b12eaf079bc77ea
+# Tag = 9446780c6a1c883b1524a1afe1a1cacb59ce458787e7451d
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = 66cb522b7300c48bf931dc3825276e974a78ca5d4bb16e
+# Tag = 70521fe6d4b5ff2166a2f0c4284241064e8d00c8004497eb23ea7734c86c72e3
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = b39b26aeeb5673b4af24ef5f72f2bea17c800a71fcc829e55eb66946e8ac9481054961570ed11e
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = b3121c219f99e949a0c87395adfd764844e6d2238a621ce13f094199c4e9133dd9bed2045c1edc
+# Tag = feefaa4150a4992c
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = a87c98f3ac6d1daf2b559afb9a31c96a40a320d1a374ca25b9d545eff1bf30483d217538300d33
+# Tag = 13fc58be1601e606c6cb1b95b3880889
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 374ba9f85d34673494f466946edf93917234f0d735b4639c197aaa22f57a15c607c9056a5bce49
+# Tag = a979ba8763533c4bde1f9d049c8f912186d8ea6ae00b9d70
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 224a5ea3ec73c7c7e5e11ce3e18d1c4a3a1a0597702d4c8541b17ab2c637e465ae5b19c5a507af
+# Tag = 51009753c2a4056b18041394a9cbd0a5d8b7518aafc95dd1a117a0ee7e149752
+#
+# AAD = 009122b344d5
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 08992abb4cdd
+# Plaintext =
+# Ciphertext =
+# Tag = 0df8274329fc945e
+#
+# AAD = 10a132c354e5
+# Plaintext =
+# Ciphertext =
+# Tag = dc73120d7c16da28dd2faab3f0e77c73
+#
+# AAD = 18a93acb5ced
+# Plaintext =
+# Ciphertext =
+# Tag = 06ce8b91a772d578f542dd5b530feb22bd037d6a9495fa4a
+#
+# AAD = 20b142d364f5
+# Plaintext =
+# Ciphertext =
+# Tag = f974bfcb95d2cf46cd039c04a3156c67ec8c058830431c3784ec8ca533297ad6
+#
+# AAD = 10a132c354e5
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+# Ciphertext = e19ffcd638c13b4f47af0e1f6390d8b2
+# Tag =
+#
+# AAD = 18a93acb5ced
+# Plaintext = 73941435b5d65677f71898b9395adafb
+# Ciphertext = eeda1fad83277f6b85eb66dbd33adb7c
+# Tag = c8dcc191800e030c
+#
+# AAD = 20b142d364f5
+# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+# Ciphertext = 5872063c27a26d3fcd5f48026e538343
+# Tag = f48dd313ab28904c4bd64a09d90e02e4
+#
+# AAD = 28b94adb6cfd
+# Plaintext = 83a42445c5e666870728a8c9496aea0b
+# Ciphertext = f22c4d27a51c962375ad663eb5525031
+# Tag = 8423df7eb27720b65b8fba738fc89c5f54d55da8ca934bfe
+#
+# AAD = 30c152e37405
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+# Ciphertext = a3a1c9939e78e3bb8e9522bdf6959bbe
+# Tag = d043a566676630809387549785b9a65045eda6699349d331a993e02e7a596bfd
+#
+# AAD = 28b94adb6cfd
+# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+# Ciphertext = f18aed0d42dfad971fc221e0c84983777a95225086e754894b6a3434273c92fb9e35da5318fd3439
+# Tag =
+#
+# AAD = 30c152e37405
+# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+# Ciphertext = caa99496d713de3bb1373abbd37efc0db62f98f7ecafe7e742cc4099605ede648ed0bdbc58563ef9
+# Tag = 6db9da89f2ec41e5
+#
+# AAD = 38c95aeb7c0d
+# Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+# Ciphertext = 524c8528f8391fcdbb9e94feb2deab3fb99fc53ef822df797f13cb69e7f8b270c634ac0cbf939fc6
+# Tag = a1ae6851f72b33f214d2f8361e892f2a
+#
+# AAD = 40d162f38415
+# Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+# Ciphertext = 4b1c820b219cfbb35ff35ccae0281fc27412bef3bda3cfc2b87e0dfa3029629215a3d002766cfefe
+# Tag = 78615ea4874949cc9fbb4193b9ae5e2ce44ef6c5b6351c54
+#
+# AAD = 48d96afb8c1d
+# Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+# Ciphertext = ece3b6fe1679bf2d962086702ccc22151bcf8392611bb0622be00c8f176ef1fc896f107a6e4bd59b
+# Tag = 05424d1b35d92ede8bc0fdc65a09164e4ba8b0559111a9e89b72c22bb65605c2
+#
+# AAD = 10a132c354e576079829ba4bdc6d
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 18a93acb5ced7e0fa031c253e475
+# Plaintext =
+# Ciphertext =
+# Tag = 82ff7c893f93f13b
+#
+# AAD = 20b142d364f58617a839ca5bec7d
+# Plaintext =
+# Ciphertext =
+# Tag = 5aff6166f4aa2e5558cb9aeac4591a61
+#
+# AAD = 28b94adb6cfd8e1fb041d263f485
+# Plaintext =
+# Ciphertext =
+# Tag = 83297838074ee2e658b33a2688f64b63e1b04815871fe941
+#
+# AAD = 30c152e374059627b849da6bfc8d
+# Plaintext =
+# Ciphertext =
+# Tag = 69825e54860fd0ea22f9b4a28df2551fb423f1d457d1ce2e3408bf687ea45e5b
+#
+# AAD = 28b94adb6cfd8e1fb041d263f485
+# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+# Ciphertext = f53b878d1e248903ca1ce24bc54f5455c15fdbb547a2adf9
+# Tag =
+#
+# AAD = 30c152e374059627b849da6bfc8d
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+# Ciphertext = 029a7d95e4b793eefc088303414b1181e6a3a4d4b29f03d7
+# Tag = d20a6bf859a1e951
+#
+# AAD = 38c95aeb7c0d9e2fc051e2730495
+# Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+# Ciphertext = 5c0063c79c13896ede0cd4385df5e393ac306cd5689bac4f
+# Tag = 509fbea6351709b879708957fdadf1f7
+#
+# AAD = 40d162f38415a637c859ea7b0c9d
+# Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+# Ciphertext = 8eb882e8e36013d7524b76552db48d6b02d419706e06ce1d
+# Tag = d5c5bc6e39f4ca973877dfb85be6517ed286013fb758abfe
+#
+# AAD = 48d96afb8c1dae3fd061f28314a5
+# Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+# Ciphertext = d0fe9622f6b5d08daa1fb954301273a554f49f475c6ad900
+# Tag = 0b59d2819aa13cd739cfb90e7df2d19fb7b470ff913529f7f78f88022abc6b22
+#
+# AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+# Plaintext =
+# Ciphertext =
+# Tag = ced39c0c97518a24
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+# Plaintext =
+# Ciphertext =
+# Tag = 53112dd7173a81fef5dd09c53010c2cf
+#
+# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+# Plaintext =
+# Ciphertext =
+# Tag = 2f3ece12c744bdb3d2527ec09311661415442165f239850d
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+# Plaintext =
+# Ciphertext =
+# Tag = 0a48f447b84732ae3ef126559bfca5727318c26cca101e2198fc4cebc6dd9ea6
+#
+# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+# Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+# Ciphertext = 8a4588eb33f1b5e9f99bfe3b9b55ac3f3398c4799e5c9e2d03fd1a08a8bc3d5188e3
+# Tag =
+#
+# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+# Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+# Ciphertext = 9c1b357ecf416145d3293f78f5a26e29ab26eb60d0c619f306f7ad67d14577cc3333
+# Tag = 9fd2c538ff1ce98e
+#
+# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+# Ciphertext = 2953c02f6bd50deea3acfa59dc8d00b0f6d8c1de65bdd72546a02f3f435787fa963e
+# Tag = 4f6f31b8362db6e275b7eb8366d38ebd
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+# Ciphertext = 22455e74e0377c242963f1bf2bbdc523ee1ef46ed92a9b45a1f86b10d91f88920201
+# Tag = 595b02ce805297131bd60a439aeea89413226131533aeed4
+#
+# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+# Ciphertext = ce1d230b9c7f4f870aeea3e5edec0f998cda5ac8e59898f04316476d2b26595f0c2d
+# Tag = 0f64bd294b056c993da0957b1018446e916e7577f97829af8430208fbe72e984
+#
+# AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+# Plaintext =
+# Ciphertext =
+# Tag = 7b09a5db16efffa1
+#
+# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+# Plaintext =
+# Ciphertext =
+# Tag = c6f4ba4a5a38ca38424241819c6ffaa4
+#
+# AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+# Plaintext =
+# Ciphertext =
+# Tag = 9494000b2b5e97d5e2299b2efda0362aad491a483f4e5255
+#
+# AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+# Plaintext =
+# Ciphertext =
+# Tag = 78dc81a30bcd126a126f1e6f118856023227931b3218967e2dbd9b2623ff046b
+#
+# AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+# Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+# Ciphertext = 1c622ba6ea9a64464a75f7899f938a44c40fb0c2056e0d822c24937bbe48c24ab7895e921a57d93bc10da14153bc3f15
+# Tag =
+#
+# AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+# Ciphertext = 27c9fec932e0735e9142c61edc741b8b8fe5f390d63e87da5be551d5a2253a08eab15cd843cbbb8e5ecb56e555d45b10
+# Tag = 6f6b8f5cdd53a107
+#
+# AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+# Ciphertext = c7c55742545fc75abed2e82464b9f1aa025c52ef9dc93b455da4863b443c20dd7618b11850f315faf0a6c05d145e0ff4
+# Tag = 7dd3e4c1c3450b49756230e3a5bef7d6
+#
+# AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+# Ciphertext = 2e48f1d4d2cb82548ff0d9f84d5fe8d07d0ac7dbc436d6cf7bb83f912cea633a5ff2f7d5cc311b5ac3dea476bc85c81b
+# Tag = c2fd550cb3a886dfcd13a30db9902bc3c2d238e5922ebaa9
+#
+# AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+# Ciphertext = cb7db9cc0ae4dfe2058050305d3afd9d57bc9fc4941dee17be60473012fcf00529754f4399fea0a1fa6f79664d1f1729
+# Tag = 21f163383b986f2e82192aedeb15f1d3c40f658860d78452c481339fa94530f2
+#
+# # initialize with key of 128 bits, nonce of 512 bits:
+# Key = 720ba43dd66f08a13ad36c059e37d069
+# Nonce = b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 905046161006f352
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = fca34b92a4c445d526e0574993ad70d7
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = c5f94db645ce0fb0ca9fe486cf3644b5c228e007e93ba56e
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 2ebd7f041980350cae468d65a6d35723bdaf91a1248bfad8651335c15eb19b33
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 49bbc22b69
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 772cce6b53
+# Tag = 84d06d6439824c4a
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = f21cb71622
+# Tag = 85a06b965e29c6498c3e3650c12e8570
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 91ffcba7c0
+# Tag = 22333b5cc88b9360e7c15bcef994c3a8d543fbaec2e0ed88
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 96de28a8fd
+# Tag = 8d4f91f34590e05e53594ee0631853cf02b6f7c927bede68d71f84d9e9c88ce3
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 6ef5d1ef7fee39fde0f04114
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 45dc364bf86f640f8e124136
+# Tag = a467b3e43a7dec9c
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 0bc3417ff2ebf75b8d124595
+# Tag = 51b040a36a78cfce302b9605365ea0bc
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 4ba955721cc2b536768ad63b
+# Tag = 5099c8e0126008480c16ee132d69a354805116955b385b0b
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 5dc0dd591ef4f61f27d7bc62
+# Tag = 0fbe83ba59db64ac65523b52b1307987d9451385f1e5a047835e1c70f35b47ca
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 33aa70ce5daac7bae38797406fa2d7eedb690154d5ad74
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 6cc291ea01afe9bb00aa5567cc10f9805f080d81e4676f
+# Tag = d00063a42b2e5bf6
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 1a093e725c45e4d5cd99e84286225d0d6f3d9e698fa598
+# Tag = 80b057c5de064041ae3ca0a73ee3741b
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 5ab6e11cfa3da31dede2027affe7684a72248407d687f9
+# Tag = 4bdc2bb651cb7c6f5edb4c3993cd8f5eb5602890fd3a5f6f
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = d28b4e37588fd6438631eb365d96fa7a414c614ff06582
+# Tag = 3e34d50cd166138f1587e17913f0b871207e42dcc0647702b7fb2be14d493500
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 7554dc82810e872ead74e663b8b57c1e1162393abd68cb47415dc411426ad0c807131f4f5affa3
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 106360255bd91d2ee690d9c00dfa051914869c84ec3e3dd19e9bed820148cb00f40a1c807575c3
+# Tag = 0ffa80e6c2328d0d
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = 2b64c4320865bbad01d876da3389e6f17fcb46110f135a10bcd0ceb02340518dab5c4fa2e64202
+# Tag = e3ffa809f90675c61e8a0073322180b3
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 1a008e963a02a8effd5c304e12abc094c569cee490540b8efa4015fb6c9d870220559f49160b16
+# Tag = 5c444c6f8884872d920bdf9551cc7f9ce084a155840786d2
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = fed1ce12b252b5042e7eacd9b0ac74642374087ad6fa19e026d6fe6f22ad3f52ddaeb17be9eda8
+# Tag = f338b20b8d2586b40dab687a83053c766a876bebbcba65074c80ffef818ab9fb
+#
+# AAD = a233c455e67708
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = aa3bcc5dee7f10
+# Plaintext =
+# Ciphertext =
+# Tag = c1d31635c4f98113
+#
+# AAD = b243d465f68718
+# Plaintext =
+# Ciphertext =
+# Tag = db2b7a97acd4513dafa3434b5e759ba9
+#
+# AAD = ba4bdc6dfe8f20
+# Plaintext =
+# Ciphertext =
+# Tag = b1cd6a550efde4066a4877da8f0c3e950a2e15c747bc07e9
+#
+# AAD = c253e475069728
+# Plaintext =
+# Ciphertext =
+# Tag = 47a6c74a97e72e8c6775ed88afbcbca54dc9e5ac23a562c550b173306edc8ae3
+#
+# AAD = b445d667f8891a
+# Plaintext = b0d15172f21393b43455d5f676971738b8d9
+# Ciphertext = a8d439334057340f76972eb975f013949f72
+# Tag =
+#
+# AAD = bc4dde6f009122
+# Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+# Ciphertext = 599ad42db14944a04f4b895c324a8f29fe2d
+# Tag = ec2f1668abb8fe38
+#
+# AAD = c455e67708992a
+# Plaintext = c0e161820223a3c44465e50686a72748c8e9
+# Ciphertext = 7f1bb2a3aa0800a700b228d8cad2bc0bae5c
+# Tag = 3db8abe18ef4c9f787878b2d3bce67d1
+#
+# AAD = cc5dee7f10a132
+# Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+# Ciphertext = 445688f97ffa18f9c81036ea7f615bc356e4
+# Tag = d45a9fc385458dabed21708d3860e623f4974c16830cdc13
+#
+# AAD = d465f68718a93a
+# Plaintext = d0f171921233b3d45475f51696b73758d8f9
+# Ciphertext = 4233e0023acb329c5deac2e94296f2917c5c
+# Tag = d3ce972af1b3b32fb6942be3d53af68f8452be5c7bb4805ae81dc65cbceef150
+#
+# AAD = cf60f18213a435
+# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+# Ciphertext = 88796533cfb16053184ba07f938881f8de5b950198aa998c442d8e26ca784d9513aa12d1c5c2c4b49e4c9bc33d
+# Tag =
+#
+# AAD = d768f98a1bac3d
+# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+# Ciphertext = a4d2441687115184d16145dcf1d94628ca3658b092f0db4e8b271e88e96b9b3206edd357292a2043e3e504e355
+# Tag = 7652dedded3ff10c
+#
+# AAD = df70019223b445
+# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+# Ciphertext = 9c8b1e71d5a7554a530d76abed2ec5436133218a8221ee60a069fef9dfac4837f404fc1f1159417889cb3dc437
+# Tag = ca68b24cae556ff70f57f0e9d1aa53d5
+#
+# AAD = e778099a2bbc4d
+# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+# Ciphertext = 1472188ebab2d275f5ac05c4c32fa5a0138234f89b431c6ec162c9002e39c4964a16df7ae56a0ba82d93cb9884
+# Tag = c8a6067affe7bd12bdd519a5e9800f0082425e5dad11997a
+#
+# AAD = ef8011a233c455
+# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+# Ciphertext = ea140108fe42bf79cbc9fc64ff368cbba04cb8086ed7749cc192e294f1acd893b6057bbf61b5e5a0af3b3113c4
+# Tag = 9b87e885eee374166d34dab4efb0752dc36aeef25e6f55f3256c6a1ccfca0c33
+#
+# AAD = 54e576079829ba4bdc6dfe8f20b142d3
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 5ced7e0fa031c253e475069728b94adb
+# Plaintext =
+# Ciphertext =
+# Tag = 78e185a427aa5c4b
+#
+# AAD = 64f58617a839ca5bec7d0e9f30c152e3
+# Plaintext =
+# Ciphertext =
+# Tag = d97d28d5480f8517d2ca8231c272d30b
+#
+# AAD = 6cfd8e1fb041d263f48516a738c95aeb
+# Plaintext =
+# Ciphertext =
+# Tag = ef3d2178003bd945296db5373c97d2d4f5d3e791f9938d61
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3
+# Plaintext =
+# Ciphertext =
+# Tag = c2109612c8f59cde3efec1ee35e838451442227db9987b8b3490336cc2d38ae0
+#
+# AAD = 6f009122b344d566f78819aa3bcc5dee
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+# Ciphertext = ba4b172d283be1dc213a677fd3cef7cf037da33602976431afab98
+# Tag =
+#
+# AAD = 7708992abb4cdd6eff9021b243d465f6
+# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+# Ciphertext = 32cacbba8fe93c876e246ef2c77b3c170cef0cacd1fd34a9c0e109
+# Tag = a8a97bf98213581a
+#
+# AAD = 7f10a132c354e576079829ba4bdc6dfe
+# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+# Ciphertext = 9bda8fbe8b655b532324f2af5639a4da595aa4b3726d3ddb557ac5
+# Tag = 4a2bdfb3c303134542ec4d3329b60667
+#
+# AAD = 8718a93acb5ced7e0fa031c253e47506
+# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+# Ciphertext = fa8f743130153af92f82ff330202903fc9d3001b25f229accf31dd
+# Tag = e294bd382afc4fc2f7fb5f8dc5454b8ed3161eaf904cf370
+#
+# AAD = 8f20b142d364f58617a839ca5bec7d0e
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+# Ciphertext = a1ef2836a5eceb2a5b3d5f03d0313b31d14154e0642a3e986d7c37
+# Tag = a45d2f551a838ad93eb9f02e99356a9d8ab99123b9506e992ce392b3017ec209
+#
+# AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+# Plaintext =
+# Ciphertext =
+# Tag = 3829f81492e158cd
+#
+# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+# Plaintext =
+# Ciphertext =
+# Tag = edd1afe90988348617acabbcebe995be
+#
+# AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+# Plaintext =
+# Ciphertext =
+# Tag = c6586d0191aba33c64de99c658a481cbaf3be98e72e1327e
+#
+# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+# Plaintext =
+# Ciphertext =
+# Tag = 2f23568e1d513a7de4a7bf63101dcde3ecd84ee49d93740971a5e2b221fabba4
+#
+# AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+# Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+# Ciphertext = db5644acb7482cc41880121bae45fb51b3f2d65f1e1a7ff36c1882be88a5710383addea69e7a9e
+# Tag =
+#
+# AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+# Ciphertext = 8a116781f063ec62de53f2f871db22625e6617ea8e49a2501b3d58f62a26a4616d216cc08f9b6f
+# Tag = 93a65e16230a5fcc
+#
+# AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+# Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+# Ciphertext = 3f4217c53ef9ae72010e5850708c5435f512be53592e2a75ddcb740e13d1f79acab62f61447c39
+# Tag = 7935c9b4b0ce34403ed2b71e68471651
+#
+# AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+# Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+# Ciphertext = 1680c5d1a435ffddbdfee930671c2f4f795e7976b535de762cb9e81837d93fe4a8ff54723aacdb
+# Tag = a7f57679beb465aa7e2664ed1d6121b7de2cbbc04a8a20e4
+#
+# AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+# Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+# Ciphertext = 4d50207e294ecef0e2297d32f1f52cdf51adf242708e102b395566cea5e88d511199570d3d5f21
+# Tag = c2a29af7af5e26e3d5174f3baca706ac52998488eb3686bad515707671e21064
+#
+# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+# Plaintext =
+# Ciphertext =
+# Tag = 7d9f2411cc6470a5
+#
+# AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+# Plaintext =
+# Ciphertext =
+# Tag = 69c595b5161d1c01c429e402cefde72b
+#
+# AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+# Plaintext =
+# Ciphertext =
+# Tag = 8bea3967c172b80269d1a20d1765f68cd2ac0866a4ed5e4f
+#
+# AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+# Plaintext =
+# Ciphertext =
+# Tag = 4b9c3fe2fe4e1da6d7c609c5e5baa0eb17d2fcc2693125518da0673b08433b08
+#
+# # initialize with key of 128 bits, nonce of 576 bits:
+# Key = 7a13ac45de7710a942db740da63fd871
+# Nonce = c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 1d1cc6fd62c7eaed
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 64d9a3b5b3a2c70de7a1be4883eea935
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = ff4d9ffc5134b5312fc6b1ab51d1419498a23ab30e9756d9
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = f87dc6fd2332628c39769f259b597ad74ed7d0063e36dbd180660bd8e07f6b98
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = f88f5730ca
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = e3a7d0398c
+# Tag = cd33c07edb22bfa8
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = ffaa76d3b4
+# Tag = 4e8ed9f8558b1b601875beef864dba5a
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 7b435a8251
+# Tag = fcb8bfa5453300d4e64f1403ddd97be699272fbaf19f881c
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = d57e780867
+# Tag = e73166263e5f9b7c95c3d472e31fd31a6b2ad397e38e68214ef7b4229bd6bd93
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 1f62118cd1e59bdb0c59686a
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 6d7c7eff2ee805f33dd0493a
+# Tag = ed24ef9f792bbd40
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = db1356f596cd85a42daf1ec5
+# Tag = 9679967c6afe6f87bcc0d8e095b2e8a8
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 4e19a5ee9e59b7c5f2a1f968
+# Tag = cf38955f445a63d9694a3c06444f5205982b0ba364dbdf47
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = d71807db6faef5ffedb28c41
+# Tag = 53c1e29d9a503fb3d3f75892995ae059f77d1209b7d0514cad4a8e26f000e408
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 2ef0bd4dc2cf0d921147eab0f7b51a34a6d66637e5c668
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 97597a47a1e842fa9d69f4bbd8bb8712ce39673fd42e0b
+# Tag = ffd26f78fac38d42
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 307bcade071efc9221f2f5912be2b873382889fd6b2567
+# Tag = 69102a8b42571dd546b382571fa084be
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 2f04ad5c3f9f925d81e4c44b2015cd5cf463c385401db0
+# Tag = 3f1967bfccb97415d00d74b8d4db1d0141c66238f4a32b66
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = ba079a481d7eea617df29f9efaaab7a774080f8ec2d193
+# Tag = 2a2410638232cd139fe919e37c9ce64dce266c096dd410be1b61a4de9b7404b6
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 9174cb244933bc2f09c50412b2a6403f572db35457b012e32f858d189d71579e9f14c68dd93eca
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 457d27b7feb85c63d953aafe4a26faac5ed9e02534d91432aec7924b68f9f1406cad86f5a55942
+# Tag = 77d43d83c3cec12a
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = 3b522d5e6e4dbb90eaf76bbd9a6b276743e77cbb38b6d0fe5a2b3d10d91b22d2df5c91fba84fd5
+# Tag = a148fc8faf3a51594872e565c68489ef
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = ea725d8b7958cbfc658158e8ede8535a359607cf79ceebac60701d07a9f37cbad6d8f7bc20c8c9
+# Tag = af0978d87a378b66aef36e3c9f94c326685e07ea759dd3df
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 1e4a9f9b7cc538553bd42dd7042882c7eeff4699507fb14567bfd35018c327f498bbaa27aef99a
+# Tag = 28d977d8654bb12da4d74a6dd4eb8bdb0d3b6d6c8c10ee931e7ff60308b63ad1
+#
+# AAD = a233c455e67708
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = aa3bcc5dee7f10
+# Plaintext =
+# Ciphertext =
+# Tag = f90c87de0d543d40
+#
+# AAD = b243d465f68718
+# Plaintext =
+# Ciphertext =
+# Tag = 17ddd9745b5fd571a81638e582894076
+#
+# AAD = ba4bdc6dfe8f20
+# Plaintext =
+# Ciphertext =
+# Tag = a0c0978081ec69074c9086d3d87640c8a5986d3d27c38ac8
+#
+# AAD = c253e475069728
+# Plaintext =
+# Ciphertext =
+# Tag = c2d42fb8e84f792d874877fb83f5c132be41c3c22205b09100c8108f2e43d343
+#
+# AAD = b445d667f8891a
+# Plaintext = b0d15172f21393b43455d5f676971738b8d9
+# Ciphertext = f80e74e87750e238b94bde879698b2187270
+# Tag =
+#
+# AAD = bc4dde6f009122
+# Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+# Ciphertext = 14ef2cffee0f16f29aac6668815503142001
+# Tag = 9eaf6899776974db
+#
+# AAD = c455e67708992a
+# Plaintext = c0e161820223a3c44465e50686a72748c8e9
+# Ciphertext = bad8ef823b389b44b9c00f7a29adde71bb10
+# Tag = 0fcca02b00a7671b7cb7e215d595af1e
+#
+# AAD = cc5dee7f10a132
+# Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+# Ciphertext = f2eaa464d4f30695c528841c6c9d90beb027
+# Tag = a5b5dc3353b7243a95a80760f67b519c996a2a4f22e04b8c
+#
+# AAD = d465f68718a93a
+# Plaintext = d0f171921233b3d45475f51696b73758d8f9
+# Ciphertext = c2b40b6f60f63091541b3c8d855cac85f684
+# Tag = cb6b8bf587e74dd5354b064b78229a73b09fa6c68c17c4ae6c371239db3b4a72
+#
+# AAD = cf60f18213a435
+# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+# Ciphertext = 34f4510460b498153c453625197c2c6be661a5034ece280d9aa86396c8232c90f96b3ec0a22362e498cdc6fee6
+# Tag =
+#
+# AAD = d768f98a1bac3d
+# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+# Ciphertext = 33a8de7a8986ed342752ce638403fee65e14bdc8f7b9aba78316d4af0c9f571002b5d422db517a0af27431ca33
+# Tag = 07700ed8f4eb9055
+#
+# AAD = df70019223b445
+# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+# Ciphertext = c68524d72f9a6014045b7d7daa72d79b20e1070d0873b124212e2a475d0acfc209c78006814ce10f6ee218d1a5
+# Tag = 76cd628cfce6c2b5fb97205371f61ad3
+#
+# AAD = e778099a2bbc4d
+# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+# Ciphertext = a5b0d7b338682ea60557633c3c13cae60a86fd596043aabbfb14701eb630a7df965fba08cbeda8a549dd4b124e
+# Tag = 867527bc34f52ae0c13ba9a10656cf4cf8c67288c80a8f18
+#
+# AAD = ef8011a233c455
+# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+# Ciphertext = 79d558204fd131936d04e273b9e73c0c9e5b9a972dfe5af25355e3e4ceef5b380a6c98a9764e95264b437f6c7e
+# Tag = 928659327a01f659bfa0261e7d95247b42c2708e6fd838cd1fb8812c7dbb93d1
+#
+# AAD = 54e576079829ba4bdc6dfe8f20b142d3
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 5ced7e0fa031c253e475069728b94adb
+# Plaintext =
+# Ciphertext =
+# Tag = 00a2ebcdfd191fb8
+#
+# AAD = 64f58617a839ca5bec7d0e9f30c152e3
+# Plaintext =
+# Ciphertext =
+# Tag = 9723758f610ae3d063f73f3d79e1dc4a
+#
+# AAD = 6cfd8e1fb041d263f48516a738c95aeb
+# Plaintext =
+# Ciphertext =
+# Tag = 53f8af4a900697c65fa5e3a4b8e78420d5ad85f2c0c33bfa
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3
+# Plaintext =
+# Ciphertext =
+# Tag = c9fb6ac839933498cb593a1c1b9bd6c46f47d23187b1236346a3aedc94316a8e
+#
+# AAD = 6f009122b344d566f78819aa3bcc5dee
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+# Ciphertext = bbe038028e324873131513f4aa886462c3a55cc1ceffa0eb5f1bbd
+# Tag =
+#
+# AAD = 7708992abb4cdd6eff9021b243d465f6
+# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+# Ciphertext = b3b42c2f0dcbfa9f9f3f3c8852304dde32558cac7386a3cf644a0b
+# Tag = 2a5d1dd723d76bb4
+#
+# AAD = 7f10a132c354e576079829ba4bdc6dfe
+# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+# Ciphertext = d6e59078153e2ba5a30f1f2f9df8e167b4c175baa32ce56612043b
+# Tag = c0194d6d410196244d648bb7d804d607
+#
+# AAD = 8718a93acb5ced7e0fa031c253e47506
+# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+# Ciphertext = ae465a34df4ab0b31a4984aedc06f66edd479aabadf5a3ef781016
+# Tag = 3b6ed456110dfad12f7206effc3cf1358bbf7ee3c830aa80
+#
+# AAD = 8f20b142d364f58617a839ca5bec7d0e
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+# Ciphertext = f06a7c85ac848f04201e17204854d2bd640b61b24fbb77e0e533c8
+# Tag = b976315e97c909c01dbd9c2303d64403d9f8f797ca5bd19d40d7fec0d44662f4
+#
+# AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+# Plaintext =
+# Ciphertext =
+# Tag = 0bc91e932c45edd5
+#
+# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+# Plaintext =
+# Ciphertext =
+# Tag = 0f2b51d9844b2ed7b6f590b8d5f502d3
+#
+# AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+# Plaintext =
+# Ciphertext =
+# Tag = 939a3b8e4c16ca5b1cbc33957c304f47c11cdf21857ae2de
+#
+# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+# Plaintext =
+# Ciphertext =
+# Tag = 89e4c348638fc0965961a3c3eda499de18f9cae991bb544cf5876e8d9ed12ba1
+#
+# AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+# Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+# Ciphertext = e92fe469af09d257301e93c2238911776c893d8f489ea132576b97a626fb3b048b04ba7a0315fe
+# Tag =
+#
+# AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+# Ciphertext = ceea2417e251da8e541678bb182202829c82aa512c346d2b2165279d2174180543fe86fcc82eca
+# Tag = adcfc2487722e85c
+#
+# AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+# Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+# Ciphertext = b0273d1e48d8a1d103a5e171ead75d2c54697a564b46a0c138c0d71d46280d7b6e615746d149dd
+# Tag = 0d46608f7480bb40b2fe8a014e994754
+#
+# AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+# Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+# Ciphertext = dd3c259c99122913a8d840ce484487873eefbab4549ab6a9063e26ce2b8b87b1c92f3ebf25e562
+# Tag = 6a4368b5e4f36d3c76630cfee14ed4b661dbfb5f7e83dcda
+#
+# AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+# Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+# Ciphertext = 807f10a7d69d537598dd2d8b3ca82a428143fe5cbfa4221a4a761d18d95bf1671c2407715e3858
+# Tag = e47a2e652112fc2e24a05df85b38a59ed5324a3cad95f545f6a08acf1430f20b
+#
+# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+# Plaintext =
+# Ciphertext =
+# Tag = b9039ac45e59cc6c
+#
+# AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+# Plaintext =
+# Ciphertext =
+# Tag = 49967e25a36daff826cc4d1fa65819a8
+#
+# AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+# Plaintext =
+# Ciphertext =
+# Tag = d76227b5947ffa4a32681f907d9e35f3db043a0626c9d1d8
+#
+# AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+# Plaintext =
+# Ciphertext =
+# Tag = 7a7bedab5b97491926d9e2e431a24be84863bbab368a3f72a59c8cb6104938ad
+#
+# # initialize with key of 128 bits, nonce of 640 bits:
+# Key = 821bb44de67f18b14ae37c15ae47e079
+# Nonce = d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2beb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d9eff602081e2430364c526e647a809c92a8becac0d6ecf
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = c9b14deb7210854b
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 4418f5c95ac6ac3a16244705ddd0cfc6
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 52d024b501d6de0eb9073906f913fc59e6c9efd4ffbe3c5a
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = afd68d0db1c19969e11af020720f40046a543fae0c20367140a0f9f530498fd9
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 9f527652c9
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 109dc06045
+# Tag = b8268fbd7d84c451
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 807dd2a69e
+# Tag = 885254742822c9587803fc1ccaa4e2f8
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 08245d6a04
+# Tag = 6e36c5e3d109e05adb7abd82ed66e58d11ced695f1fef392
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = e638f11fda
+# Tag = 3162d25b1a549628d55aa00b58817a1e27ec6ad5b5f4790ea9019bcb091c8195
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 3bcc58bd1d27674aa349933d
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = abcaa3ab35cf533965adf6af
+# Tag = ccd56641984bf845
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 6ff7906e752f7cca92c0b602
+# Tag = ab71b502e59b3db482a6efe3c89e8224
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = b43d2d23820f5debcbb8c3a8
+# Tag = 872338634528b8b5a03f0d3c47c18a58a10feb32b4e7a525
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = dafd906ac47f129713647493
+# Tag = f1565eaaaba8891af7a68f6fa1307887648ca7cd9358c95393a15c28d9c7c85c
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 149a0721a3eb46d7fe1d9a38d50a741f69478902fa3cc9
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 55d51d2f173afbfaf62539cce15d874a5c428ece3050ac
+# Tag = 5a96c688d1e692e8
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 85d32004535aa4d595f4659128359ec313054d078b238f
+# Tag = d812a331c9a8e23fe160c57d087c17be
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = d32bed8926ca9ae7a490c20927ef925b49c6eb3676db3e
+# Tag = 826642fbf26dd76f0ca5ad2d0ad5a830eca50726f2834943
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = 71eba47090e3cd484dd172feddea2b6ca6e4f36f4690fd
+# Tag = 6357c6f26d21ec8f2122a7685a2bb1d43920e173bd4aba6975dc9de7bc2d40ae
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = e73faab21a7a787bfe88843724aaea70baebc7682fbcf588460dd0c868d9282caf6f8404aa3124
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = e52c35e251cd3e40e20e48387dbaba964d02340d5a18c0fbfe02bcf92be6ec0cb656a5abe76ece
+# Tag = e8497d00b38893dd
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = c885e15513a1c4a644fbd62968041ec6dfd091e379bb938cf90b206be6b11e758d2c36c619f261
+# Tag = 8ea855f0707acc3f9536c5999d328b19
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = a6d79ad809c7e98215edb9b512f5222dd1dadf579a95c39b98349ad52a4cf0af238c670ffbeb9e
+# Tag = aa6f2cb55a1abd8e3da6449ff654428843a50c4113caedaa
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 99eedd546ce7b40b3679586f6f3a51eb3e7d7cc031ab1bd730244b4f0da8c1b2b05eef98d355ea
+# Tag = 408bf7d6f7376d593256a77e355727f5e712e26cd46f5b35ffe8291bc3b5056d
+#
+# AAD = a233c455e67708
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = aa3bcc5dee7f10
+# Plaintext =
+# Ciphertext =
+# Tag = c5e3601f70555194
+#
+# AAD = b243d465f68718
+# Plaintext =
+# Ciphertext =
+# Tag = 5681d2203ecd8817043b892b2cbcb936
+#
+# AAD = ba4bdc6dfe8f20
+# Plaintext =
+# Ciphertext =
+# Tag = f7d6e1fcfa8e255805f1910a732bd43cbfa06b1292c97d3d
+#
+# AAD = c253e475069728
+# Plaintext =
+# Ciphertext =
+# Tag = 31574046ebd65ded2ceddf0b0f29a993e906bbdc7add2907ab6038e8be3d93b2
+#
+# AAD = b445d667f8891a
+# Plaintext = b0d15172f21393b43455d5f676971738b8d9
+# Ciphertext = 60fb8939903545646a89f2332e8be6055ff7
+# Tag =
+#
+# AAD = bc4dde6f009122
+# Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+# Ciphertext = b2b4cf0583362c5fec453c415c23a3232644
+# Tag = 95ce17ecad7a905f
+#
+# AAD = c455e67708992a
+# Plaintext = c0e161820223a3c44465e50686a72748c8e9
+# Ciphertext = 3d8af7230484c891dd35dc3d8254f3fbc35d
+# Tag = cf74293f44b72ada93c52aa31deb004a
+#
+# AAD = cc5dee7f10a132
+# Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+# Ciphertext = 705d5dacc198312de028b6162c0bd7242703
+# Tag = 2e7fd009c84d02dc86518b49417e3425e2c95c92d35727e5
+#
+# AAD = d465f68718a93a
+# Plaintext = d0f171921233b3d45475f51696b73758d8f9
+# Ciphertext = a8f0a941c6e08c26c7eab75aa5183f944631
+# Tag = 181c0b882995b2ea5fdd5d53b7a753cca65e9a0ce50e8e10bfd6fec3d21839f6
+#
+# AAD = cf60f18213a435
+# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+# Ciphertext = 528e3a35f4249b7de29d8894d6b3cd07c7af5048d55c548a97a789e41db0043335413ea3840369f623c8bc99c5
+# Tag =
+#
+# AAD = d768f98a1bac3d
+# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+# Ciphertext = 2f8f49fd8dbfa2fbaa4655f3cb9ffc55b8635a9b5d1d1cf4a19e1898db76f08d44b2df5e8fc1c61c462a15b731
+# Tag = ee49265028af20b3
+#
+# AAD = df70019223b445
+# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+# Ciphertext = b0503f549a781e4a29d64c910a8b3e18a046399faeb33543f4da10ac26f6514e1ebce49c3cc8695f7ddd6f5976
+# Tag = 62b1af8b77164e92e215c73a766ec468
+#
+# AAD = e778099a2bbc4d
+# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+# Ciphertext = e14a75ee5b24b51e13143dc678c18b9ceab72f8c9416e50653f3759c473ffb2f2bbc45ffe005a10dc1adfedb1e
+# Tag = d6095aabf3803d8cb91b55cf20196737e92c8f86c1319fc1
+#
+# AAD = ef8011a233c455
+# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+# Ciphertext = c51853146b416c2873965404bf3b509c0aaa857749d7362b0109850642699e4226053788581868eec0b1c58ebf
+# Tag = 30f3314091eba609d7dfaffa370e2e32f5a53f064e10d6510707466444ed9f06
+#
+# AAD = 54e576079829ba4bdc6dfe8f20b142d3
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 5ced7e0fa031c253e475069728b94adb
+# Plaintext =
+# Ciphertext =
+# Tag = 137d652dee2b3890
+#
+# AAD = 64f58617a839ca5bec7d0e9f30c152e3
+# Plaintext =
+# Ciphertext =
+# Tag = 252f1a3033311f6c7c2169a87fcf6d60
+#
+# AAD = 6cfd8e1fb041d263f48516a738c95aeb
+# Plaintext =
+# Ciphertext =
+# Tag = 572a2bd5ff12ae5387721a6142a4ffe2f91a1e330d80ec2f
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3
+# Plaintext =
+# Ciphertext =
+# Tag = 98eac818e123e7ffcfdc76a6ab46a3a5121aff12b917014262056c2376e31e48
+#
+# AAD = 6f009122b344d566f78819aa3bcc5dee
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+# Ciphertext = 2f9170d1bc1ebb38220790a741c3ca3a62e514f861dd407807bb72
+# Tag =
+#
+# AAD = 7708992abb4cdd6eff9021b243d465f6
+# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+# Ciphertext = 29e5dcfeeb6b2b18393ab1630c461abe7e63f98cdd1fce05952526
+# Tag = 8e013ec9a218ba07
+#
+# AAD = 7f10a132c354e576079829ba4bdc6dfe
+# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+# Ciphertext = 69dda85a6eac0e36c4d2639a37f2fddb0fd158fc2b4272f9beb313
+# Tag = 7d186118c662ae7a4700fb1c56a8d13d
+#
+# AAD = 8718a93acb5ced7e0fa031c253e47506
+# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+# Ciphertext = ef052db258506a93b6cc9ac99dc456a00a122d196391b001bb1af2
+# Tag = 14bc2f070bef543d6fab1ae82cfc96257386c303c97f8794
+#
+# AAD = 8f20b142d364f58617a839ca5bec7d0e
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+# Ciphertext = e7fb119c6e51cc3675e6599259e9aea6f6bed2123086f35d2b1796
+# Tag = 48f54e4a89d2597c58e4b0528cc9e27d1f2c2912803fc85cfdd211bc40d18b5f
+#
+# AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+# Plaintext =
+# Ciphertext =
+# Tag = 4177758b2c96a15d
+#
+# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+# Plaintext =
+# Ciphertext =
+# Tag = 0106f4adffb2206e93cae6af52fb4f24
+#
+# AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+# Plaintext =
+# Ciphertext =
+# Tag = 976132981df0a7c259ff62a8a9b13fd0b8d3c4cf86f19c11
+#
+# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+# Plaintext =
+# Ciphertext =
+# Tag = e4219ef913039ff02f6e0672e24eaf85cb8c58dabe6ab8ad1862e7237f2641fc
+#
+# AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+# Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+# Ciphertext = 43068574ad814e660bcafd4e832efe1552d5eb090d5935704f8934ede3b1929612c9b134dcceb0
+# Tag =
+#
+# AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+# Ciphertext = 60dd30ca650886ecda1252fba10d9dbca4dbb32f3b9a41b166a139f294c010520fd00ed054410f
+# Tag = b5620ff3561f2a13
+#
+# AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+# Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+# Ciphertext = e2e28c21e1064a5ef6478497988e8d1599b524a9a0f54e4647510dc69352f1765a2e2530239036
+# Tag = adcd89918c9c3c041461981f93ddabeb
+#
+# AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+# Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+# Ciphertext = ceb2341faea9958276c6b40180871dad7988f42c33a34767e65ebd336526efa3b346cc12574d05
+# Tag = bb0885e2959f513f1c2d158702560dda758676fb283a5e97
+#
+# AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+# Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+# Ciphertext = 2c05aac1e69aca316290c89e0574bdb448407895cfa81fadacc71fa059e6cc1842ae9b0f9e220d
+# Tag = 6afedec4d9a766c3363706ce055f08bca2f60bde083383e935f58b3dabf8aa66
+#
+# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+# Plaintext =
+# Ciphertext =
+# Tag = 6e91e63feccc2bd1
+#
+# AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+# Plaintext =
+# Ciphertext =
+# Tag = 7396f158fed2057ae76c7ce5a7f7174d
+#
+# AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+# Plaintext =
+# Ciphertext =
+# Tag = 5fda1b4b38b662d2d3ad1fe4f29ac1c18dd68f7dd07dd100
+#
+# AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+# Plaintext =
+# Ciphertext =
+# Tag = bbaee3d2412409fb7a02bc894962d041d3cd3b51c016ed60047ce3d90a9020a0
+#
+# # initialize with key of 128 bits, nonce of 704 bits:
+# Key = 8a23bc55ee8720b952eb841db64fe881
+# Nonce = e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da3bfb5cbd1ede3fa001c12283e4a40566c787e849aa6acb2c8d4dae0f703091f2531374d536f657b819d93a9bfcbc1d7edf9f0061c282e344a5
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 534cd0a431735501
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 53cbd422fd55c34ee32a8a4eb22487a6
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 1ed0b2c5549b3f64a74f8f6035cee2738e08cf6045cdaeb7
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 9b7135be2dfc49f443d3da0e4ea9f56390bd27c609e72e11ab49d11fd29e33b3
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 77ff879847
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 946cb16c6b
+# Tag = 2f0312a5a3efc44c
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = f7cfc2c756
+# Tag = 7233cc66b56478282a5e7eb5b73f4839
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = f408b47b8a
+# Tag = ed7c05f56147746ba72475daca6a2cd39720fbbdfcaad4d0
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = aca8ad7c9a
+# Tag = 5d37d98532f298aebe897ba2a6eac54f40706982fa1173a4d601b39cd286971a
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = fc8c32ca4cd340e2fd492a02
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = a23926c8356894079ba04f05
+# Tag = aaa0b7dd666a843f
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 9bbd39ed5673695debdf968c
+# Tag = 592894700f2beb726450375bcc8ec70f
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 285fc4f10cafb17710e1f920
+# Tag = 8f721021a532b7176b9ad65427bbfbf10997c8921dcf084a
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 55471f3a72834ba325561d94
+# Tag = 942476dfe4f0d4588eeee440801df51622b58ff5e6f8047ac301cd91698e768f
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 28b9011636b5f4958ac1cd3b92ffb554c526b8d7d20da2
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = dbbcbed166f56ae785e85e18197b3518b787cc4ef01917
+# Tag = a9adaed644ad8300
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 5b7800a0b402d5c0c4428719537be9503941121f239f57
+# Tag = 3c5e16a5078a4bda7eb7e7d4c7ae1d4e
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 651aa0196d9ceb173144682ceeab55551517e199d90705
+# Tag = 80f701f0d6d1c7361239859012a4af810352c110032eb9af
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = bec349401bedd3c1f18f75679c7a59c9c8c8138efc1a89
+# Tag = 074c3426f6855b27798d174bbdef6d98b8c6abea86804a052b457a5b3c38b0ac
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 8558033b63d6c6781ea0da1f3bec1d7dbd75882bbe6d7edb017be04120a9db103543ae55946e8d
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 2b1d01629db1b79107369ad9d130ce0b649cf9148fa4756bc388f0fda263b3ab39c2035a0eb766
+# Tag = f4daf0457710b339
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = 1ebfc7abf4320134d5a7caff805e25bf60b9d325aaa8995772d6d35b64a7ae3a6ec620a7d368ad
+# Tag = ebb1cca3b3d5bfd14d07b8b4b42b75f5
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 96d717cd82b6312a9f0879d224e18cc607c36135198a53479e51b47944157b8f6951a3f0d68d55
+# Tag = 3b20187e3307403e882d8ad25c844f85a31ddf01f8c5b67e
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 25e657a43a0064639f38a87d3dff3106dd3ae15ac31bffe8f2562aa43dc1a20e201d1101c778e7
+# Tag = 6b81c7c7d7446d8e320c8ebd9c1d807ad6c86c1f418007a02d9682c72c3a730b
+#
+# AAD = a233c455e67708
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = aa3bcc5dee7f10
+# Plaintext =
+# Ciphertext =
+# Tag = 48b28fb07f73257a
+#
+# AAD = b243d465f68718
+# Plaintext =
+# Ciphertext =
+# Tag = 01552079c0126f43883a04d56c5f4608
+#
+# AAD = ba4bdc6dfe8f20
+# Plaintext =
+# Ciphertext =
+# Tag = 11606b58521a06880bb3aebb1bf993b1fcbb789b47bdc835
+#
+# AAD = c253e475069728
+# Plaintext =
+# Ciphertext =
+# Tag = 1ba35ffeb9f81053ea9d588e680a6c859d411c24c905bdf4ad23c5f2da409dbb
+#
+# AAD = b445d667f8891a
+# Plaintext = b0d15172f21393b43455d5f676971738b8d9
+# Ciphertext = 22e04fb197058dacab29f25383a8cd73d5e6
+# Tag =
+#
+# AAD = bc4dde6f009122
+# Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+# Ciphertext = af1080469382333ec831ff93cf025774d642
+# Tag = dd62fb616a47d366
+#
+# AAD = c455e67708992a
+# Plaintext = c0e161820223a3c44465e50686a72748c8e9
+# Ciphertext = 5221c8807bffbf9ca501516fcc619931497b
+# Tag = 46a00541e4bc2a96978833f853b3aefb
+#
+# AAD = cc5dee7f10a132
+# Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+# Ciphertext = 27e083c554288379b7e67036d265619d2dfe
+# Tag = 4e4528bc1c84405967c57d98a57001bfe05e66b8ef5ff9af
+#
+# AAD = d465f68718a93a
+# Plaintext = d0f171921233b3d45475f51696b73758d8f9
+# Ciphertext = d4bd94ae157ae498e07ee85e241a6e324d68
+# Tag = 641c18defcca6aec5f7c18907bd99b5834e77f0f76a7ca770d2b698918f9a85c
+#
+# AAD = cf60f18213a435
+# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+# Ciphertext = d4346d0114eea95d0518ed851acf70fbb85654d207a2ed5dda94586db55172455dedc4b2b3f8d06b8abd73a8d6
+# Tag =
+#
+# AAD = d768f98a1bac3d
+# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+# Ciphertext = b68f350c0082dd859d0358ce0aeb2f08172579d2ff701c51ea9ba12723ec3b19d8715dfedd392e464921a6fef3
+# Tag = 3e2225025f50f0fb
+#
+# AAD = df70019223b445
+# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+# Ciphertext = a2106a71b6fb28914a4e706f577c837a07f053694a9546e0ac02075cbd0e9d6976f217e2bdfb83673081403e9d
+# Tag = 926c8bccf757eb1fef8531660478de69
+#
+# AAD = e778099a2bbc4d
+# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+# Ciphertext = 71a784f2cddd2bcdeff53b4b1166c1fea1d805177b66a109e74df8b95eee5577bf0740c868ffb61d7fc92206d3
+# Tag = da8e645646f083d20f4577e2e151b2b1d399cea95ac04b93
+#
+# AAD = ef8011a233c455
+# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+# Ciphertext = b2a62822d837e8e4ca21a4ff770abeef3804ec7bec68637bcb3bac4ddfcb2ce06f0542f328963372a717cd2ef2
+# Tag = c124a16deac6543ca980db251487b4dc4da5486f712bf7a18fc5fdea423b4a58
+#
+# AAD = 54e576079829ba4bdc6dfe8f20b142d3
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 5ced7e0fa031c253e475069728b94adb
+# Plaintext =
+# Ciphertext =
+# Tag = fa8afe5e1c671936
+#
+# AAD = 64f58617a839ca5bec7d0e9f30c152e3
+# Plaintext =
+# Ciphertext =
+# Tag = 6d38fef0f13f1f2746c78104bb8740b2
+#
+# AAD = 6cfd8e1fb041d263f48516a738c95aeb
+# Plaintext =
+# Ciphertext =
+# Tag = a0709994c90c33c66a226eaff4198473db2e5fc774ea7ad1
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3
+# Plaintext =
+# Ciphertext =
+# Tag = c716d647e6929e8b59eb44c356bdcad3652083c4d888b184cad21b1f2eb7761e
+#
+# AAD = 6f009122b344d566f78819aa3bcc5dee
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+# Ciphertext = e4e907850afa2e02f3b70476d762cdfdfa39681aedd373331ad762
+# Tag =
+#
+# AAD = 7708992abb4cdd6eff9021b243d465f6
+# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+# Ciphertext = f90670cd80216596424ada1d38a8d5aa5663e66c2b85692dd1d01c
+# Tag = a883aaff925387c4
+#
+# AAD = 7f10a132c354e576079829ba4bdc6dfe
+# Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+# Ciphertext = 62b18341977bec6c409604ca2c3c04a7d50e146864639fba6b7053
+# Tag = 7de0ded769b5ec6347b186146430931e
+#
+# AAD = 8718a93acb5ced7e0fa031c253e47506
+# Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+# Ciphertext = 227efbbdfe1fb41c97b91fc76e752559d3fd2910a5e05cba073cc5
+# Tag = f52ea0a597e16500ba4bec37e57b34dd50739df84dd0e7a0
+#
+# AAD = 8f20b142d364f58617a839ca5bec7d0e
+# Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+# Ciphertext = b796d09658de20fdcad2b43c679c24bbc2224655150ed670748f1f
+# Tag = 08280257c4401f07daf5c423cee144df5ee398991d1745242521457e49da66a2
+#
+# AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+# Plaintext =
+# Ciphertext =
+# Tag = d4bc9fdd1de9550b
+#
+# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+# Plaintext =
+# Ciphertext =
+# Tag = 37c1db7477587c88f5b00eb96a6994b0
+#
+# AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+# Plaintext =
+# Ciphertext =
+# Tag = 4084671b700efdf3f543de5a994185581384f37e5fa25efe
+#
+# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+# Plaintext =
+# Ciphertext =
+# Tag = 6c557930eb46c4a57eea09e05d9740b7237f9bebb236bcc0845a824758645d0d
+#
+# AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+# Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+# Ciphertext = 91803cef593dd5bc83eac04a256d031c85955fd1359d40b257c1017e766431b8bccb49c8abe288
+# Tag =
+#
+# AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+# Ciphertext = 703939868321a0bbe37a6b38c355307727dd4d6a280daeedd595cc14514a0c070e1ae5d0511bea
+# Tag = 9243b0e1de1fc542
+#
+# AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+# Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+# Ciphertext = d7b68b5dfed8bf0558d3ae70ff1962c956e359dd3b9bff9344840ee5e7090dc9aa096744a5435e
+# Tag = 3dde51abd657710fb1339672b757eedc
+#
+# AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+# Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+# Ciphertext = 7ce32f34015faa206644e4cf8601c67fb5d7a12bf2551607a98b204ee16c50d4ae487b7611a1eb
+# Tag = e630e260300b0f4d6844de8a9880a4c8c7b15771fc833de3
+#
+# AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+# Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+# Ciphertext = 3b3754b7dcd8e31130ce7150a551ac5a8b1baa4bee134fcf59a2850b0111ad3bea4153f72b5a29
+# Tag = 21f7ae500494ace6f9d050e337704db7255943ef902da5c140c5345f46bfd9da
+#
+# AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+# Plaintext =
+# Ciphertext =
+# Tag = 9a561ea80a3c0290
+#
+# AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+# Plaintext =
+# Ciphertext =
+# Tag = 1a6774cfb3ca2fb0306bc86a5204d734
+#
+# AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+# Plaintext =
+# Ciphertext =
+# Tag = 914f4d81596d69b66002c4efe55bbe5669058efa1793da19
+#
+# AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+# Plaintext =
+# Ciphertext =
+# Tag = 41ee138ce6803aa4dc9fb83248e3d0abae6e390673bf7fd2e8fcfeafd709388c
+#
+# # initialize with key of 128 bits, nonce of 768 bits:
+# Key = 922bc45df68f28c15af38c25be57f089
+# Nonce = f354b516d63798f9b91a7bdc9cfd5ebf7fe041a262c3248545a607682889ea4b0b6ccd2eee4fb011d13293f4b41576d797f859ba7adb3c9d5dbe1f8040a102632384e5460667c829e94aab0ccc2d8eefaf1071d292f354b575d6379858b91a7b
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 257090f77c284721
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = ae4182f0ae6103790cb070ed89d8b6ab
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 61a17f87158587fc9d9636be02a564aa7ea310bd86398fda
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 649cacf048be9188800feef25f67938ca7cf863fb9ed7a82a358bb8490323f22
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 7f64c78f4d
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = e390ecf887
+# Tag = 92223d8412a9c5f1
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 60367f1974
+# Tag = 21242d3a33923517ed487da47f50bd7d
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 435ea8c725
+# Tag = 2fec061d9d160fcc4978d7d865d0dc221711e61d7f9cc32c
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = f7eca14a65
+# Tag = 59418e8009259740db63a999f8d5514249075ae6c4efe4f97eea73eb30c1c6aa
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 32dfd0771d966277171684c2
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 0adf98a1870658a9baf0f7b6
+# Tag = d3d4b74316b6b7c7
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 9f0277d612635cb319aaf319
+# Tag = 44098061b86fbd8724f7078d8906267d
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 49b641289558a2d285cf3a9f
+# Tag = 6e7fb1e8a588b36356de6abfd552f87b814255a874b34c01
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = c45bfad0f25f5743050cbd56
+# Tag = 255c746ba88784bb0f4e430a982e6a801bef1d147ef2d981203e634105dcf3d1
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 0f1aee7616b9ba6a5fd73c0614f211baabffe69abfc17d
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 1243dc105852ba4939d5d077dba6988fb8e81f1a299042
+# Tag = 42847fcf7aad5563
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = cf46073fe38d3f85feb11bee5f9ae4146ff6945ef82059
+# Tag = 247606c9fa41b36e5d1b35dbc441faed
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 2e48b18f7d21b3ce5239cc6a8508fbb07febd6716a48c3
+# Tag = da76a61b9a209edbcf89dde0eb07233cdf72c770db7440d0
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = d218f5628a7e645ff6efd7d0e85c2c330c55a74427b509
+# Tag = 8a68c502a1042c88e9fe4727f4dcc2d385166104fe60f4d0def8b6a587e1f14f
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 1f45e463a640a6a0e2c6b0cf90795f05fd36537c69e36ace6c24515f7c42d56e4d284d72b3f347
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 222dae017d51212bd081b220b4ba4e313aa65d5417a5d1060464ea1dcce34157a023cb338c259a
+# Tag = eca4688b8637d88a
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = 77b551a03c8800a3c47d183db7820d3138f35e8d90503ea98d9097145ef1520c925f20dc5a76bf
+# Tag = 0ea7f02c84cc13b0addcf20b42a015c0
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = f1bed7f09b521c2dbf09620bd36374698fe7b71755962eef3d60f8f52c8c1879cb8fb1ae68fab7
+# Tag = 9b8f23688791c3e3413e7fa9b9188abab8cfbce456fbfb8e
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = dc87bc8ec601d2af568e8860115c33edaca2c170b19a7d98f131196767796892635224cb4acdab
+# Tag = 3f4c02431bbce6d6c216401ff2727c91ccaa8eb308e42a1dc39eee4a0ca56370
+#
+# AAD = 44d566f78819aa3b
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 4cdd6eff9021b243
+# Plaintext =
+# Ciphertext =
+# Tag = f5a8094c723476f5
+#
+# AAD = 54e576079829ba4b
+# Plaintext =
+# Ciphertext =
+# Tag = f95dd7da308d5690f7cb9b869bbe54f4
+#
+# AAD = 5ced7e0fa031c253
+# Plaintext =
+# Ciphertext =
+# Tag = a473d14f917b577964205c9b804db1e270a2f74fa8eb2f1c
+#
+# AAD = 64f58617a839ca5b
+# Plaintext =
+# Ciphertext =
+# Tag = cca440f6d035c6cf273c8cfe00031cf8a5fcafc563e9ea984b78c9dcc787c2cd
+#
+# AAD = 58e97a0b9c2dbe4f
+# Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+# Ciphertext = 94c61a477cae6bb988adb58bc54c0bcbcd207fc4
+# Tag =
+#
+# AAD = 60f18213a435c657
+# Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
+# Ciphertext = c1d8e53f19720cc4070bf1a08bce88e2c9309233
+# Tag = 9d841625faad2244
+#
+# AAD = 68f98a1bac3dce5f
+# Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+# Ciphertext = 58ad1430735ebc990f9d1e9d7da8d8ce0e870717
+# Tag = cd7501206caafb399ff5653b1cebaa64
+#
+# AAD = 70019223b445d667
+# Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
+# Ciphertext = c7d4d94c7d51d8ae6c0062b49bae3c5ff9c2936f
+# Tag = cde54ef5f5f4fd1461a6bf8a1ae6cbb7d324ef62da9155aa
+#
+# AAD = 78099a2bbc4dde6f
+# Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
+# Ciphertext = f9ef6e5197ed99435d374abf12ca9e63a9db2362
+# Tag = 239e70b9de81c122baa7ec8d31221d3066c7699d61fd6fe08b708cd8ce02a288
+#
+# AAD = 76079829ba4bdc6d
+# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+# Ciphertext = b7c713271bbe5051a0c1c99ab1b5abec05af1a6ebd8ccab79a23e1555fbb17588773764ee856096b1de168a4f6356a2f36ec
+# Tag =
+#
+# AAD = 7e0fa031c253e475
+# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+# Ciphertext = 881f2e6eb36827225032996158df75ed7b11910e6c94d7f515482b92bbd29c28b51d89aade616c1fbe8c3dce318599e2cd8b
+# Tag = 6a311f6a94d3e9d6
+#
+# AAD = 8617a839ca5bec7d
+# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
+# Ciphertext = 26d8c2d3af698f01f6a2303c6ba19b73520f7d67b75541948ebb122ffc1e96b881dd9662d4315f5c89c0fd87db4308d636ff
+# Tag = 4c24ad19a0d9c1bfa56ef3593cbeca78
+#
+# AAD = 8e1fb041d263f485
+# Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+# Ciphertext = c522468d5579b4da65e76d586534f9f5413394b465c76b2444bb52f8805b760126eeefd73539095777c9bb82cdc5cfffcc7a
+# Tag = 60e038d453325551b2aed60bb79b6238f5fbd6649fd132e7
+#
+# AAD = 9627b849da6bfc8d
+# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+# Ciphertext = f0115819b3cb61f334e05f07ed71472f409f83d4420e11f64dfb5c395f492261c0cc6da0ece4482fff590357ae32da5a0a12
+# Tag = 0862b4e4df0618b347b0d92e700b07b63ea6b33ba9f4605219fc5f244ff58c71
+#
+# AAD = 9829ba4bdc6dfe8f20b142d364f586170798
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa0
+# Plaintext =
+# Ciphertext =
+# Tag = ea24ec1a2662524e
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a8
+# Plaintext =
+# Ciphertext =
+# Tag = d5aa8fcb4b47fad9f74894192d52ff42
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
+# Plaintext =
+# Ciphertext =
+# Tag = 624bcbe68351b128ddcdcf384065b6b3ddb75ae0c26e6d77
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b8
+# Plaintext =
+# Ciphertext =
+# Tag = 96607c892b3a15fda8b1e1d7ab78811beac62cfaeb6f59fc383a2a43f4c071d3
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b6
+# Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+# Ciphertext = 6545148db611e243a9f41b6dbb8141d1b899c760c3862dac472d87e24ff6
+# Tag =
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe
+# Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+# Ciphertext = f81d9117ba585443e156fa0d8ac7fa149ddee3ae3a9c2ad47319c8616c25
+# Tag = 4fbe7f26413c6566
+#
+# AAD = c657e8790a9b2cbd4edf70019223b44535c6
+# Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
+# Ciphertext = c255b9d727cb54ed034f889fb7fa710d9d187bf0c5ac3ca8c127269718fa
+# Tag = 1ca7ea5a292a3537db047f049d15921f
+#
+# AAD = ce5ff08112a334c556e778099a2bbc4d3dce
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
+# Ciphertext = 973d3eb7bc52ed3686c727d9adc6c02037b008422fd682bff1dd869d3e12
+# Tag = 7f3de5054fc77601c5dbd87abe2da5ad61620841c1a56b84
+#
+# AAD = d667f8891aab3ccd5eef8011a233c45545d6
+# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
+# Ciphertext = 02b7186d3933eae5a9cab9d7e2daf9e0d2b7046b2323d55130cd6471b720
+# Tag = b4ea6bbf1c6d025d0e08d8bd21b6bcd8ac65053733d98dc87c602bca89fbb34c
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
+# Plaintext =
+# Ciphertext =
+# Tag = a4c2b9a93517eb8c
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+# Plaintext =
+# Ciphertext =
+# Tag = e0f0305c463829ac1721b596070a0f5e
+#
+# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
+# Plaintext =
+# Ciphertext =
+# Tag = 49c6a456f025add55f4a0e677f63283d7309905fdbe91bea
+#
+# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
+# Plaintext =
+# Ciphertext =
+# Tag = f624bf7756ac159585a97875bec41f371eaab26ebd6071077142a51f12add791
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
+# Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+# Ciphertext = 22f39a03bd5ee90fda71c94fe22f79fb1f0e4f7df33111b84153ee20e185ca0c2164d08c7eaba108c2844e8d
+# Tag =
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
+# Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+# Ciphertext = 83e008bd30d27d77699d6214a11e0823f321a3018d5f4b3056f27bf73716e63c2ba219238b815078fad77f86
+# Tag = db57d743b18b34f2
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
+# Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+# Ciphertext = b6944ea67c13f2afa92515d7e09273aa910501d211ada0cecd50ad1212cfed0f1f45fb8d504d87f72a7bb7c4
+# Tag = 1cd0684de66d1e0998998812fba1ddf2
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
+# Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+# Ciphertext = aeca5368ff55a0a97da1597902ac444dd53fdd2f74b600c5ab794a6ee8b2c0d33b3f06b849a9398f2910ed9d
+# Tag = 9b9d339431b60be22703aec6a7d292c8e2bf195745e22360
+#
+# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
+# Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
+# Ciphertext = 23055bcdca8fdc0451c5169d0188407a27705e37a9933773f56d30a82d04fb5f8c3067ff655d01330e9b65d1
+# Tag = f8bfdc4166741bd099aac315c35a385c6b379633309dad9d0639d09c86ee185c
+#
+# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
+# Plaintext =
+# Ciphertext =
+# Tag = 2c2ced637c2879b0
+#
+# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
+# Plaintext =
+# Ciphertext =
+# Tag = 646f5a0536c3b3099a44daf25ba8e3bb
+#
+# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
+# Plaintext =
+# Ciphertext =
+# Tag = 69ca1124e84d1accb9830c71bdc8c0e18e6dd244eefb9e01
+#
+# AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
+# Plaintext =
+# Ciphertext =
+# Tag = 0982618e762ef15c5987d4b0db50063bc1cbdf0080867e770c0ed962dea50f21
+#
+# # initialize with key of 128 bits, nonce of 832 bits:
+# Key = 9a33cc65fe9730c962fb942dc65ff891
+# Nonce = 0364c526e647a809c92a8becac0d6ecf8ff051b272d3349555b617783899fa5b1b7cdd3efe5fc021e142a304c42586e7a70869ca8aeb4cad6dce2f9050b112733394f5561677d839f95abb1cdc3d9effbf2081e2a20364c585e647a868c92a8b4bac0d6e2e8ff051
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 3f646cac3a0e1651
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 65b23d8c219efa8bf68560b3172de0f3
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = dab5b83342bd6cc9b6995e05d552570da342fd910eba12cd
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = cd92250d86dfdf5052556b5eec04f984ce0899e86e31885a7ac9cf9a9b7af778
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 2ef9dded14
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 4d0d16be4b
+# Tag = 6c689d66783946cd
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = f827769ac3
+# Tag = c46de0399191398dda9d13b1150d9a97
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 80af0f3c9b
+# Tag = b59ed5061508509a3d0a67286c9efe04adf03996ef6c5192
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = f5211c90d6
+# Tag = 21a6771dfba0187b6f058bff9f0f1333156d9f32aa7d136efc6908212be3ef6a
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 16d43411e768fb563cfd8555
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = b66db058cc700d2bb30b1575
+# Tag = da252e676839a63e
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 4faceb7f465d903bb2e59a6e
+# Tag = 85d330723ae4fcf4a286ef98ca7f1091
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = b5f7043dbc578788b6d31054
+# Tag = 52403d1f747e6d95d17ecb573f655f2fb0152d137817727a
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 0e8267d12e9207e8982968bd
+# Tag = 208f53174bd2f1576ca4877cf6b70bcbfbb62871ffb5b493b167095fa270ef2d
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = b0ecffed5fb7999a8118b4b13f384cf7c339f9a4190e6f
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 4b7acf9436a0f4cbad29627dbd0efd12854bac94ae34e0
+# Tag = 8ee6b8626a90bbfd
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 08e9d69325b3f48cedb6c3faa1c4d2b25f1870e1e6ba41
+# Tag = 3abb337fdb097a7c061014020eac8d32
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = b29dfbb5057d3f0d9748c4202432a8ba81d3140bd53ce8
+# Tag = 421116dcc81675d135153e2689d2091b5721dd1e23ec0d7a
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = 2d0a9868896e1ef0e891a695e760f2616ac37b99563920
+# Tag = 6b9299fd2f98c0ea7f311dd863e7ed15808e1d96dd82a08a270641c47bfb6b5f
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = adfabd8a0748414180979fd50ff9baa34479040d0544252832db595cd9caec9ed82f24ac94a115
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 0c6a58c292196e697066b1d9e4f6997334a4bfdac9d146c69622f810e4e6b8d8456c9d4fbf0a13
+# Tag = b646fe49f40a086c
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = 2e5c51069d4c1872eb4cc139426a4a85ad880531b93dd2b01fbaa043f8167f38596e95d90b621c
+# Tag = a70f57d015bc8be61a567d4427210b56
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = cd76b1fe0c561fedfbf214bcca1fea188136320253071ce2056292d8ad2d309c7517d10f063faf
+# Tag = 6f833fad638a3e94e2d1e62a40350954f4d665513b7f2508
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 9e1d19de588faa447fc02f19e1ec1595a3aa121966e741bb68a57839c98bd3cf38e9bc368b58a8
+# Tag = 3a85d04228b0ef1a34aa284eb8ad5ca3d9602f71ee232d3e7be4955bbcff7ec6
+#
+# AAD = 44d566f78819aa3b
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 4cdd6eff9021b243
+# Plaintext =
+# Ciphertext =
+# Tag = 062c4dd9ab2dfccb
+#
+# AAD = 54e576079829ba4b
+# Plaintext =
+# Ciphertext =
+# Tag = d173d05933f76688911cad099cd8c15f
+#
+# AAD = 5ced7e0fa031c253
+# Plaintext =
+# Ciphertext =
+# Tag = 3d9d99a18db85d2209b2ce485a73a6e032d58db4d7fd71b3
+#
+# AAD = 64f58617a839ca5b
+# Plaintext =
+# Ciphertext =
+# Tag = cfb868bf8a2c41ded07cc4d93225ebdfe17d10e6fed105fe447ec9795a31fc14
+#
+# AAD = 58e97a0b9c2dbe4f
+# Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+# Ciphertext = 45d5f5373296deadf267cbd4ca73d4fc4aa1ebbf
+# Tag =
+#
+# AAD = 60f18213a435c657
+# Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
+# Ciphertext = ca0ae0885e9e77a6049936db208441e28a6a36a4
+# Tag = 2f12e384ea59d310
+#
+# AAD = 68f98a1bac3dce5f
+# Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+# Ciphertext = 476fed2cf9a180ef23bd49e2709a6b1275e4b996
+# Tag = eacfc69d5637df836fb013df48c64a4e
+#
+# AAD = 70019223b445d667
+# Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
+# Ciphertext = 47d0d6fc8c91061174c6f899b104c330a95480f3
+# Tag = 480a478bf2067293a9c797527800458d3734334b4fbc6a3f
+#
+# AAD = 78099a2bbc4dde6f
+# Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
+# Ciphertext = f03187e7074057770c3c4bab6790ccb0dc782b38
+# Tag = 317461fd42cbbf1e1d79a9feb320fa0adddca3b8884a663d3348fd7c82e8b0f8
+#
+# AAD = 76079829ba4bdc6d
+# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+# Ciphertext = 0fc535f9aa3afe956298a99c9045ca34dee7fb9271b7ee9a69f378ec0ca8c6f111dc3b81ec937b608efb8bd44f2fa5c5506b
+# Tag =
+#
+# AAD = 7e0fa031c253e475
+# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+# Ciphertext = 0514bc86f4468f8955c44cd3660f903aa67b04256bd00d09e2cfdb2db4803665a069a501127c61faf4806a39587f86f77614
+# Tag = 15887cc389f6bf34
+#
+# AAD = 8617a839ca5bec7d
+# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
+# Ciphertext = 71376828dbf354c4f240bda3b134364c7b38a6ba1d8f4641c093d43f65ada2d404e061f8ff0fcfbb558512d69a5dfb807e9f
+# Tag = 2376ff06eb4e6c89e6c508d3a7f97bd1
+#
+# AAD = 8e1fb041d263f485
+# Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+# Ciphertext = 5a24ba4f1e6f6714e4252d990a3ac98d2741431ff2866cc7e210f8dfe967e5d4d64821fcde0df9a2d5f47e999f013f9493bc
+# Tag = 2d6f431606a78403c6158833845f8be1c5168f5c8bc43ad8
+#
+# AAD = 9627b849da6bfc8d
+# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+# Ciphertext = 1eb64568609870c566654ef684cba33c69b47d4d31d3a88bfb60b02e06a413cf743e957cb43e24090924f4a8c521f0794d78
+# Tag = 69a5188333b59a94199bc67a34b5100b396e1eed057f373e4257a8eeda6437d6
+#
+# AAD = 9829ba4bdc6dfe8f20b142d364f586170798
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa0
+# Plaintext =
+# Ciphertext =
+# Tag = 05d90ca8d9fcbc1d
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a8
+# Plaintext =
+# Ciphertext =
+# Tag = 72fc7f594a911df2b23c88803256d67a
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
+# Plaintext =
+# Ciphertext =
+# Tag = 7dc8786259c0620d370a89b2dbfb1479e09d2c78e721cb18
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b8
+# Plaintext =
+# Ciphertext =
+# Tag = a8c5cc1302ff465d72fa3eeb3f5c3c3b35b8c360e17980cddfff79750ba367f1
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b6
+# Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+# Ciphertext = c6a90c2c72cd38579093abe75a7bf7c87f3f50c954a4b736ed12051e5ce1
+# Tag =
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe
+# Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+# Ciphertext = cc904c5afb2791bd80d36b5bee0f2a3b445c3ffba6dfd68493588b71b7f1
+# Tag = cd346c1a579fc58e
+#
+# AAD = c657e8790a9b2cbd4edf70019223b44535c6
+# Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
+# Ciphertext = 749cef1b1461a026b02958d9cdde1767ef042439ec552c758b8b22238197
+# Tag = eddb7d04c5c0c990e41e71fefba58aae
+#
+# AAD = ce5ff08112a334c556e778099a2bbc4d3dce
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
+# Ciphertext = df038280ef8c7569ac2ab3fb75b8466c983fb17e1a2d1eb11383224e5e73
+# Tag = a209ed6d032508a1488a0497fe820f1a732ff8203ce55eb1
+#
+# AAD = d667f8891aab3ccd5eef8011a233c45545d6
+# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
+# Ciphertext = ca2f3e57c048a61a6d0f11d8068ddaae364b449a6c38f4d78f4e8c05e2da
+# Tag = a4b7b2e4dead77b8c4c2d2c4a1a041b878303664da7da9b478ab61727e3b0bbe
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
+# Plaintext =
+# Ciphertext =
+# Tag = e99479703dccc08e
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+# Plaintext =
+# Ciphertext =
+# Tag = 2cae19e94e1cbaa73d417b0302f54220
+#
+# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
+# Plaintext =
+# Ciphertext =
+# Tag = c92c4bfd6b65861599feb15fa8b8fa643d262f0e2c3efcbb
+#
+# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
+# Plaintext =
+# Ciphertext =
+# Tag = 4c54434c1defcef17c035f1b4a5003b9b2ff88ad32ffd2489cc4026715a8892b
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
+# Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+# Ciphertext = d49dc019aa268da9791fde2d841b7203a843f8a79fbf035bdc7e959fb9dfd522a3b103e13ced4bc00ab46649
+# Tag =
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
+# Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+# Ciphertext = 3f281bf42d9e55fef322b332c9adfbb249bbb6f200ff21afa4f675a3fdd46c7f5f5e7efaab66c77bd7055a52
+# Tag = bfab283a60155584
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
+# Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+# Ciphertext = 01186f43b52ff617aeb1050082ec620977e440675421f1ce8e28885317b750ddb4b0ebae443b39a072489cac
+# Tag = 96ef908dbfce2d3ac0107e100ee57a0e
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
+# Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+# Ciphertext = 6a5c03ab563f78bf1ff87c648fc059ad147e28b2c3169f43e048f614c92a410fd859609fc91d5c48a1b83ecd
+# Tag = c61e08a3a33ef763ca6f44a2de62691835b2cf875bed8ee5
+#
+# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
+# Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
+# Ciphertext = de6db0e7a85625a9893a48b2de428e510ddeec1b42c8dd6f3993bdc32f312f2c42b59818979b07b43218916e
+# Tag = f14b9405611da03ccd7fd1dd632c61f207abd0f468531757f2b026220c74194b
+#
+# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
+# Plaintext =
+# Ciphertext =
+# Tag = 78db4b23706e5b82
+#
+# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
+# Plaintext =
+# Ciphertext =
+# Tag = 638e1f6afaed3c5fd73b67d9a6e6c851
+#
+# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
+# Plaintext =
+# Ciphertext =
+# Tag = c2e15647c05896411fb1885c45d4323de3fd120363d051fa
+#
+# AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
+# Plaintext =
+# Ciphertext =
+# Tag = 52bcb73dd85f95f3b609d6fda83be04dcf1b1cad89403d16df3e11daf5c62b6b
+#
+# # initialize with key of 128 bits, nonce of 896 bits:
+# Key = a23bd46d069f38d16a039c35ce670099
+# Nonce = 1374d536f657b819d93a9bfcbc1d7edf9f0061c282e344a565c6278848a90a6b2b8ced4e0e6fd031f152b314d43596f7b71879da9afb5cbd7dde3fa060c1228343a405662687e849096acb2cec4dae0fcf3091f2b21374d595f657b878d93a9b5bbc1d7e3e9f00612182e3440465c627
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 5a686e0c6d62a6e5
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = ef3fce120647313b9b7f135c357ff192
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 7144cad512b3fbf3c32fa6596ad03576fe7226fbd8fe97bf
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 52bd36047d30e8b19e1fb9ccbf4dbef9b3d68692cc15622c95700a7c95106a12
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 13acef3cc3
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 03731b76cf
+# Tag = d5830dbe7266f0fa
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 763eeeb32a
+# Tag = 7ee7f976fb42848bf44a9e476122da60
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = c3792fa2ae
+# Tag = 96eda6b1e9a33173dc1303b89ca1f93436cd33847415a2c4
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 5e1da00f75
+# Tag = dbc8e96b3f4d447e62c8d1343aeaec5fda69a10f75178c623b6abda4808e8ab3
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 27de5f4193b9ec0318b87eec
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = dc9daa2951f46f303d178b54
+# Tag = e1212580731c99f1
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 09f669a01ae6263da77a5d81
+# Tag = 4e2a9fe20cd8f7ce58bc47233bd1f2f9
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 132693bc7c3ffd2db5d610b8
+# Tag = 753c9be86fb7654bec9fb8b7f9c1319e8408d3e9d8699448
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 3df09231ff759dd2d01fde5d
+# Tag = 11c9ff0b46d33791e2a768243c32ac4762fb3bd59ac19994048d7bee2d9fc80b
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = a3bd685d6e05be37b64c8454556323149f2ce336012f9b
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 4b403bcc05b7c968caa9609b0283b9414ddcfd33ca2528
+# Tag = 42510b3f172f2529
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = a0fc56210aa2f048059433430f9d362c559830755d21aa
+# Tag = bc01f2aca02ebf17d093af82f8f032c4
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = b831a340f30d627c0f28d4af24bf72aa9c95a839feffd6
+# Tag = 25867e752db96bd2ad4879dcf5bfa0415ba7af4fe4cf8c1a
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = be99946ac3b80df2fe19deca88effcc772c7579b6f5655
+# Tag = b7ee7201f0f2dc6d2b155385c6db65425dcddb15cde4b8730ec148444f9ec114
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 9cf9633d61095c2754734e70ab9914c01444a8af7ade7daa7a94ada840ed0bdf813a08ea51250e
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 596bbb4e1638bf2efb4f01473c79bf6fbd565dddeb796be30984b997ff9ecb7550a87b7dd94e81
+# Tag = c792bf8e50b7070d
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = b1b95d3ad101302fe47453c5ff0067cfe69b446076619cbcefe53e06b377a94f710528b0946703
+# Tag = 01d2c64eac873c447c4a939e53460179
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = bbcbaa5bc4cc6017146155ac65ec28e48a3d20e80955466ff79b3a2913ddfc7ccd27edf34e9177
+# Tag = c185c1f847262fd7ac77a60f7a83093431e7d8fa13c0e641
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 6ad082e3f8309ce4d10999e0bdbc3504471e2f1b0a0acab78d0cc43cc057fa2dee70febc2c2965
+# Tag = e0b48ad39b64b09748eeb3da6bdd94a0fd960b6d302f58fe4366701866f96a59
+#
+# AAD = 44d566f78819aa3b
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 4cdd6eff9021b243
+# Plaintext =
+# Ciphertext =
+# Tag = 80fc0e11b2776964
+#
+# AAD = 54e576079829ba4b
+# Plaintext =
+# Ciphertext =
+# Tag = 4885d30c0460ca7ef0453e5ff3884151
+#
+# AAD = 5ced7e0fa031c253
+# Plaintext =
+# Ciphertext =
+# Tag = 218849fc9366d54aff8ba1251f06a8c33ae3aefa0745ce54
+#
+# AAD = 64f58617a839ca5b
+# Plaintext =
+# Ciphertext =
+# Tag = 4231903e6e8650a76ded60d09b6bffa9feffbe6c4053bbc6b6375866b78ab672
+#
+# AAD = 58e97a0b9c2dbe4f
+# Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+# Ciphertext = 498fb6f1bee9c08a84719af14b28ddd322566aea
+# Tag =
+#
+# AAD = 60f18213a435c657
+# Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
+# Ciphertext = 00204e48f3d2e85db90a8a6633ef55afbd377dfb
+# Tag = 1cfb09d2e898fa3a
+#
+# AAD = 68f98a1bac3dce5f
+# Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+# Ciphertext = c476472809e760507d38815110670cbffd1405da
+# Tag = 0248e50e5ae0e426c02866898212f970
+#
+# AAD = 70019223b445d667
+# Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
+# Ciphertext = ff3d8a261c9e10832c33a3ed62458312760dc6d8
+# Tag = 29543461655d7fed421fdfa41773ad67c694659ed8e01d3c
+#
+# AAD = 78099a2bbc4dde6f
+# Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
+# Ciphertext = 8ef90037ce43475cd51804c307f216075931eb54
+# Tag = c4c51d4dd00a732b126169d64837f7bd6adde499abb9578730da2f504a1b9f1a
+#
+# AAD = 76079829ba4bdc6d
+# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+# Ciphertext = b8f2e3e900bf0253b9d2750c927ca39fd879d2976b75077ff4995cd5a9b456978f636f5bfd31a24895b5c2d406a5a4bf2e41
+# Tag =
+#
+# AAD = 7e0fa031c253e475
+# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+# Ciphertext = 965ab4502e55aaa100c9e0a1030b2730725acd86887a0a3da811a4479a2357c12733d7b17767286ce7a77c6e96fd572df4b8
+# Tag = ae48a38e53be9300
+#
+# AAD = 8617a839ca5bec7d
+# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
+# Ciphertext = 1a72a53b185e476d43cfd3d97efc8c67af3b4531a04ab559019390f76018970febbaa94d954083182646eeda066902236b9e
+# Tag = c8de95f46e34a55ac9b4d886b65a942d
+#
+# AAD = 8e1fb041d263f485
+# Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+# Ciphertext = 882d6d5f37b1a2fa2fe8233d4a0ec85b7adec94c6ac6c2ff5d7b9af35980f9af4398e4ad357ff1706efe527d7025b51aa617
+# Tag = 77db3999f5fa495358fe99849e9ad85e3cace7d857fe7dae
+#
+# AAD = 9627b849da6bfc8d
+# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+# Ciphertext = 8f505ab334d6e5ba42f2ec1376355dd90e082a5032be63bcb67d01f81ccee0278b8ba8dcbc4a4bfbd70154180d27b64d2b01
+# Tag = 2ec3a5c12112ea337d3bcb0a53e11315bf8189a3b5ad20e47c1f2bfb5a86bc6d
+#
+# AAD = 9829ba4bdc6dfe8f20b142d364f586170798
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa0
+# Plaintext =
+# Ciphertext =
+# Tag = 3257e78b715a0fbd
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a8
+# Plaintext =
+# Ciphertext =
+# Tag = 1ce2c4b79bff9b12c288cab366b28d5e
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
+# Plaintext =
+# Ciphertext =
+# Tag = 788f36e74953ed889b78054f232a02d550a1f06b0ab5a222
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b8
+# Plaintext =
+# Ciphertext =
+# Tag = 466fb87db92c9090946bdc041d5d216094149e92fef6dc7996baff8e4d2c66b3
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b6
+# Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+# Ciphertext = c7a8ef6a58b50706ca9ff27de41a466edc893e130482170dd3679ed1c288
+# Tag =
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe
+# Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+# Ciphertext = ccd182779e21be688c6ca494662bc47702dd6d121f6eba59e0721ed2c07f
+# Tag = 58b2f95edc12ae53
+#
+# AAD = c657e8790a9b2cbd4edf70019223b44535c6
+# Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
+# Ciphertext = dafcc5c02f8b201ee0a24a6d63cc8a0a30dd6ac7ac332f3ad0d97e3df939
+# Tag = b583f42120d13ba8608204fe22a9ea01
+#
+# AAD = ce5ff08112a334c556e778099a2bbc4d3dce
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
+# Ciphertext = c7ff666fc51e3d89ad4dc213f59f65b9127116d10b72baade3c9e51606d5
+# Tag = 74cc26879e1e3cce63a49f4c9b4aea59b9d5850f29bd100c
+#
+# AAD = d667f8891aab3ccd5eef8011a233c45545d6
+# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
+# Ciphertext = eead6cb784e8f0cd925f1a832db3944e407a0d7064fb6c7adce79f751475
+# Tag = 0d1a4a6edf67916e38fa1037c6350be65e4534ff362c5ad60ac9c6c504797552
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
+# Plaintext =
+# Ciphertext =
+# Tag = e2191197b77804c9
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+# Plaintext =
+# Ciphertext =
+# Tag = c7f2c1c66e94c86640dd5ed6283f834c
+#
+# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
+# Plaintext =
+# Ciphertext =
+# Tag = 28f2ed85c415d3ccc2e08412fa6779df620329cbcaf850b6
+#
+# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
+# Plaintext =
+# Ciphertext =
+# Tag = d09104ffd899ceda208c44b471a3ac79d65398302ff23a53f6c39897532afb55
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
+# Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+# Ciphertext = 874cc6e6546a9be48cd043e70508a6d1070cf892fcc815b15dbc90ba0b48599e557b0563815de9af468ef58f
+# Tag =
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
+# Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+# Ciphertext = 74e5981636e65c03a592381b4366d029e0816d6347c61597ef1258a8ebd061ccca2bcddba42b6d20ef0e90ee
+# Tag = 80486d47f1c71ddb
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
+# Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+# Ciphertext = 72a9efa0a78cceda3c65f07f985835b950b8d2565a030d54cde7631ff5c5cd20aac5448004f8645e8e454fd5
+# Tag = e473b2e785dfa779d64ee31021ca4e30
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
+# Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+# Ciphertext = 6b2943f4b2186fe699221b09ca1e0b1f27db409697c86eb0d976f8a5c58c405da08d5ba966e53d578dad53f3
+# Tag = 0513216ccdc09d8aa4bca65fde363e8433193431fb1f7f75
+#
+# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
+# Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
+# Ciphertext = db9f993fde1dd01739ff3dc133f3a01780dcf4d4c0edbc8f442aaa2f4db231c5a8a96b19336f3d779e75aae1
+# Tag = 7e63ea3793977273f9fdbcc4ed1a97a26549d7f0b128cdbb40763f017ac45cbe
+#
+# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
+# Plaintext =
+# Ciphertext =
+# Tag = 3e451771ccfcce92
+#
+# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
+# Plaintext =
+# Ciphertext =
+# Tag = a82f02467a9af70481c45185aeb88b3b
+#
+# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
+# Plaintext =
+# Ciphertext =
+# Tag = d6b9b76a977b979da4af99d3adaa384fd57911b16c200713
+#
+# AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
+# Plaintext =
+# Ciphertext =
+# Tag = e690f4696bd48cd5392910ba74b4f6ddfca118695021e08042cd6bea949cd692
+#
+# # initialize with key of 128 bits, nonce of 960 bits:
+# Key = aa43dc750ea740d9720ba43dd66f08a1
+# Nonce = 2384e5460667c829e94aab0ccc2d8eefaf1071d292f354b575d6379858b91a7b3b9cfd5e1e7fe0410162c324e445a607c72889eaaa0b6ccd8dee4fb070d1329353b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667c888e94aab6bcc2d8e4eaf10713192f3541475d637f758b91ada3b9cfd
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 8cbb835a1d67acd0
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = eeee5454ab5614bf502f1cd892b163e6
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = d3c77fbe9fa9a99feaac1e5ffe92f04fc7f3a951e53f32e1
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = fe69c22bcf4147c946e0da5e2346802eaa364b76f816fb5bbf4422e82eab1b12
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 7760b50efd
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = b0dc1a1c4d
+# Tag = bc08a919a13fbf54
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = e590478583
+# Tag = a3a2718748d51ef0899c54e41cd14ebd
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = cad2acc9c7
+# Tag = 35887022c618ef898b3023382f4b4c4ce85179e1f8ccf508
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 5f4362000c
+# Tag = a8527b7ceabe3b75756e5c3e9fb282cbc5219855320fe95f4bcd72d1890b9f8b
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = f46b821b52c8d3ea709db1a5
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 6d7c1b63118266cbb9e1b9e8
+# Tag = 65abcd602d0a6cf3
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 4779ea92d6a0b8feb071520e
+# Tag = 8f293749ce9bd7823730f8704700e5fd
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 6fe91761006a2220d0f269d9
+# Tag = c2475297af1963a073c5c0bb62902d9682eb5ceebdc045ac
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 7cbf00e4df2d558941d7c3db
+# Tag = dc6a39e56d3a7f03d1b73fb421645d5803bb6e8444c134ada494f5bbc5448b49
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = d543bbe88c028a1c1b3d062845240ec827409c0cac4608
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 5a986f73e8ce418df4603e1589a4a9ea229e51ce4b98e6
+# Tag = 3f32efbea1aa50db
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = f913bc1c8e89f93943bebe9a4d5bb1611354a683fade69
+# Tag = cae40ad9f7c75cd954cba88290340e52
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = a51c59673a8680f216d1f42a27133149580121aa7a5fb1
+# Tag = 988accdd465c765577e75ff2260c3e49f284167fd69c5186
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = a1b1c3ffd499c254a5bee4a76cbaf97704313416f65ae2
+# Tag = 7afaf111746e780b506d44b33add8a751e12b98014a7a435cfea6f177f948090
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 34683ae09324615ef0906383f0d16e92bf1cb014cd20b6b89aaf08eb7baf8ed6d3bc2c652f0d76
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 1380cf8b141c4d963ef828e78408175b2d953cdcbd516bc0041ea72cc84b4bcc0e5872740fd109
+# Tag = ffe1556d350320c8
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = d939d5d3480fee44af7820f191672ba35a511337bc35803ec4d90614a03f43b04444f390e5386d
+# Tag = bef4c1380e02d5c5753341aa8d8f6503
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 03aa9d6f2281c3b20dd65971e1adeac9585c3773d01ffedefa6287b8ce2f52c942d3a93802cc04
+# Tag = 3c1b3d5590e5a3c33a6b3bc0d091326e8e88019ed7d5c6ad
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 49ac6419f4ef6b26f5cff2dbf11406e6858e7011fcc70699aa1940a32fcbfe6a8313ac60f967b8
+# Tag = 756382a6e872816b0f295cc158b46fd45ac866ab6d5c37c660f7dfcad6837b8f
+#
+# AAD = 44d566f78819aa3b
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 4cdd6eff9021b243
+# Plaintext =
+# Ciphertext =
+# Tag = d4cbc9de27a6154c
+#
+# AAD = 54e576079829ba4b
+# Plaintext =
+# Ciphertext =
+# Tag = 98d045e1554034b3a620dfe161b0aeda
+#
+# AAD = 5ced7e0fa031c253
+# Plaintext =
+# Ciphertext =
+# Tag = e4fb2e680f9100f5aa3d1e21539455b88e2ad764dfd193d2
+#
+# AAD = 64f58617a839ca5b
+# Plaintext =
+# Ciphertext =
+# Tag = 853fabde6e03c789c34220a1db5e6a1ede37a288ebf9f7e5cb1f30a6787fbb01
+#
+# AAD = 58e97a0b9c2dbe4f
+# Plaintext = f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+# Ciphertext = d7c105c648c7404455565dc70a152fce178df003
+# Tag =
+#
+# AAD = 60f18213a435c657
+# Plaintext = fd1e9ebf3f60e00181a22243c3e464850526a6c7
+# Ciphertext = 4d242dc2c9906b5a9eba26e52c6fc5bd1b672e59
+# Tag = 8e09d34b6a43ddf6
+#
+# AAD = 68f98a1bac3dce5f
+# Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+# Ciphertext = d70715db40b4fd2b9f7a83a0282494c800eced32
+# Tag = 038d52118bc684845ad1d4b85a58c5b0
+#
+# AAD = 70019223b445d667
+# Plaintext = 0d2eaecf4f70f01191b23253d3f474951536b6d7
+# Ciphertext = b320a8716e319e1e1926358bc21a45309672d855
+# Tag = aac3ad393ae9d07f501f4f5aca0ab241229ab23a05abe192
+#
+# AAD = 78099a2bbc4dde6f
+# Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf
+# Ciphertext = 99241490f501912a1c0dbdad235a79c44be4be6a
+# Tag = 59d5bf769cf478f73403131df332c0306d2097b44e6378ba9ebf8538e6063e42
+#
+# AAD = 76079829ba4bdc6d
+# Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+# Ciphertext = f3c20d15ef7e567d57f752eb5200ce03e8129bb48eb2ef86977202aa93a13521e38a125a7bceb44ecb917c0d0514d9b41606
+# Tag =
+#
+# AAD = 7e0fa031c253e475
+# Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+# Ciphertext = 8cd40273030403c0dafc16aaf0b0fdbbe102e7daf2f45a6724c15da2a2fd7edc63a33c9d2385a92fd8d2ea44a5cc6f1b72e4
+# Tag = 80eafad1d8d511c8
+#
+# AAD = 8617a839ca5bec7d
+# Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
+# Ciphertext = 7a33848c68719ab9c53836ab563d02dfe189659b0256ea2780b7e99ce9cf6796b664e793a62c48e22ee4ac12d708564df19c
+# Tag = 6870d98201dd8b56b0f664ee6654e7e4
+#
+# AAD = 8e1fb041d263f485
+# Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+# Ciphertext = 019dc26ab6b3eae9ec11c27bdd31e3d5b360020ba8d757736172255e2be3ad1570b3727e4df72ddff734195288a1937b9af2
+# Tag = bdfce6e6a3a490045631e968568dfdde1f3338ab451a0bd7
+#
+# AAD = 9627b849da6bfc8d
+# Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+# Ciphertext = c84992d6c75ecd6fee704dfd979cd2da9bc6abfb9072a95abe7838a581f31b877fa51ecd4ef9bc3a4deb905cfeed235ee16d
+# Tag = a3c89806315c72e98f9334a4ee2c6fce15d34f63be8c5bad3aee667c71664c28
+#
+# AAD = 9829ba4bdc6dfe8f20b142d364f586170798
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa0
+# Plaintext =
+# Ciphertext =
+# Tag = a050ed631a89113a
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a8
+# Plaintext =
+# Ciphertext =
+# Tag = f96c121333e8fc4f335ab8a314f96728
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb0
+# Plaintext =
+# Ciphertext =
+# Tag = 89a522680aa3bbdff515cdf93579022524dd2080bc8aa3db
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b8
+# Plaintext =
+# Ciphertext =
+# Tag = c864688687dad46b9b99a5d5f0b2135084626b2f05dcb71d2c6f56d509389c62
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b6
+# Plaintext = 5374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142
+# Ciphertext = d44658a4a2cd6366ecb1c4e04924e84a49bd8b8d0b26056e7540f4f7d6f1
+# Tag =
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe
+# Plaintext = 5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294a
+# Ciphertext = 16818be085451184f92f36b0d114f9111fd62a8d11f19d008b2de739d821
+# Tag = 8ddfff945931ecdf
+#
+# AAD = c657e8790a9b2cbd4edf70019223b44535c6
+# Plaintext = 63840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152
+# Ciphertext = 544a70ddad580d60775f28ad8222aac9f58dbe8756639e0a59a7bab71eb8
+# Tag = 8a0e5231c54177cbff7989a5872267d5
+#
+# AAD = ce5ff08112a334c556e778099a2bbc4d3dce
+# Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395a
+# Ciphertext = d7191eec553563a315c5363bc2363b2e0aa7160ee1294c4e7c1178cce2e9
+# Tag = ce7e1520f9b8df4502ccfcf4f7f53c13334730449c67188e
+#
+# AAD = d667f8891aab3ccd5eef8011a233c45545d6
+# Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162
+# Ciphertext = f10fbb509106acbb6ea55312321d637a7925b4e79835c19051fb65b74f40
+# Tag = 2e65b558be2522d8135be4ff5efb1d1976ac53cb9abfcb9b21ac9b74a287f7cd
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da6bfc8d1eaf40d162
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e273049526b748d96a
+# Plaintext =
+# Ciphertext =
+# Tag = 137dfe109d6521fb
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+# Plaintext =
+# Ciphertext =
+# Tag = cb4dc877ede36c141507e54a5ebcc047
+#
+# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a
+# Plaintext =
+# Ciphertext =
+# Tag = 76611c16527fad7ec998d73eded502eee0e5507778d5247c
+#
+# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f182
+# Plaintext =
+# Ciphertext =
+# Tag = c96faa794fb616f847f1acd2ba64d44896141bdec8c56f21ee318442d9e1c13a
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253e475069728b94adb6cfd8e
+# Plaintext = 3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+# Ciphertext = fec3f18d0b6cfd45224f34eeb9527098600fb86eafff33e3070b446e8b387855a4dfd09a69c7bd7120daa485
+# Tag =
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5bec7d0e9f30c152e3740596
+# Plaintext = 4566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+# Ciphertext = a87f405dc5e3fe873c4b6538553c039229f7a9b0f84d3a7b693328a1e9bbff0358f65da28bb8c98a76bb7ab5
+# Tag = c309df12f27d26e8
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263f48516a738c95aeb7c0d9e
+# Plaintext = 4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+# Ciphertext = 395aa1723397da50e450b4fd58ab6fdebb1155bb07e70c1cae823ca07b5e048200dca29049131313329cbbc6
+# Tag = 4958058cffc9277fa3a52bcf2781ef45
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40d162f38415a6
+# Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+# Ciphertext = 7dd3cf99686d7e2683724d94abaf82acda420e8ba67d574043d4811e908884beb6b977ae6eab035615d9a94b
+# Tag = b9a4c65390873f8ba320d10f88552164c4d18bea7c4410cd
+#
+# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273049526b748d96afb8c1dae
+# Plaintext = 5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b3
+# Ciphertext = 0b27077bf9064bf7f0520c626d67138afaf95c57738bfd698adb189274550adce43ab44fb674e98139e5b815
+# Tag = b5eae367c79ea867419282a8855a830e034f1f23b07d6aa7ceebf5b1da05016b
+#
+# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf60f18213a43525b6
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe071029324b546d768f98a1bac3d2dbe
+# Plaintext =
+# Ciphertext =
+# Tag = 222b0ea9432f7bad
+#
+# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
+# Plaintext =
+# Ciphertext =
+# Tag = a25dfabe677eff1d92a5e646b1b0c458
+#
+# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2bbc4d3dce
+# Plaintext =
+# Ciphertext =
+# Tag = 6ad8cc9f8f9a9cb666654d1d6bef0d63002eed997e8c4f78
+#
+# AAD = f8891aab3ccd5eef8011a233c455e67767f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233c45545d6
+# Plaintext =
+# Ciphertext =
+# Tag = 538b3bea41ea3f75fd7bdd6a68bfb76ce1d625ee536a73b7625078e6924cac5a
+#
+# # initialize with key of 128 bits, nonce of 24 bits:
+# Key = b24be47d16af48e17a13ac45de7710a9
+# Nonce = 3394f5561677d839f95abb1cdc3d9effbf2081e2a20364c585e647a868c92a8b4bac0d6e2e8ff0511172d334f455b617d73899faba1b7cdd9dfe5fc080e142a363c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d3
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = bdbce20db9fe79a8
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = c7f1baa2405cc76169ab747062d3dd52
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 743d337e170c68cf27246cbfbd53943a29273496ddf0cfcb
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 7b10a954a16a25b93508964ac028870c634ebed9ba9eca39edf9e3378dd4e0a0
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = e01d5bd189
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 6074a98c57
+# Tag = d1ff44ac6d477915
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = f7e8f19c62
+# Tag = 734dd473d536cccff76e8dfc1e9e3766
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 12a1fa7a14
+# Tag = 96960af729c81b2c7a1546bf349e3b66b2aa5916b9d2f2fe
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 84e36030bc
+# Tag = 6b9d78cca4b76ec7fa5f6f0eb09bf89d20ba33caae45e6d50afcd8814830049b
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 2c88621a3ac28f956e22830a
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 47cd485c13fa0ea09a942534
+# Tag = f766d1395124e695
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 2cb1d13b97f79810b9a7f227
+# Tag = 950553e726684b100f8238a569626fe0
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 88915058c7daaa04db6726d4
+# Tag = e1d37ec52e061970f03817185a9cc4d402703151b4c8ca36
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 6e0d7f25249c2715793b6aed
+# Tag = cc1a053bebff9d6d91c828fd27224ddb718d64e6c42d34fdeb23c290a1a3388c
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = ae82aea99f30f3dabeeaec752971e746b6ba1d35160ab0
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 531d1e030b3f29148aa2b41acac16d3b1449782bb4ebe6
+# Tag = 0df035115e562537
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 136512db5a7d854652afb993ad1237c1b5adc7b83c5337
+# Tag = 28066c90cc3ebfa316716c22709fe78b
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = afb90feda3f1ff98b9ced13c683590fe14701e7be3de40
+# Tag = e85b82eeb5c2d752be6e7451469df2826e4a468717d1586d
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = d8c4ad37ffe7daf4854408c4d2c39774b7b11b453f007c
+# Tag = 550a785575c57eec8207a11d29a90d6042173877db27eaafccf334794bd88af0
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 39d88312d19d07958127daebeb10bd2d8f4164b3dd2462fa321131061156bb6c67b0cecc5ae8d1
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 92a2cef0b6221953303776d81788869f6e5bf2a4c442b42540c2adef715fec68c5730666e35fcc
+# Tag = 1ee32242ffd6cdba
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = f9cd7bcdc5e83d2a296064b1d9ff9c3f6bc8fb59aa7c096edbfdc6cff89d38e6f7d478b08a6234
+# Tag = 16b5735a3cba93ee2ca816b72f9f47f4
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 8e6a7626d99704015fbb61f36245eda1034a786f37f620cecd883139e65492035e2a08ebc790a0
+# Tag = ed81fd3de45fef135bc05c92856d4c2125172dce71d06c71
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 557379c1555a0a0915a6f64fc9327bfea7f5a4bbbd5c893a1d53d2dbdfe31157c4cfbdfbedd3c9
+# Tag = ef77368c65d0d73f0d6d4a98050a874c6286d5337e40ac29f1d05c75412050f5
+#
+# AAD = e67708992abb4cdd6e
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = ee7f10a132c354e576
+# Plaintext =
+# Ciphertext =
+# Tag = 4beb07036c1070fc
+#
+# AAD = f68718a93acb5ced7e
+# Plaintext =
+# Ciphertext =
+# Tag = 60705c79629b4341b7ec756efcc09b48
+#
+# AAD = fe8f20b142d364f586
+# Plaintext =
+# Ciphertext =
+# Tag = be5b3fa772986bce240f73e2fb0d0eabf0ad1c17fa66a300
+#
+# AAD = 069728b94adb6cfd8e
+# Plaintext =
+# Ciphertext =
+# Tag = 33ffd04548cf5dcff995921df46bc3537a78f8bdcd00562951e18a84dfe28cd2
+#
+# AAD = fc8d1eaf40d162f384
+# Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
+# Ciphertext = c64f502a9058dc5ffe1e9cf6249c1bb45c4a9dd3f042
+# Tag =
+#
+# AAD = 049526b748d96afb8c
+# Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
+# Ciphertext = faf271a278aec77e12c24e0b2a98309c204e4dbb2084
+# Tag = 79f8c81ec8956b18
+#
+# AAD = 0c9d2ebf50e1720394
+# Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
+# Ciphertext = aef22a36547824a0663730c2f55380b2a861e643e5d3
+# Tag = 39f653c362aaa546fb38452e48f1a628
+#
+# AAD = 14a536c758e97a0b9c
+# Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
+# Ciphertext = e61af45db7132c9e38f2b37c8027d69f004317bde39f
+# Tag = 7e66ff46cdc4e75528c47dc842a886e24faa15327ad553c4
+#
+# AAD = 1cad3ecf60f18213a4
+# Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
+# Ciphertext = e102a8fc25a8a399baa6d2b1af052ac079a998b0ac00
+# Tag = 267514b85221bcda642fc26ccaaa8d43a92992bf9fca9e10630f20fae6007ef7
+#
+# AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
+# Plaintext =
+# Ciphertext =
+# Tag = f2c6d2e0cfcf89ee
+#
+# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+# Plaintext =
+# Ciphertext =
+# Tag = 138bd6a251f432a424df778759eb11d4
+#
+# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
+# Plaintext =
+# Ciphertext =
+# Tag = e2e1c97b1b77849c1bef54172d2c4e5be11a38c6c8a4c6e4
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
+# Plaintext =
+# Ciphertext =
+# Tag = 85ad61699473787bfa4035fb57da783cf7cae00aac873729047a1147e2a91057
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
+# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
+# Ciphertext = 2ca7106cc0c15a64c7d1722d4b9c37d5a12514abef3c389aaab699d1805223152829
+# Tag =
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
+# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
+# Ciphertext = 2a99e10c4fc0367bbcfaf0dcf6c476f19cbc587d4edd51f1cefc6e9f2aef335f0dde
+# Tag = 2bf57212d307c0e1
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
+# Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
+# Ciphertext = 05dcd8d5dac17a99ee9376627805e294ebda5560b7889a62b3cd1c7c0b8bd8f7545e
+# Tag = 01f0578f966d45052fcb37685e02dda5
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
+# Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
+# Ciphertext = 5997890a7da21ecf3a63312aa0e37a5d5be515c13f3ef117b323d76107b97ee8c1b2
+# Tag = 348a8c138d1471fa31489fb0fa68f63bcbdcdde5612e21dc
+#
+# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
+# Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
+# Ciphertext = f8be750fbee8c0eb5717463bebdd241d307377d243c2f592e48a3b97fb8b94bcd709
+# Tag = 15799d0c81a2f265693704e06dca53b0a4bff1a4d6a1c571c55381bb35ca27af
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
+# Plaintext =
+# Ciphertext =
+# Tag = a21749f034c39f75
+#
+# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+# Plaintext =
+# Ciphertext =
+# Tag = db2f973194f73b96ec8a1c37ad94b161
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
+# Plaintext =
+# Ciphertext =
+# Tag = 90a3dbcc7ba07e13bd5d43143bc3c42bd6022a853965c8ee
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
+# Plaintext =
+# Ciphertext =
+# Tag = 4dc660eb6667d5a7d32f91253c05bc3c8c20e120905c1aa1ac9a4e05ec4e23ff
+#
+# AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
+# Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
+# Ciphertext = e0e011fc88919158bc5ba297d2d69e30d35ca7533afd4fecee86c06ef80797205eafec7398652cb0cf721136645a03c159be
+# Tag =
+#
+# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
+# Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
+# Ciphertext = 7ea2af78b36c8d36bce0a75cc7941a807d165b6b4cbf0a0c5524969dc4dec71aaadc846d9e4ab97565176727bbe68eb07978
+# Tag = 1a169dc37b4052ca
+#
+# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
+# Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
+# Ciphertext = f3307f681f22d6530e62a92632509e008bc9bb59d771792e02785550366bb32ed173bbd348831d6239a198c8a65bc6508464
+# Tag = c03b862ba790674d2cf3bcf71db8ee0d
+#
+# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
+# Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
+# Ciphertext = a89c2578c38f7a5e2bae8100c4bfa3f09f20b8a846326505cd2f0c41efe5335a5bf87e4b106bd391f0c41ee93b7c162414ec
+# Tag = 3866d89ad71141f60f6546326ccf83d77924f55ed33b058b
+#
+# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
+# Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
+# Ciphertext = 8834f3a02194ed0689b3bfe23e72c02eab4a28e076b56cb81915e3b312edb3b357a3823fbe5ed0628705e97b6ea529310c8a
+# Tag = 672db0d83ef3d5cc0529ca8b8a69dcf6d2cbe55991c0d620bb6f8df4cdc50de4
+#
+# # initialize with key of 128 bits, nonce of 88 bits:
+# Key = ba53ec851eb750e9821bb44de67f18b1
+# Nonce = 43a405662687e849096acb2cec4dae0fcf3091f2b21374d595f657b878d93a9b5bbc1d7e3e9f00612182e3440465c627e748a90aca2b8cedad0e6fd090f152b373d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a9
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 5bbe3056efe78b59
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = ed7da3d5ffd6868f7d9a3cad5c3b6b55
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = a94245bc152a147026b8eb7bf5066af7e1e409fcf6c22def
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = b8164d98bab7b47b09298e8a8633cb1cb13f2cd6fb57fe8454a11da2db6178e2
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 07a580412d
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = e793ce0085
+# Tag = bcbec78e33261609
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 9e9c6bc8d5
+# Tag = 216140c258aba5d8e0bd72eb9beec13e
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 2d7683521e
+# Tag = 2f2af547d8a19e09fbd51a985767762dc7bce29215be4d1b
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = a5f2661398
+# Tag = dd13b57e10d0e98856f364f2dc30c0a2327285255ede29a303f48652b31e8267
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 269743ac4cf7f0d1aa4f93a2
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = a0799d6e77db87e10658a786
+# Tag = 72dc49e879329f62
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = bfda08ab5dd7d14c5163d470
+# Tag = 0d9a8763ac660bf9de839dff7b9d3398
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = c8847fc0a34aa04a103217e6
+# Tag = c681993c0d49730137336345b1ac2dd4d58bdcc1a5bf12d7
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = cd97b35faca4f1daad4f6896
+# Tag = ea17eb1c1eb5a2a5da513ac7602631c97dbf6b23d756f93a496709d3044fa40e
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 0bb56c27b5c8d32ca0036b7f57bbf2957fd9f01e22a9f5
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 688bba1a6d69232d81bc1e9fc992a4a55150eec153bada
+# Tag = ee467925b566d73e
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = f30ef0c0616a1d81c1608a6873bac0243eb2663a38c1c5
+# Tag = ab6af91057e62599839ce4d36b334baf
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = c00a848cd7cea2c0fabee782024c34638e835fb6a3eed0
+# Tag = ea321116285549481a2303ced86324c8a184467e824d6ab3
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = a87561ac9f6aa6ea791534ef539c26fdcd22dc4b1f91f7
+# Tag = d715b1ccc20839453234d457612b7d087b7f2ac07ae18c171a060bf8a48d2625
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = a56636080ced6a50b0b915efc4d0ca64b9254124df777c369f086751ac2aba3bb0dae2728023ed
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = bbdf44719865d90c05be25c1877677c79bba171318dbcaf8f1b15b48e5360be53ebc90b35ea1b5
+# Tag = ef1f34dc2b68f29c
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = d8692ad92b2785e8d36823d714b8fad20aed565fc0b7376b0a6a7513caed0f76bdf0ebed6f7593
+# Tag = 0f55c7239cd881080c6db1e612c65e6e
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = a043abe2d7ccbf7681fea974973a37aa3f9c6e3c3511f9f3686dd4133d241fd2403df63024cd19
+# Tag = 74dcd4e892b0c494c951469b0b42c354c1843c2ce3a66751
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = d7d3dfa9268f8d52cffc767b2e9a78e5bd7e748da40a8d7b16557cd068aabfbcb00d60bca11548
+# Tag = d902359213d8d8ceeca677c6cb357e97904c7657f1c6ca5155a7c44ec6b0a149
+#
+# AAD = e67708992abb4cdd6e
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = ee7f10a132c354e576
+# Plaintext =
+# Ciphertext =
+# Tag = 62fcb1d60a5dbaa5
+#
+# AAD = f68718a93acb5ced7e
+# Plaintext =
+# Ciphertext =
+# Tag = 7b069886bee6e7c81cbcff423dcb7e13
+#
+# AAD = fe8f20b142d364f586
+# Plaintext =
+# Ciphertext =
+# Tag = 2e3e1e4291edc62170ab007d49f68bc43204a11bb2948d2f
+#
+# AAD = 069728b94adb6cfd8e
+# Plaintext =
+# Ciphertext =
+# Tag = eb845cde9358d437940946696a61e7a576424ec98a09e64f7985a2b3964fb89c
+#
+# AAD = fc8d1eaf40d162f384
+# Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
+# Ciphertext = ed50d186af626a4288611de1acf231ba0232ec228d8c
+# Tag =
+#
+# AAD = 049526b748d96afb8c
+# Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
+# Ciphertext = 2e332dbd08e1b4de6c55eef7553318c3f0e4f755d15c
+# Tag = 933749bbc1d83999
+#
+# AAD = 0c9d2ebf50e1720394
+# Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
+# Ciphertext = 725f172a062767ff798fe159116dfd303d4eb12c8ec0
+# Tag = 2df742b6eacbe6b27d177540897e5f54
+#
+# AAD = 14a536c758e97a0b9c
+# Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
+# Ciphertext = f957546d247f21669c0db13b57c7d44443455b5b1032
+# Tag = cfe7ecadaaf689f0666bda2389c32983da2facbdb1760e42
+#
+# AAD = 1cad3ecf60f18213a4
+# Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
+# Ciphertext = 0643058ece0d14584f26051441883d0c7e3fd970a501
+# Tag = ecf55c6d2c4417e44e50ab925f9b3fdd253d69f593d2047278a10a1a23639185
+#
+# AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
+# Plaintext =
+# Ciphertext =
+# Tag = a3f593c9d2a3b91f
+#
+# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+# Plaintext =
+# Ciphertext =
+# Tag = dd5e060ba931c23e309801a3bca036b4
+#
+# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
+# Plaintext =
+# Ciphertext =
+# Tag = 7508eb13a3a94d73c5898c3361a7ae4c273617e38dd11043
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
+# Plaintext =
+# Ciphertext =
+# Tag = 07aaa7a8f84fdc883a250c76eb82e150f521c85ff0edd12e640373ec0f0242e6
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
+# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
+# Ciphertext = 47928f22b49a1554a20f4318d3b45207ac0ee00d39d25eb52ff57053ee5b000f3581
+# Tag =
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
+# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
+# Ciphertext = 57792857a74446fa6a38064a457e18b045b535728b6be44208652de434b33e3d94a9
+# Tag = cdec92c126180a28
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
+# Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
+# Ciphertext = 7c5552d22338e0dbf677027f011a3a4b5ca1bc67753c4bf0f1914e7c7bd39f5639da
+# Tag = 5aa60294d511f088a80beb51d0c91f33
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
+# Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
+# Ciphertext = 5c8c3cf39b0ca57368dc7556b97bf705b89588007d0e183f7ef81266e23b9aa8b182
+# Tag = 5c873087ec32d8d4099dd7ae862bdfdcb2e188c673ae94d1
+#
+# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
+# Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
+# Ciphertext = 2a92e33b4930951081d812808c7e583ed7efa3fad0d141000cdea6994f504099f644
+# Tag = 915ba59578f73b3c27aa15b513dd304323d9b81a677e070c0ce8b1683199b55e
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
+# Plaintext =
+# Ciphertext =
+# Tag = 85132ebdb8bdea65
+#
+# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+# Plaintext =
+# Ciphertext =
+# Tag = 5d7affbceb3a6581169e25281e611e0b
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
+# Plaintext =
+# Ciphertext =
+# Tag = 3966b563ef3ddf934e720cd7805f6c7a55d1d7892b428339
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
+# Plaintext =
+# Ciphertext =
+# Tag = d15476bb9718f32a3973b7a42823ef927bb0f6df6ca8b6bf7d0779ca4f0b19f4
+#
+# AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
+# Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
+# Ciphertext = 9f1ef776f07a9385566e60d077c5a2e5d6021a274eb5742c409cf5e6ee954c8d6e7ff6b86ff3a40963d7f0903737b1209ea7
+# Tag =
+#
+# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
+# Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
+# Ciphertext = 7a37ced5c11949c21bfa00d538baaa564be45eaebc36ee5e3715f20e92de7c68146cf8a28a2774bfdadb584bfe0c8882dc66
+# Tag = bb588f119584c10c
+#
+# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
+# Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
+# Ciphertext = ab941f07a782b76db1a95bbf23dddaa6a1e3173d6710a816416ac1060afe9b76f20f644b7cf331076bd8ff6b499a24d83bc9
+# Tag = bb595cd2c7d12087961d2ede496f9aa0
+#
+# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
+# Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
+# Ciphertext = db101d928228e17d2c05fb665a870b0bfa1e8979915909982198ce735b4d3cfd01dcc4518919e27b299ba13948152303dcac
+# Tag = 4b91278ae197b6dd7cca31e6b472966f18d85a1ffee5cb3a
+#
+# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
+# Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
+# Ciphertext = 074816336911211a675a6d3c8ee33e920326ca0c8d8133ea7a39e5c0a488c783967ef4240266559e9ae05f1ddca21c402278
+# Tag = 68600a63c443e63f31e81620a26f45b550d96b1e16715edfa36620f015df38a5
+#
+# # initialize with key of 128 bits, nonce of 52 bits:
+# Key = c25bf48d26bf58f18a23bc55ee8720b9
+# Nonce = 53b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667c888e94aab6bcc2d8e4eaf10713192f3541475d637f758b91ada3b9cfdbd1e7fe0a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = c9a77131beff6ea7
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 9235945ffab4e4030ff097e5b7960b98
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 55d6d886a9baf3b9cd2f65d3dc9ff7acb9274ecf08a3c83f
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 4b53f16c4456450a9cf7450b12ca82053331877d0ad3e7c624054c2bd45cf5b6
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 222709e208
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 3ba37b69ee
+# Tag = 87defada8cb651cc
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = b5002b428f
+# Tag = db97c666231642eb6be759fbc27a9814
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = f95e5aa38e
+# Tag = bae6356f3fda549e737876dd31094f263d2d7b1e7c8a2e68
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 9148a865ee
+# Tag = a14f5efbb50dc9f253fcd127ab90b1ae1e098b1543cf77b5592a5091b5e6c755
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = b879eab819bcfc92e8608df2
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 57ca5bbea4c3aa923a609ac9
+# Tag = 27a3373e39618d4a
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 4a1d241d295976b22e24614d
+# Tag = 8e2a78933156c3e3cd843496311989a2
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 4622f684646c6a8453702837
+# Tag = 300d6c8315511e2be3730faf8ecc69fe1dc18280b29870b5
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = c0816f3687e8ad56ea95797d
+# Tag = 4a48951f37e87f8b530ecb926148a6fff0142dd0442aaf92599eb44e3c9ecd7a
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 873eac1a9cfab77ece9e43d51c694829e09da4c20caf4f
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 9d377d7bced80845f9a14bd4260e18c2f01f2f0dc211ad
+# Tag = b451f4acc3bffd14
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = ae1df422e36779cc059e422151bfb28f8d03ae717386c2
+# Tag = c5861f19540a191c889720a800d26d68
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = b8107dc9ec704d9974f85219bec7c0fa896c01003f3c6f
+# Tag = 54f8e8f8f0fc17350b6525531588901d3151bf8a13298372
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = cdf15ad1b8160a13591f6259e7c4ee0e6cd188fe6bb103
+# Tag = f9fef1835eac3a788b4569213110a5ebc1aa1e87421b67ca3340d5c71b577250
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 5748248becbd75c146f0c1bb1af11dd56ba5a93225c9be3e34b8a97680b345e5914bef37cd1818
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = af34fd3b0caf844f90d40c8037c8f8e562bdd564e7d9f2bf94c1c4b1ddb11cfe0b346a811ea8b9
+# Tag = 174c21811c38a679
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = f79e39c562ee1dfd145d5b3bda18e8d858e6c9c2a63a7f880162671f751351fb77b4ac54eb4e5c
+# Tag = 9c93f5a15f8bb51d2d7fae0a4f1d3302
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 4d3083b3a6e04c71636c14c6f5ca90d9a3c86cbfda560c9ecf685c6126388c5b18ae8e65aab1da
+# Tag = 4a06586df0e039c966179425e83618f0413c069887642985
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = e30281295f04cdc45237f4e93da99e8285994dfcbdbbc0f3e5fbae14a598a60e89036b5d7462d7
+# Tag = 27ed3ef9a0c80cf0e5080df20f15a25e8de17bfed05f3d6f43e2e462da0b145d
+#
+# AAD = e67708992abb4cdd6e
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = ee7f10a132c354e576
+# Plaintext =
+# Ciphertext =
+# Tag = 74a5d9cc59bb17ee
+#
+# AAD = f68718a93acb5ced7e
+# Plaintext =
+# Ciphertext =
+# Tag = 3975be9d7123ea8dd17b09f50f4d0d62
+#
+# AAD = fe8f20b142d364f586
+# Plaintext =
+# Ciphertext =
+# Tag = 722b9ae37a84d94ad3dfd416b28e8a78c675d5b251ae1833
+#
+# AAD = 069728b94adb6cfd8e
+# Plaintext =
+# Ciphertext =
+# Tag = 8c884c7633c8d662d099509820a4b09a2b6e506da14a8b27c41587dc1b70185d
+#
+# AAD = fc8d1eaf40d162f384
+# Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
+# Ciphertext = 23957669f2d84da158e015d6e7f3e7c7ee6e049c489f
+# Tag =
+#
+# AAD = 049526b748d96afb8c
+# Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
+# Ciphertext = e0d8bd2afca001c0944812bfb68e7ea0b3af9b2c4a64
+# Tag = b4a614c46f6e115e
+#
+# AAD = 0c9d2ebf50e1720394
+# Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
+# Ciphertext = 0c50d4090d15e45ad328314e68164ae21c0cfae97655
+# Tag = 0543e9fe561c7d52414c8d315a30cdd2
+#
+# AAD = 14a536c758e97a0b9c
+# Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
+# Ciphertext = 393d855318676fc5e77574c3216e76cacbd404b8894b
+# Tag = 52b3bdedc69d5f77a2209ab85afd486b4c229fa329519718
+#
+# AAD = 1cad3ecf60f18213a4
+# Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
+# Ciphertext = 9d0e41199c3d4157a1482467032be52685704b594ffe
+# Tag = 8499312b60d67a702f4759a54545520a4de912183eb557f71e7ce141227c4905
+#
+# AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
+# Plaintext =
+# Ciphertext =
+# Tag = 68b9e8d52661950a
+#
+# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+# Plaintext =
+# Ciphertext =
+# Tag = e5c611444a6e35e0560bf2871f3d3fb9
+#
+# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
+# Plaintext =
+# Ciphertext =
+# Tag = d87ca71c9f321cc153a45d5c9a7f70dca7b0af7e841a8223
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
+# Plaintext =
+# Ciphertext =
+# Tag = 9411cce7aea1ff835cbd1c9e6285fd3273b96c2d6d364900718211d17205ee33
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
+# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
+# Ciphertext = 0a325a9febf9404fb77721d17555711235ec6291f5ffdb4fb820b3666ad385070165
+# Tag =
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
+# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
+# Ciphertext = 9bcb7ad754e25334906f43d59b1f72f0b21a1aa995234e2732f79435236c08358a24
+# Tag = be8ca69bff1e8910
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
+# Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
+# Ciphertext = 6cddc150af6c838bb729e026a52b145a6980bea5fc9b8d6d4599e6ade94ce9ce1e4a
+# Tag = 3db9ec1add8ae7a4c0fee46723a1cf41
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
+# Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
+# Ciphertext = af5083b8298ace4b7ac0f8859ce9d57699c70c2bec9a11573f048e1e6b9bfe7e68c3
+# Tag = c724d993f596bb70ac0c8939c9e29b9ebf846c431c57c32d
+#
+# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
+# Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
+# Ciphertext = 3c615844cce28a3f7877918ee72527cd6396c4b3eae7928f5c92aec0499c18eb4cdc
+# Tag = 615ff0b9443cfeeb0cd498b721e5033d000a1531f08de1ab8cb03005832250cd
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
+# Plaintext =
+# Ciphertext =
+# Tag = eed1b155e68437a0
+#
+# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+# Plaintext =
+# Ciphertext =
+# Tag = 67a5d4b9bec0540bbe8a3720c6024ab5
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
+# Plaintext =
+# Ciphertext =
+# Tag = a9e072fb57e305b1a211b0a5101dfeea4a56169de658c354
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
+# Plaintext =
+# Ciphertext =
+# Tag = 1c90e975764944b8cba925e5bc58de0581147b0aafc1548d08313684103fc680
+#
+# AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
+# Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
+# Ciphertext = 534438da447e2067c10340725bdc1e2e773e6e0b487c1e0ac5852d1c3a2df02687901d60bdfbf4983430be2fa1fc85dcd6b3
+# Tag =
+#
+# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
+# Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
+# Ciphertext = 5cede84d7c78573f236e504e0a38ffb033ea79c7c76c1229eb1fb26cfb29f70a35c32484841761818cb27cf37a73d78f619a
+# Tag = f0d49d5c236bdf4d
+#
+# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
+# Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
+# Ciphertext = 58f46a195008e8e657b53a13506f77a2c2be03932e7a461445fba5e24bc4ab36465732984c050d39315c678cba25bf7e4ada
+# Tag = 9831743efc823d4d119bdee88bdd6bf4
+#
+# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
+# Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
+# Ciphertext = 12cb6d3c66cdf9dbb87c1e0fcb89920b2950250904cc6ce187bb34be2f64fdd3549a4ec5bdd12d9c6e73e87d1538aa77ff3b
+# Tag = ddbd7755bdc22506cf64289dbeea8945c1d210b5f1df8315
+#
+# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
+# Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
+# Ciphertext = 2bd818fddb47a0d60451f549ce2a36bac008fe540f7a7186e5442e844a31489c45734517cf9df09e68558e2a407a80b908d5
+# Tag = dd63d9aad646d28a3834ab612fdf1fc7775c106c356b553edd620a4d107d53b4
+#
+# # initialize with key of 128 bits, nonce of 16 bits:
+# Key = ca63fc952ec760f9922bc45df68f28c1
+# Nonce = 63c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f455
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 517bb6750ce74e15
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 59312e6b1ac7bab102f8975afb25c813
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = d113d78cd4ad33a9987db82d8dd242fa87fc8079c96327fd
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = a1adf0802c5742f0b7b38d90d684999803eaae0a987872f0bc1db05fb5a6008b
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = 406a50ec18
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = c1ec06af92
+# Tag = 77241593b9e227ef
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 055a7d510b
+# Tag = 922579428985e00056bbcd27aa3012ea
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = d3e978f92c
+# Tag = b00142b26b25d9065665d6371e4bff62e0cde518eb06c57e
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 69fe677600
+# Tag = 5b564585d25890205d043ec60162df08e366034af08c3be85cf050bfb1f6d593
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = c2e64d2ee371edf2c8d6fc47
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 79dbe5c178fa67f678e4bf12
+# Tag = 100ac8ed1f77d7b9
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 002cb53f326513a7ac61373a
+# Tag = f48fc9b6b2192827b91c87495bcbfede
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = f7b84c6c90475491295eafbf
+# Tag = 867e6638940ee876766fa0947fcab5fc99f14265e90bd219
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 5d474b2604b76a5e34015aa3
+# Tag = 6f8fc2fde9d151cd9527690702544e8a9788369e96c107a4218668f066acc469
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 9c28aadfd9331ce6a532090710853008fd21c2d1c402d7
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 703d1e5f851b5071806f0420dac7f1424b872f047695bf
+# Tag = f23cb900812a070d
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 9ceb2b3c8e3678c7ebe4a24e7c24e1a0170739d6005e3f
+# Tag = 22fc398d90276fe1fc361107718e821f
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 1bfad283fb9446d812502e18e3e900407476767fdd5e1a
+# Tag = 58bbac8653ba83689cd384b5f6eaeca7cd99b8add19638cc
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = f05d75bbda5ccb9400713542632c0e55d4c3f9834f1b35
+# Tag = 2b688af20f0959a56827c71cfa79fc91637a8685527bd0fe457d29dbed10fc3e
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 9745ca96e4ed5903c05b777cd9ed7d3a044d223e5fd6d41db1e48e58e777b9777e8815b082fabb
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 2a08e9d06d24c2db032bc5e23c0859a8a952d2029bb4ef53580fc77eebad3d0df45f4df42dbc17
+# Tag = 6c58ec36d9d3bbe5
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = f126ff4a2d42b416cc5824b6c96b0e2f0b901f1b7b4045c34454b2d22228e7faa97eeb82c29f19
+# Tag = 914b37985c69622c0a75ffcf0dcba59b
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 74df1108ad8fb37da0858e5ab4bc5752fd06fc9304c1491bb3a04de9a71df622b491a09311f776
+# Tag = c6466f39cb8007570423fbebb6e31676cbd947093acd188f
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 61e1a6d20ed860d8bd787240a2622e974f8a0f003dd09357eb31f29730a6237f5e6dc0fd56785d
+# Tag = 4a2f704dab65a3640eee4efaba60072e22ab71288c422acc303b6612871b52c5
+#
+# AAD = e67708992abb4cdd6e
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = ee7f10a132c354e576
+# Plaintext =
+# Ciphertext =
+# Tag = 963b8f1b4c4ba956
+#
+# AAD = f68718a93acb5ced7e
+# Plaintext =
+# Ciphertext =
+# Tag = baab6945f8dee5d1a1cb7ecc5a5bfc3a
+#
+# AAD = fe8f20b142d364f586
+# Plaintext =
+# Ciphertext =
+# Tag = 742256032689966c732d2ec45ad8ccfddf084c34c3cef054
+#
+# AAD = 069728b94adb6cfd8e
+# Plaintext =
+# Ciphertext =
+# Tag = ec775512b21ceafdad402a3b5c9732638980619db646e2835dacfc9e0d6ceb2f
+#
+# AAD = fc8d1eaf40d162f384
+# Plaintext = 3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
+# Ciphertext = e17f35268a34b8e50c1dcfda886029fa3a8397f0c3c7
+# Tag =
+#
+# AAD = 049526b748d96afb8c
+# Plaintext = 4263e30484a52546c6e767880829a9ca4a6beb0c8cad
+# Ciphertext = bbd17ae6e0d41c834c4de236c13d2394b8dabfa41ec3
+# Tag = 8600622d3de66540
+#
+# AAD = 0c9d2ebf50e1720394
+# Plaintext = 4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
+# Ciphertext = fc747f1599c77bda5e74af50b59bded41be03fa6b69c
+# Tag = b0c89839cfec87c769f4bf169f73775e
+#
+# AAD = 14a536c758e97a0b9c
+# Plaintext = 5273f31494b53556d6f777981839b9da5a7bfb1c9cbd
+# Ciphertext = 3e9d2b5188e6c6a53cf5030bd4599500a5cf9f1c0f10
+# Tag = fabd0e88bc4b0e2891f09b54119023abf2057e895b18d493
+#
+# AAD = 1cad3ecf60f18213a4
+# Plaintext = 5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c5
+# Ciphertext = 3995d624d0d05fb8c6ea74b995e38c465602f40fc729
+# Tag = cc072eee5121dc677d3f7bfb29379f6975e039e77b90019f94cb38634e2f0634
+#
+# AAD = 7e0fa031c253e475069728b94adb6cfded7e0fa031
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839
+# Plaintext =
+# Ciphertext =
+# Tag = fbb13ac80f048f48
+#
+# AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+# Plaintext =
+# Ciphertext =
+# Tag = 76bf4a86ea75f629a24647c3497948f5
+#
+# AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849
+# Plaintext =
+# Ciphertext =
+# Tag = c36d79a4352e1699da77f652122dc4fcd78f8f59abf2dc31
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051
+# Plaintext =
+# Ciphertext =
+# Tag = 77518f95ea372df15246efdd7ebd4f72f9c12b415d7d3c74d92d733de206d3c6
+#
+# AAD = a031c253e475069728b94adb6cfd8e1f0fa031c253
+# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f
+# Ciphertext = 40f38fb1935b5438565f70da9e439d6f4b7caeb36c9d0da73b367f1b14865d9967e3
+# Tag =
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a839ca5b
+# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f617
+# Ciphertext = 212d19f557fc1505a18e97ffa8ad0dd71ab89892e27102670405c7ef0701b6d82615
+# Tag = b15f1f1c8f4d35c7
+#
+# AAD = b041d263f48516a738c95aeb7c0d9e2f1fb041d263
+# Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f
+# Ciphertext = 2529d74b424dfdc48fd1ddd1760d54c631062ec7a71d6dbda0d8cd91c11992999572
+# Tag = ecd800a8bdc405a972a84a086bc37fa6
+#
+# AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6b
+# Plaintext = f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627
+# Ciphertext = a1a2311172efcc9e1fc53665b277aa861379ff3213c04956d2c540c30a0f6aa800bd
+# Tag = d12ed3f47b7e66c256dd36794ce4c0a40d4db611c97ef76f
+#
+# AAD = c051e273049526b748d96afb8c1dae3f2fc051e273
+# Plaintext = fe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2f
+# Ciphertext = 23c5cd8fc4903829747479915261b78654bc8631075be35ba3b689332d97a5a9ccd2
+# Tag = 7f9dd289816dbd8748ac743354716292ec81c399d616c53af0f8a59ef04c108a
+#
+# AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e273049526b748d96afb8c7c0d9e2fc0
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c9d2ebf50e17203948415a637c8
+# Plaintext =
+# Ciphertext =
+# Tag = 9b7e4fe8414cdf53
+#
+# AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+# Plaintext =
+# Ciphertext =
+# Tag = 73891d2096fe95e113b8c96c10fdcf1a
+#
+# AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d8
+# Plaintext =
+# Ciphertext =
+# Tag = 6eb6c8913e152b5af68175c1ff4c461c71c83f89a2416bba
+#
+# AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe0
+# Plaintext =
+# Ciphertext =
+# Tag = 71decb11965b05e8d0861934a570140da494797aab7eeacad26f9d9ff71574d7
+#
+# AAD = d061f28314a536c758e97a0b9c2dbe4f3fd061f28314a536c758e97a0b9c2dbeae3fd061f2
+# Plaintext = 0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647
+# Ciphertext = f76abc53e591ed31a1efa1249d91dfa253a7e27bdd072ae2a8e7e9e940ac8dd32a4ac5cc1fc267fab44980e99b258f003787
+# Tag =
+#
+# AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa
+# Plaintext = 1637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4f
+# Ciphertext = 04ec8c07eef82836373eb69b41826d1ad21c6924e4aba77209df4df96329bf25c9555a42e3048550b95251487d2a4eb735a0
+# Tag = bf817ca8213c66f2
+#
+# AAD = e071029324b546d768f98a1bac3dce5f4fe071029324b546d768f98a1bac3dcebe4fe07102
+# Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657
+# Ciphertext = 9620151e271f710df5a4e6deb14c910ccb0361a20ffed79d1eb8b65e257692f7bb101f7641f463ca030c670c8b934361edb3
+# Tag = 0853d4e7a6276f8ddf1f471319ead5dc
+#
+# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a
+# Plaintext = 2647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5f
+# Ciphertext = 3c171ed0c7189c9492d91528f901fdb1fe920762a4a3eb86a313884238c1584aa9916322caa75336aa52bbb9a831bcb74c3c
+# Tag = 6562ff882423bb89667f2dbc84b162161887bc4f7298c5ee
+#
+# AAD = f08112a334c556e778099a2bbc4dde6f5ff08112a334c556e778099a2bbc4ddece5ff08112
+# Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667
+# Ciphertext = 6ea079d914b0b91a55114cecbe1b7adabc303fb036ec1211a7a5249434563b9a4c2e56a32c00dbc8d8bd60d4db99efe79d51
+# Tag = 26c586c8208740240fa4bb2db0897132c27e3c70874ac5af42544d2ce684da30
+#
+# # initialize with key of 128 bits, nonce of 80 bits:
+# Key = d26b049d36cf68019a33cc65fe9730c9
+# Nonce = 73d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2b
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 5f4111619cd1553a
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = bc8eeae299416a4727255804f374f84c
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = bd49129b54cfb1e21b2d7042a307c36ac75ade06e18b4d2f
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 7ea1c20e889eef9b5e04ae3b5338f02ae7c9c80d07cdcd0ad37339e9aaefb6d5
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = fd2a0e4b4b
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 7d8d262e7c
+# Tag = 82ff04794b500947
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = 456912ba11
+# Tag = d0bfc7cacf4efbdd0f941f92151589ec
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 1931e10759
+# Tag = 95fa9610eb80b602e43ae14a1e7fc3d1088c4ab8de74167e
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 8b32fdbcd2
+# Tag = 43225a535245272277691b4153c7ca55d26becc3425bc307f0a65dae7c58b30f
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 6f481310526b8a8b0844c9b9
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 7a3ca34f2c32248adeb4fa85
+# Tag = 418427ea6c383b2c
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = f2fb50ae65eb6dc13813d6c8
+# Tag = 4a844571c94a8a11c9696b6bc7df0ae0
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 82dcbe96870843940f820bbd
+# Tag = 4a0c143ceb09c4a7cdea711eca573e6765a31f1f57cb1f39
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 2fdc92457a855ad1c2ce0e4e
+# Tag = e0f236d3d5a0cce6a0b2058ab1c30a900e1da65e1bfc3c95d754cb8253c650ed
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 3125449a4fa3c7ebe156651accc579b4f31f9556a2ad45
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 82ab7550857efd719899ce14637ebe9989e816f2d6e26b
+# Tag = bb63bd63af0a05ff
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = ec5ae11ead411fa769de8661c5fd5ba5890f190c57930f
+# Tag = 98173050b6ce8da73b1b727a9f04e592
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = fdc75307b6614af182bf9656c7021b945a128ea28b5c9a
+# Tag = cbdb90120887aec18f58743b8612738c649ccd07d6fb1710
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = 75a6340d90880909ed9b8c694a5ba1890996c3d5cc8897
+# Tag = 1f55584b10481541f3026b94dd9dd1585903ee432ade24bb30d2614e4c24e16e
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 758d378bb49b7a21e424d85661f69318b887ac9b098834d78ad2b14d6cc177670eb1720f24f851
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 4275d4fbc28b33ed2bc3f6ba65a9bd19334ddbe12f82633dc58478f0fb153620ec8fdc814cbfdd
+# Tag = 67d6971dec8b79c6
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = 21da8369e61305f240369f1a1e85574f0109b390500111c600abd3c572febca24e90c5b21d79f1
+# Tag = 8e1ae3f1138a7bc53702ae4aceb8f840
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = 6a9ced69bce3e60f20c35f88c62fc7d10c8cfcc39810d16304a2e8ded8c168d701c38c222ccb25
+# Tag = 8ab10e43b188ecfda5ed9f4053029a233842ee1bb52c82e0
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 49678c911ada7cc99f06c755b2a7febb4d132548623731b77bf87788fd12f65145274a46aaa3e0
+# Tag = c3ed2118f7328be094583aa8ff2b759bce5d259d715e5278816439b17c101cc4
+#
+# AAD = 8819aa3bcc5dee7f10a1
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 9021b243d465f68718a9
+# Plaintext =
+# Ciphertext =
+# Tag = a71cf06c88cbc973
+#
+# AAD = 9829ba4bdc6dfe8f20b1
+# Plaintext =
+# Ciphertext =
+# Tag = 9368317d41aab2269e7d94708d843a07
+#
+# AAD = a031c253e475069728b9
+# Plaintext =
+# Ciphertext =
+# Tag = 80bdff5e3dc01cc2b13e6357f684df7a485bb73290d18f88
+#
+# AAD = a839ca5bec7d0e9f30c1
+# Plaintext =
+# Ciphertext =
+# Tag = 687f2b8e8918b80788355b7de8ac8c344c2912d11b046355b604bdba9e77766c
+#
+# AAD = a031c253e475069728b9
+# Plaintext = 7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b
+# Ciphertext = 82aa30d01b72ca9baeb9707e43875abc1b84f57e7b23afc1
+# Tag =
+#
+# AAD = a839ca5bec7d0e9f30c1
+# Plaintext = 87a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+# Ciphertext = 556fcc8185b12bc0167a879e744dc89804fafa6b01631c61
+# Tag = de6740d406c53256
+#
+# AAD = b041d263f48516a738c9
+# Plaintext = 8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+# Ciphertext = f65d15bbc66527bc8ec309df5987772ee31db91d0c7bc172
+# Tag = 1a0899f3d1b4265acb5b7580bc4cebb5
+#
+# AAD = b849da6bfc8d1eaf40d1
+# Plaintext = 97b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+# Ciphertext = 9cdba140217e734901c8414901a019e25f9ff4b138ff4954
+# Tag = efc70c3485600a3b438791e9f0c245629a4419cdd09d8d36
+#
+# AAD = c051e273049526b748d9
+# Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+# Ciphertext = 203123fd38519bba35c7425c0e16b406dde4f4a04e15ed64
+# Tag = f39f261a3efbd147e2b2bc4555dc469825006792cb9ff4f004505133740d5a58
+#
+# AAD = c253e475069728b94adb6cfd8e1fb04131c253e4750697
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = ca5bec7d0e9f30c152e374059627b84939ca5bec7d0e9f
+# Plaintext =
+# Ciphertext =
+# Tag = 2468fe3d48670c94
+#
+# AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
+# Plaintext =
+# Ciphertext =
+# Tag = b1081f4cec1ab6cd646be0ddc8d6aa92
+#
+# AAD = da6bfc8d1eaf40d162f38415a637c85949da6bfc8d1eaf
+# Plaintext =
+# Ciphertext =
+# Tag = 1fed174acbe536ee21a4a269d551f0755a0ec5ac25a5f784
+#
+# AAD = e273049526b748d96afb8c1dae3fd06151e273049526b7
+# Plaintext =
+# Ciphertext =
+# Tag = f7fa367b7196c77c78b791b6c288c02a96b625b846e33705643deff9dd4161e1
+#
+# AAD = e778099a2bbc4dde6f009122b344d56656e778099a2bbc
+# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
+# Ciphertext = 69c0bf63df493c8130a29dddad9980fff7cb2166aa09361a4f190c73969142cb10100ca842
+# Tag =
+#
+# AAD = ef8011a233c455e67708992abb4cdd6e5eef8011a233c4
+# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa020
+# Ciphertext = be83d961ee14147e3cd6214d7e1e676fdc19a8ca7dad8331781baab147b604aa08f3f40927
+# Tag = f463f98f6630f854
+#
+# AAD = f78819aa3bcc5dee7f10a132c354e57666f78819aa3bcc
+# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a828
+# Ciphertext = 2801ce757e376d9a0152177c8496553949385f627bf95cb996e168333fd33993d080e44955
+# Tag = ce8fe44c491d87383f5a7d53d0451937
+#
+# AAD = ff9021b243d465f68718a93acb5ced7e6eff9021b243d4
+# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb030
+# Ciphertext = 4f23d5c00d433f82794bc66e4ab2d1f3c01125a9bac1f99d831472882e481d19af9dad0ad3
+# Tag = 9ef415ed96e0ac73ecc3d6d30a019c933bc7becb1c8ec1d7
+#
+# AAD = 079829ba4bdc6dfe8f20b142d364f58676079829ba4bdc
+# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b838
+# Ciphertext = 8dff6699a2607abf4051044e452f81620d64599eeded02351afb06cbd08a379a6209168dc3
+# Tag = 249b371536e4061f78305c7d9689690dba5dff4101360461c910ba5ae99f462e
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e17262f38415a637c859
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a6afb8c1dae3fd061
+# Plaintext =
+# Ciphertext =
+# Tag = 1e7d8c0ed3f00911
+#
+# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
+# Plaintext =
+# Ciphertext =
+# Tag = cc8862820230c5aaeaa5426ad1ece4a4
+#
+# AAD = 9c2dbe4fe071029324b546d768f98a1b0b9c2dbe4fe071029324b546d768f98a7a0b9c2dbe4fe071
+# Plaintext =
+# Ciphertext =
+# Tag = c4fbbfdd62e0da97bc83f9ba603fceaf7b00e7a9eda51bed
+#
+# AAD = a435c657e8790a9b2cbd4edf7001922313a435c657e8790a9b2cbd4edf7001928213a435c657e879
+# Plaintext =
+# Ciphertext =
+# Tag = 26db49a2f83ddfaf1966bccc08ee29a0ef5a80fc06f9c253c75f463e07a5a1ab
+#
+# # initialize with key of 128 bits, nonce of 44 bits:
+# Key = da730ca53ed77009a23bd46d069f38d1
+# Nonce = 83e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da3bfb5cbd1ede3fa001
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 72fc2aa9dfec5626
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = cb5671ddb1e46a714030d049bac4e3e6
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 111337b2df5d4a0c20a472ef9e49ebaf275a3557008b5cd1
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = efa6b8dd73ec93732de560ba0ac36c7ab17e746b00c6d7ec3dde349f9a64f36e
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = f6e50165c6
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = a324348eea
+# Tag = f764f4650f63e062
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = d692e0b7c2
+# Tag = 55dd98902c7e70e478b74801c9b9e8be
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 035886516d
+# Tag = a74ce36933a9b9884dca69d7329e78e76fd792a3295a8ef1
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = c74ed5f518
+# Tag = 73a1c12b7bbb1da10f808bc57613662948599047fa8a098a63215445c8b0a992
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 35516e2598a48b7639c31a17
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = f04c072676d946ecb4275473
+# Tag = 58caa361fa13d5f7
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = dc48388aae68cd5250061ba0
+# Tag = 310cb30f7b0ac66e70d738fdab7fab0b
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = 719f6f55785fe0dcb563a1f9
+# Tag = cbb4551c2a83df8b33b98744d0314a48ec915fa9e3fdcef8
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 4748b698ada2a06ad9c3ba63
+# Tag = a161d8867f08840a0550d0f91bcc0d9801fcc8941703e0444449be551ef6a51a
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = 09c5084e667b5125461f2332f57bdbcccd56f259e3ccbd
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 5e88d356c6d45f06eec4e079b1c01f7603b44d8a4f6daa
+# Tag = fdad68df4244f781
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 388e885dba0e6a547616edc32daece79308a218286ac57
+# Tag = 7675543738e93034058d3afbac4e65ea
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 824d4a3b91b1a12222024354784a97b744da3bf2af22fa
+# Tag = f7c760411695f920e4f2c4f547df712c2cc26c986b81a75c
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = 93f0c49bc4f8fba2e8f640f11a22568556b6eca2e998c8
+# Tag = 78704f99f4b85a06800c31a4ea37b9ad825fe5ae174eff6d88f7aa9266ec1135
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = 333b2640ea152649d8c10563d7b7d7a4ae519b1872f2d25e8b5fb80124e7c13e14e05077f0f005
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = 7725f24b4cce732e54734fc34ce97630c736a1c3bb337bfb56fa4f2281edc8f884e38b216ca819
+# Tag = 28040c1d64171887
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = 05d87c6ec71b18547d59be266efb8dae30f5d3fcc4a3c3481fee2f0e71b3d3ce6db4561fd582d5
+# Tag = 866aff568d10353e19e1897747adc713
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = d354606ac33d4f950bb95e2a9babd3ab5cfcac3096e530f65d5d4fe17f750a64ebc4574732bd16
+# Tag = c6debd8c79226f17ca9192b959a3698177899cca008cf911
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = 4538042e140b9a616e4756482219cae23721e52e0a4027d0aec4010b116d6620786671fd4c6b8d
+# Tag = 215489fdd7381fa99c0df68727f78081491d496cf68a2cf5a3e474cc480c4737
+#
+# AAD = 8819aa3bcc5dee7f10a1
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 9021b243d465f68718a9
+# Plaintext =
+# Ciphertext =
+# Tag = ee79299bf39b92fc
+#
+# AAD = 9829ba4bdc6dfe8f20b1
+# Plaintext =
+# Ciphertext =
+# Tag = 3bb2275e67c6c4224512649f8faaa476
+#
+# AAD = a031c253e475069728b9
+# Plaintext =
+# Ciphertext =
+# Tag = 43aa46c80187f9598c09bf82941d3144192a004bca97dcc2
+#
+# AAD = a839ca5bec7d0e9f30c1
+# Plaintext =
+# Ciphertext =
+# Tag = 070838eed9ef934e58ac03f99ff6fc9d663814f749ab942df3b86e89614c4384
+#
+# AAD = a031c253e475069728b9
+# Plaintext = 7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b
+# Ciphertext = 9f9cad8fa7c82175a43e395ed26ec70829f7f11d1565c5f8
+# Tag =
+#
+# AAD = a839ca5bec7d0e9f30c1
+# Plaintext = 87a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+# Ciphertext = d1fa47053572153cd10de80a26e578290cefb8943543447a
+# Tag = 29d1a1adc77bbf9a
+#
+# AAD = b041d263f48516a738c9
+# Plaintext = 8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+# Ciphertext = f74bd649e89228225563841e7c2641893e9b6cc24dd983d5
+# Tag = 19eb819974feffce116446131ef05b64
+#
+# AAD = b849da6bfc8d1eaf40d1
+# Plaintext = 97b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+# Ciphertext = 7e18d89cc51af41909900ccb23478936d10dee1a93757702
+# Tag = b5b8d7e93f2fcbe23151a016a264db0b2bde795663fb778b
+#
+# AAD = c051e273049526b748d9
+# Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+# Ciphertext = 86eac3782da4ae4d7ab2ddc893e9e5a3852ce0e90b07914e
+# Tag = 4b76f11c70a7daeb21a31d5880e4319655cdb310817c7230e8e1a1dd2d82efff
+#
+# AAD = c253e475069728b94adb6cfd8e1fb04131c253e4750697
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = ca5bec7d0e9f30c152e374059627b84939ca5bec7d0e9f
+# Plaintext =
+# Ciphertext =
+# Tag = 146d93d2f5d3e1e6
+#
+# AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
+# Plaintext =
+# Ciphertext =
+# Tag = 094859713e48b019a6a08936d4c56b60
+#
+# AAD = da6bfc8d1eaf40d162f38415a637c85949da6bfc8d1eaf
+# Plaintext =
+# Ciphertext =
+# Tag = 4e1132bca936e934287363b67191000df66a3df3cfd260cf
+#
+# AAD = e273049526b748d96afb8c1dae3fd06151e273049526b7
+# Plaintext =
+# Ciphertext =
+# Tag = 2fdf1e5bf76b087a02c179590f0283c84257ce9605679b9001bd6a7b3d635d18
+#
+# AAD = e778099a2bbc4dde6f009122b344d56656e778099a2bbc
+# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
+# Ciphertext = 251407b4a09952b44aab4249a33d1ca63a799ddb55938b15a6474c8f64dd62fcd7248e22e9
+# Tag =
+#
+# AAD = ef8011a233c455e67708992abb4cdd6e5eef8011a233c4
+# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa020
+# Ciphertext = cb9b42f3327943301fdc528f50489210080591688e391921a807ca98fbedd8f01a4a607496
+# Tag = 6293bf3357d1e53c
+#
+# AAD = f78819aa3bcc5dee7f10a132c354e57666f78819aa3bcc
+# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a828
+# Ciphertext = 9f3e4cea5037aab126783d9fb47d59ff4999678378ad6ee3781166c061f4da5dc53b1829be
+# Tag = afab2eee6f87cb5416bad721a6bcec84
+#
+# AAD = ff9021b243d465f68718a93acb5ced7e6eff9021b243d4
+# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb030
+# Ciphertext = f244c8d8860d5fc4743e140e0d27672a73f9fb99b3da5ccf073d69863455a1b47bcb3f74cd
+# Tag = 9f0fb46999bee79f332f8d440c8dfb474a92c2569408a6a7
+#
+# AAD = 079829ba4bdc6dfe8f20b142d364f58676079829ba4bdc
+# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b838
+# Ciphertext = 46a66a31fd419ff61ad94f1c6fe3854dfdba23f8d3406049104f776d9cb2946505f5b0c83f
+# Tag = 1c9c1e5a93e913c127ebb9c97d54036b249704900f16bfa6b97711e1ba5f36e5
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e17262f38415a637c859
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a6afb8c1dae3fd061
+# Plaintext =
+# Ciphertext =
+# Tag = 94e00b7c57ebfa0c
+#
+# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
+# Plaintext =
+# Ciphertext =
+# Tag = 499ec63e88671215ab71bb78cb993701
+#
+# AAD = 9c2dbe4fe071029324b546d768f98a1b0b9c2dbe4fe071029324b546d768f98a7a0b9c2dbe4fe071
+# Plaintext =
+# Ciphertext =
+# Tag = c55829248014a5527684d51155c1d1d279fc2895590378bc
+#
+# AAD = a435c657e8790a9b2cbd4edf7001922313a435c657e8790a9b2cbd4edf7001928213a435c657e879
+# Plaintext =
+# Ciphertext =
+# Tag = 5011765d32f5907f8324dcfd47c132b07c1f8bb0d3bdc0257ad33001e0c3e123
+#
+# # initialize with key of 128 bits, nonce of 08 bits:
+# Key = e27b14ad46df7811aa43dc750ea740d9
+# Nonce = 93f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9b91a7bdc9cfd5ebf7fe041a262c3248545a607682889ea4b0b6ccd2eee4fb011d13293f4b41576d7
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 4287fc16f83e7758
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = aa49fa00358fd747bca6bb5beea719d4
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 39ad9444737ceabd08ee68fa5f04518d3f0a7822ff67cc32
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = e775bafc8fadb340760eedfe92093741ae96a13086487753b06d2a0872912572
+#
+# AAD =
+# Plaintext = 6f901031b1
+# Ciphertext = cbe9b5814d
+# Tag =
+#
+# AAD =
+# Plaintext = 77981839b9
+# Ciphertext = 08833f527f
+# Tag = 9da8081892c447cb
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = e6696ec916
+# Tag = 3d63ac7e7982de43aeae250835e60976
+#
+# AAD =
+# Plaintext = 87a82849c9
+# Ciphertext = 01b63da71d
+# Tag = 949c2b9f7f15802089ec8f6035e664cb17e897dc0e2b96ed
+#
+# AAD =
+# Plaintext = 8fb03051d1
+# Ciphertext = 43e075fcdb
+# Tag = bc41c4aac0b7e11355b804f7f83c85d350027011faf3b5bc0f78511a550afd0c
+#
+# AAD =
+# Plaintext = ddfe7e9f1f40c0e161820223
+# Ciphertext = 6285efeb06624f723fc2a1e3
+# Tag =
+#
+# AAD =
+# Plaintext = e50686a72748c8e9698a0a2b
+# Ciphertext = 9c8a3fd6573a9c30f00f9307
+# Tag = 868a0d5c2a1bfa3a
+#
+# AAD =
+# Plaintext = ed0e8eaf2f50d0f171921233
+# Ciphertext = 952844009ca95705214e08b2
+# Tag = 75a721d9bead8fc66f59fed89644ce74
+#
+# AAD =
+# Plaintext = f51696b73758d8f9799a1a3b
+# Ciphertext = a746a55f6525954b2cfd99b4
+# Tag = 7f5972b57800cd74f6c9394b61f5247f02b72cff98ec709d
+#
+# AAD =
+# Plaintext = fd1e9ebf3f60e00181a22243
+# Ciphertext = 7937173673d928a71ca7b421
+# Tag = acff90843d5fc6ab0d88f68eca4a0bf7ead77189efd3c2657f3785c3f50c9fde
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+# Ciphertext = be8febbe2173ba47a0e9784ee33cea39357ee7aa62108e
+# Tag =
+#
+# AAD =
+# Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+# Ciphertext = 5f068487a3d5730f02d9c64b03de9f1b039b599da6ef1c
+# Tag = 38b0610a2c9f6490
+#
+# AAD =
+# Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+# Ciphertext = 5062c8114152834c81ce32196a179ac27049eae4803a9f
+# Tag = 3d5037c9e88ff50657a4c5d6eed26716
+#
+# AAD =
+# Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+# Ciphertext = 4ef64e180d5ba769c4faa851bb1b1bd807da65540bc27b
+# Tag = 237b1c5f0caa59aab5cf2e0455d0f8fc18195a1222677ecd
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+# Ciphertext = 150fdda3e0f6b6dee4a651cc6a48b01424b85b3a6bd6b4
+# Tag = 9326d003fbe66b5be322ada2c23663a4e0dc67cc05b5e71cbf79387a280164df
+#
+# AAD =
+# Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+# Ciphertext = c9e857458685193dc403b4ccb21464f6fbef41ba0d52b92ba4b262ce04816fdf2d3758072acb0d
+# Tag =
+#
+# AAD =
+# Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+# Ciphertext = ade1a05fc6da6bb56feaf822f0b90901a82f1a6c86d3bd7966f6211cc19ae5ca3960258358584d
+# Tag = 4a0582ab4b646696
+#
+# AAD =
+# Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+# Ciphertext = f97adb42fac458549f62ed513930a2c4b5a64597bb6f21c0997eb96f4fce77176ef555cfd7da75
+# Tag = 04d57b95ddf39adb2f320801ad7325bf
+#
+# AAD =
+# Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+# Ciphertext = ac47ab94e806ebcabbcc451e692cb8dec3b60d6a5dd9aff11fea97c948a5a4b31a56a3ca66fe0e
+# Tag = 600fac3cc91e0d9288ea11087675b696d8664a6dcc3ba763
+#
+# AAD =
+# Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+# Ciphertext = ed7390a2cf24c94779bd044bff3b456098527f73d2488d6ed1706cef9c65e6d82d8f4a7d350182
+# Tag = 86ee26626a83a16d7332e4f48f9108af95711c201e9f483a32a294c6077d0c0a
+#
+# AAD = 8819aa3bcc5dee7f10a1
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 9021b243d465f68718a9
+# Plaintext =
+# Ciphertext =
+# Tag = 604aac50511008d7
+#
+# AAD = 9829ba4bdc6dfe8f20b1
+# Plaintext =
+# Ciphertext =
+# Tag = 310b38a622eeb807f2c57fc725ff6357
+#
+# AAD = a031c253e475069728b9
+# Plaintext =
+# Ciphertext =
+# Tag = 68fadca05b09f8190ff790f8f5bab01904d2c0c39cd8ad10
+#
+# AAD = a839ca5bec7d0e9f30c1
+# Plaintext =
+# Ciphertext =
+# Tag = b3939abad431e80940b01c13349644ebec775661623b7d9ca0bdd94db3d4dc4c
+#
+# AAD = a031c253e475069728b9
+# Plaintext = 7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b
+# Ciphertext = b0bded1ac0271160fdbdaa82f2dc7ed9d2938dffda38f256
+# Tag =
+#
+# AAD = a839ca5bec7d0e9f30c1
+# Plaintext = 87a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f27293
+# Ciphertext = 82cbb73114eda1a91c0cbd4eab2a6ec4f67ffa7ff3bce214
+# Tag = e132cc11e29f9ed3
+#
+# AAD = b041d263f48516a738c9
+# Plaintext = 8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b
+# Ciphertext = c04e351401427ac7bdc95cef3ed57ef142c1c43a4777df83
+# Tag = 09d7df32e6967dc20330b9b18441537b
+#
+# AAD = b849da6bfc8d1eaf40d1
+# Plaintext = 97b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a3
+# Ciphertext = 3e9c5806450fbfef0c910eb97a833e268611060d7c6d149a
+# Tag = b817125f9da3121bed367df944596ec84c5aa2ef97235cff
+#
+# AAD = c051e273049526b748d9
+# Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e90a8aab
+# Ciphertext = 013cd19122273e7f6064f66ddcd0a269018cf198a9c96717
+# Tag = 0a9b6d3fc840de1834f921706388652165bbaa66fed20af57d4ba70a6142eedf
+#
+# AAD = c253e475069728b94adb6cfd8e1fb04131c253e4750697
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = ca5bec7d0e9f30c152e374059627b84939ca5bec7d0e9f
+# Plaintext =
+# Ciphertext =
+# Tag = 87124bcec2990e17
+#
+# AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
+# Plaintext =
+# Ciphertext =
+# Tag = 68310a99bbe5bcb4c71904c80de84a62
+#
+# AAD = da6bfc8d1eaf40d162f38415a637c85949da6bfc8d1eaf
+# Plaintext =
+# Ciphertext =
+# Tag = 0fc952cf56a86d8ee7206debbaf0eb8434fe956662e92203
+#
+# AAD = e273049526b748d96afb8c1dae3fd06151e273049526b7
+# Plaintext =
+# Ciphertext =
+# Tag = 26544c1c8792b6562826bb5ed7eb8981743baa309609919fdc492e1c792db207
+#
+# AAD = e778099a2bbc4dde6f009122b344d56656e778099a2bbc
+# Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
+# Ciphertext = 9465ef900f9d28e81418c572bb6aab32858e119a1b855e4c272efa9cce05636308e6f094c1
+# Tag =
+#
+# AAD = ef8011a233c455e67708992abb4cdd6e5eef8011a233c4
+# Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa020
+# Ciphertext = 549929005139e7adc21862093a35a0d771fe17106c4f816df74e543127478ff7850d2ba241
+# Tag = 5994e7ea2f8264fe
+#
+# AAD = f78819aa3bcc5dee7f10a132c354e57666f78819aa3bcc
+# Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a828
+# Ciphertext = 1942c07aa249ae11baa43b1a5194f15c4bf98ff9ab27fdab650fa55202d5e7798c77594aa6
+# Tag = f9852bfbde1f5effc2d522f118b48ab8
+#
+# AAD = ff9021b243d465f68718a93acb5ced7e6eff9021b243d4
+# Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb030
+# Ciphertext = fce5bf3badf6f08d74dfd05fc2ff62a5abee30006d872cc498df19ad7f2fea21aef6ee7b93
+# Tag = 7e7de7f423a89bad791f7d4edd1eaea3856ce140f7994d2c
+#
+# AAD = 079829ba4bdc6dfe8f20b142d364f58676079829ba4bdc
+# Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b838
+# Ciphertext = 0690f57ab9fa727f4bb2d8fb91b9f79dad64f832e9ed0a9ed5b86de0856c859cd8878b4eee
+# Tag = 6bdc79bf57b0247e2667bfad87f2176feb2882f4e24fb1eade7f1b63491b38a0
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e17262f38415a637c859
+# Plaintext =
+# Ciphertext =
+# Tag =
+#
+# AAD = 8c1dae3fd061f28314a536c758e97a0bfb8c1dae3fd061f28314a536c758e97a6afb8c1dae3fd061
+# Plaintext =
+# Ciphertext =
+# Tag = 00c11942e0ce5c31
+#
+# AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
+# Plaintext =
+# Ciphertext =
+# Tag = c88ca1b82714b5f6941bebc538ce7131
+#
+# AAD = 9c2dbe4fe071029324b546d768f98a1b0b9c2dbe4fe071029324b546d768f98a7a0b9c2dbe4fe071
+# Plaintext =
+# Ciphertext =
+# Tag = b155947eebee4b5cd7494715795daf3017d01a475b126f37
+#
+# AAD = a435c657e8790a9b2cbd4edf7001922313a435c657e8790a9b2cbd4edf7001928213a435c657e879
+# Plaintext =
+# Ciphertext =
+# Tag = d60d4c8448df7f9aa90403b115918cf8da30d868ba96b8dbfd054060a47e37f4
+#
+# # initialize with key of 112 bits, nonce of 64 bits:
+# Key = a53ed77009a23bd46d069f38d16a
+# Nonce = ff60c122e243a405c52687e8a8096acb8bec4dae6ecf309151b213743495f6571778d93afa5bbc1ddd3e9f00c02182e3a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d0d6ecf30f051b213d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2beb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d9eff602081e2430364c526e647a8
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = e1f65ed4799ce0e96a16fe5686f85e3f
+#
+# AAD =
+# Plaintext = 3b5cdc
+# Ciphertext = 222aef
+# Tag = 392beb4e95684dc5b97683af4c1c00d0
+#
+# AAD =
+# Plaintext = c3e464850526a6
+# Ciphertext = 77b7f5255aa468
+# Tag = d3294efa2735eda5088ed7c06ee13ccb
+#
+# AAD =
+# Plaintext = 8fb03051d1f272931334b4d555
+# Ciphertext = 1a3fd59a68c58288ff2f9c40c3
+# Tag = 3f61cdf406af73f623c1d20eaf6c34ce
+#
+# AAD =
+# Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
+# Ciphertext = fbd3f6e1c23e78b785790b9d655afc06a4735b2e87e2
+# Tag = 981ea58e5bc51f084d72c6ba322b1751
+#
+# AAD =
+# Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef
+# Ciphertext = 4598dcdfeb2d51a78cf272e1c9814895f29b8ea62c0b320945dad6a5671026dd1f5f392e
+# Tag = 5589beefc13695d2ab71d731c7947abc
+#
+# AAD = 54e576079829ba4b
+# Plaintext =
+# Ciphertext =
+# Tag = d9baa1edbd2016587578749dfc38c446
+#
+# AAD = 69fa8b1cad3ecf60
+# Plaintext = a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f1
+# Ciphertext = f9b774839975ea54f4164cb0c0899c95da9f96cd82
+# Tag = ef0eab96785e0c2823edb202a12bf560
+#
+# AAD = a839ca5bec7d0e9f30c152e37405962717a8
+# Plaintext =
+# Ciphertext =
+# Tag = 4d941d757e6097c8eff3bb12025d0ae0
+#
+# AAD = c758e97a0b9c2dbe4fe071029324b54636c7
+# Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191b23253d3f474
+# Ciphertext = a88c79f84d28437697ed846848ac183d7a4a67a0959bab6f2e23428e9c3530
+# Tag = cec47b9f3d5054b5c42bffd66c88d0f6
+#
+# AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+# Plaintext =
+# Ciphertext =
+# Tag = 0743090b18737818ed9e5b200d0f1f5c
+#
+# AAD = b142d364f58617a839ca5bec7d0e9f3020b142d364f58617a839ca5bec7d0e9f
+# Plaintext = ef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5
+# Ciphertext = c006a061d383e200f2ad353819780d2d63620beabed49c77fed295d6bff87fac20dff95c580cf6cc4439d67ba7
+# Tag = 6cb093e95d6ab61af80dc6df1a463b69
+#
+# AAD = e8790a9b2cbd4edf70019223b445d66757e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223b44535c6
+# Plaintext =
+# Ciphertext =
+# Tag = 43e2f25ad278f48887e86d62a21152a7
+#
+# # initialize with key of 104 bits, nonce of 72 bits:
+# Key = 049d36cf68019a33cc65fe9730
+# Nonce = a00162c383e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a161c2238444a506672788e94a0a6bcc2ded4eaf10d03192f3b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223e344a506c62788e9a90a6bcc8ced4eaf6fd0319252b314753596f7581879da3bfb5cbd1ede3fa001c12283e4a40566c787e849aa
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 6a90200ceaf49bef422ec10f4b08640f
+#
+# AAD =
+# Plaintext = 99ba
+# Ciphertext = 08bf
+# Tag = 1788ce3ae56024347ee4c389e014fbe5
+#
+# AAD =
+# Plaintext = 7fa02041c1
+# Ciphertext = c0d79c347b
+# Tag = a4537af01d093470639cac46363fe882
+#
+# AAD =
+# Plaintext = 0728a8c9496aea0b8b
+# Ciphertext = ad5cbf19fb7f1d6620
+# Tag = 3f66353cd96a4a0b8ad1780c617a6e53
+#
+# AAD =
+# Plaintext = d3f474951536b6d75778f81999ba3a
+# Ciphertext = 50b505d2da5ce59eafb6371b96400b
+# Tag = 1227fc67b00c6281b08490e8ce6ed714
+#
+# AAD =
+# Plaintext = 85a62647c7e86889092aaacb4b6cec0d8dae2e4fcff07091
+# Ciphertext = b198d0d1ccf782f6275dfef4a5ca0f2533a2890a72638b15
+# Tag = 7c0386d87d936396ff04d40f1a8a34d6
+#
+# AAD =
+# Plaintext = 61820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d4
+# Ciphertext = 74fda61013e7646a8102f62787961d11e2af80c13aaab80be228a8edae9dfd31097e2a0c0bd3
+# Tag = f1fe2b47b41526e89c9c733a456a24f7
+#
+# AAD = b243d465f68718
+# Plaintext =
+# Ciphertext =
+# Tag = e50a8af84f67f9d13e39d96b347c299d
+#
+# AAD = c556e778099a2b
+# Plaintext = 62830324a4c54566e60787a82849c9ea6a8b0b
+# Ciphertext = 8ea4a9aec57fafdd8015323f8cdbb1cbc7e8a3
+# Tag = 480cd3e9c75be25392ec3c9b363cbb5b
+#
+# AAD = e172039425b647
+# Plaintext = 1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191
+# Ciphertext = 8f958b8b5d492b08d90ba7b5d8f54f1b95c7835c2738edb66adfaa71c8b8a2b138c3d9d2b1553dc90faa6e570b5687
+# Tag = 86f4ea9714d2bc10c2ae500ae1dd8a1b
+#
+# AAD = 64f58617a839ca5bec7d0e9f30c152e3
+# Plaintext =
+# Ciphertext =
+# Tag = 9f8764f4ee751f99cdd6ca3a504eff32
+#
+# AAD = 8011a233c455e67708992abb4cdd6eff
+# Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+# Ciphertext = 65670a5d28946be4fc4019beee5efe818921c3846e69f2a3015e7db0
+# Tag = a486be8700a19b469583e0bb98d39cdc
+#
+# AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+# Plaintext =
+# Ciphertext =
+# Tag = f6f4081122a75f898496b234e2c41ef5
+#
+# AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce
+# Plaintext = c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d5
+# Ciphertext = 81bf6a6746400b66264ba18606956d50d55d077bc2e0c397bf5b20acb7a620d418555b853b40462b
+# Tag = a6b2a85539b769320d6c979764cecab6
+#
+# AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+# Plaintext =
+# Ciphertext =
+# Tag = ecc433ec167cc9fc16bb58f2bf9192c9
+#
+# # initialize with key of 96 bits, nonce of 80 bits:
+# Key = 63fc952ec760f9922bc45df6
+# Nonce = 41a203642485e6470768c92aea4bac0dcd2e8ff0b01172d393f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b516773798f95a1a7bdc3dfd5ebf20e041a203c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9b91a7bdc9cfd5ebf7fe041a262c3248545a607682889ea4b0b
+#
+# AAD =
+# Plaintext =
+# Ciphertext =
+# Tag = 28a524868cfeb34ea90ec7826f337c5b
+#
+# AAD =
+# Plaintext = f7
+# Ciphertext = de
+# Tag = ee4555f7341372103ab71c55535bdf91
+#
+# AAD =
+# Plaintext = 99ba
+# Ciphertext = ff9f
+# Tag = 4bc0ab83549588db26252d140c6094d0
+#
+# AAD =
+# Plaintext = ddfe7e9f
+# Ciphertext = 1f277bb0
+# Tag = 5cdf45253d3c028fd184558810d05846
+#
+# AAD =
+# Plaintext = c3e464850526a6
+# Ciphertext = fae9a85b882b8f
+# Tag = be5e59244750a36f1307beeb3ad0dd5c
+#
+# AAD =
+# Plaintext = 4b6cec0d8dae2e4fcff070
+# Ciphertext = a78ae059f47f0e07719dcd
+# Tag = 711a5cb5c29fd02ef77c3f69b19b3ea8
+#
+# AAD =
+# Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
+# Ciphertext = fd03713013c8e04d6cf2f710340fae5869
+# Tag = 0b5b4593a64aef67c0af2e05f6c2fed5
+#
+# AAD =
+# Plaintext = c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+# Ciphertext = 665834855377354a8862594b83c3268bbab64cd2692943ec1815
+# Tag = 1377aada741f277657edbfb7b8c4ae86
+#
+# AAD =
+# Plaintext = a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9
+# Ciphertext = 958314a613ec7a0f529184d3220df37eb332ad3ed06669b5c6907424dd7d454f07b6486d6cc17a2d
+# Tag = e6d130d4993ee850b2f0a57bcbfff903
+#
+# AAD = 10a132c354e5
+# Plaintext =
+# Ciphertext =
+# Tag = 16c1b00d915be6e35de375ab24047582
+#
+# AAD = 22b344d566f7
+# Plaintext = bfe060810122a2c34364e40585a62647c7e8
+# Ciphertext = 627d8c6ecd1dd9affd6a3e5179f8ba28ec08
+# Tag = 733d8903e514acb20778351e2671bd3b
+#
+# AAD = 3dce5ff08112
+# Plaintext = d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2bab
+# Ciphertext = 53009fca1f7cd34253e5b44507dd34bb80a9a35206d7640033ee589a8ce656d264b81c83485adb17f55dbc159c
+# Tag = 113f22cf20eb5d5c4dbdad32d8f89c49
+#
+# AAD = 20b142d364f58617a839ca5bec7d
+# Plaintext =
+# Ciphertext =
+# Tag = cb4b7d9aff15027753f5acf81e0df0a6
+#
+# AAD = 3acb5ced7e0fa031c253e4750697
+# Plaintext = d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e36384
+# Ciphertext = 1c80b2634d0d7c7beb8c1a5950a1697556d1b28953844e27c94d
+# Tag = d501234924a86688b32ee02699d2e19c
+#
+# AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+# Plaintext =
+# Ciphertext =
+# Tag = 8e2058a292f7d459c92f586f308a5072
+#
+# AAD = 9829ba4bdc6dfe8f20b142d364f58617079829ba4bdc6dfe
+# Plaintext = 3556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e607
+# Ciphertext = 7d9d405ee2daee5ac4214484edfb499e2214d413467e164c7e3158b49c11ae588631d3fe
+# Tag = 78f852770b66d60e7839982c01fe2328
+#
+# AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+# Plaintext =
+# Ciphertext =
+# Tag = 3d519ddb47fbcd09c435f1e3a9c6844f
+#
+# AAD = 8213a435c657e8790a9b2cbd4edf7001f18213a435c657e8790a9b2cbd4edf7060f18213a435
+# Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758
+# Ciphertext = 0d51b1d0b43e70e0a552121c60ae6fcb24da6120ac2604208a4a6a76fc75077c103cdec9a6b4bc62a9e7827156f204b0c397
+# Tag = e58fdde4564e883245bcf9315e1062d0
+#
+# GlobalTag = 1e7c6c56424f8c1fe0bd042d03da3a1e
+#

--- a/tests/kat/testvectors/Ketje_Major.txt
+++ b/tests/kat/testvectors/Ketje_Major.txt
@@ -1,7 +1,7 @@
 # Ketje_Major.txt
 # Algorithm name: Ketje Major
 # Test vectors obtained from https://www.github.com/XKCP/XKCP
-# The test vector file format hasbeenadapted to fit the format supported
+# The test vector file format has been adapted to fit the format supported
 # by libkeccak's test vector parser.
 
 # initialize with key of 1576 bits, nonce of 0 bits:
@@ -8083,5 +8083,3 @@ AAD = 8213a435c657e8790a9b2cbd4edf7001f18213a435c657e8790a9b2cbd4edf7060f18213a4
 Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758
 Ciphertext = 0d51b1d0b43e70e0a552121c60ae6fcb24da6120ac2604208a4a6a76fc75077c103cdec9a6b4bc62a9e7827156f204b0c397
 Tag = e58fdde4564e883245bcf9315e1062d0
-
-GlobalTag = 1e7c6c56424f8c1fe0bd042d03da3a1e

--- a/tests/kat/testvectors/Ketje_Minor.txt
+++ b/tests/kat/testvectors/Ketje_Minor.txt
@@ -1,0 +1,8296 @@
+# Ketje_Minor.txt
+# Algorithm name: Ketje Minor
+# Test vectors obtained from https://www.github.com/XKCP/XKCP
+# The test vector file format hasbeenadapted to fit the format supported
+# by libkeccak's test vector parser.
+
+# initialize with key of776 bits, nonce of 0 bits:
+Key = 740da63fd8710aa33cd56e07a039d26b049d36cf68019a33cc65fe9730c962fbf38c25be57f08922bb54ed861fb851ea831cb54ee78019b24be47d16af48e17a720ba43dd66f08a13ad36c059e37d069029b34cd66ff9831ca63fc952ec760f9f1
+Nonce =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c5c2c6fee7e34d4703cb1a09864774ee
+
+# initialize with key of576 bits, nonce of200 bits:
+Key = bb54ed861fb851ea831cb54ee78019b24be47d16af48e17a13ac45de7710a9423ad36c059e37d069029b34cd66ff9831ca63fc952ec760f9922bc45df68f28c1b952eb841db64fe8
+Nonce = 3d9eff602081e2430364c526e647a809c92a8becac0d6ecf8f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 5d68d159d04678b74f25c5329d07ca6d
+
+# initialize with key of376 bits, nonce of400 bits:
+Key = 029b34cd66ff9831ca63fc952ec760f9922bc45df68f28c15af38c25be57f089811ab34ce57e17b049e27b14ad46df
+Nonce = f657b819d93a9bfcbc1d7edf9f0061c282e344a565c6278848a90a6b2b8ced4e0e6fd031f152b314d43596f7b71879da9afb
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c6547763d89bf489a3cbd373ca32ea2f
+
+AAD =
+Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef
+Ciphertext = 6361ff54c063323aa83604a9bad069f1a94d7d2a0d433cce3f6d994d2ddeee1fa514700a
+Tag = ed4b71ea490cf168e936e64c55f80b0b
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = acfb4e3ac739eadc3c3c56d4a5e5b234
+
+# initialize with key of336 bits, nonce of440 bits:
+Key = dd760fa841da730ca53ed77009a23bd46d069f38d16a039c35ce67009932cb645cf58e27c059f28b24bd
+Nonce = 1b7cdd3efe5fc021e142a304c42586e7a70869ca8aeb4cad6dce2f9050b112733394f5561677d839f95abb1cdc3d9effbf2081e2a20364
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = bf0c767484b8a46ea84fdc5f186a562e
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262
+Ciphertext = 71411337423396475af398814adf8d1ba9daa25f933582ddfbf9f562ef914a
+Tag = 7a73bff8832ee6da68c5a6b1e84876cd
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+Plaintext =
+Ciphertext =
+Tag = 47348271ef55a9de150b542f2351a6d6
+
+# initialize with key of296 bits, nonce of480 bits:
+Key = b851ea831cb54ee78019b24be47d16af48e17a13ac45de7710a942db740da63f37d069029b
+Nonce = 40a102632384e5460667c829e94aab0ccc2d8eefaf1071d292f354b575d6379858b91a7b3b9cfd5e1e7fe0410162c324e445a607c72889eaaa0b6ccd
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 017eda3312e3c24f372293dcfb2de318
+
+AAD =
+Plaintext = c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 3ea13493e6c20d6a5272e8dbce6c64ba8f63447bae53b09616be
+Tag = 92c5148d16f73ba5fcbb442ef648e6a1
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb7c0d9e2fc051e273
+Plaintext =
+Ciphertext =
+Tag = 911208e93f5a7167a33445c265cce43b
+
+AAD = 891aab3ccd5eef8011a233c455e67708f8891aab3ccd5eef8011a2
+Plaintext = 2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5
+Ciphertext = cd9de63a8e64c64c5beea8f9eaaf9521bad641c3e44f8ba6f671f6dff87e92e7d272ba1c97c775661e13767ce1bccf
+Tag = 0dd30d4bd09b49763f5ae2c05550d0c8
+
+# initialize with key of256 bits, nonce of520 bits:
+Key = 932cc55ef79029c25bf48d26bf58f18a23bc55ee8720b952eb841db64fe8811a
+Nonce = 65c6278848a90a6b2b8ced4e0e6fd031f152b314d43596f7b71879da9afb5cbd7dde3fa060c1228343a405662687e849096acb2cec4dae0fcf3091f2b21374d595
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 5cbfbcc3b27c1c74180a63c177abb49c
+
+AAD =
+Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e9
+Ciphertext = 6072988a6a48ae108290b1c6eb55188cb6cdf89a5a
+Tag = bdd630d9aa5ab88b325d555c318bd7ec
+
+AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
+Plaintext =
+Ciphertext =
+Tag = 318ec011df0de72244a3c94fff9d93dd
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d1
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b5
+Ciphertext = ae8b68a1e96bfc72507bbae76e2c5f6e74bb560065c7a0e36bb138636e52f1d654936c78b5eb21df82a4
+Tag = 5a286396c2c1e5f108a97040c0fa6ff1
+
+# initialize with key of216 bits, nonce of560 bits:
+Key = 6e07a039d26b049d36cf68019a33cc65fe9730c962fb942dc65ff8
+Nonce = 8aeb4cad6dce2f9050b112733394f5561677d839f95abb1cdc3d9effbf2081e2a20364c585e647a868c92a8b4bac0d6e2e8ff0511172d334f455b617d73899faba1b7cdd9dfe
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c503a332402c018d07913bbde5cb5226
+
+AAD =
+Plaintext = 75961637b7d85879f91a9abb3b5cdcfd
+Ciphertext = 4f090e5291bc57093ab3c5cff0604e74
+Tag = acae4b537b582ef6f3f4036ba32364a4
+
+AAD =
+Plaintext = a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9
+Ciphertext = 69f018d0bb8be881bae0a842675f4a1c91d914d9553f5c516fcf3be154b09b23bf0e86a06b09a17c
+Tag = ea890316786f807d93844ccb626bdb65
+
+AAD = a839ca5bec7d0e9f30c152e37405962717a8
+Plaintext =
+Ciphertext =
+Tag = 9aec763c7d3a5d005a3a9d4387e0c493
+
+AAD = ca5bec7d0e9f30c152e374059627b84939ca
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c
+Ciphertext = edaed614a409dd632f67ff9bd40134485269f3146f655f05b4289c3a2280bf0ef53a
+Tag = 297502c6d99b676cb9d9f678da654c93
+
+AAD = d869fa8b1cad3ecf60f18213a435c65747d869fa8b1cad3ecf60f18213a435c6b647d869fa8b1cad3ecf
+Plaintext =
+Ciphertext =
+Tag = 7b65e9729ef7f461152567a8551a7c6e
+
+# initialize with key of176 bits, nonce of600 bits:
+Key = 49e27b14ad46df7811aa43dc750ea740d9720ba43dd6
+Nonce = af1071d292f354b575d6379858b91a7b3b9cfd5e1e7fe0410162c324e445a607c72889eaaa0b6ccd8dee4fb070d1329353b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4186e3342c31d8469d6e8cb91c8a4c48
+
+AAD =
+Plaintext = 4b6cec0d8dae2e4fcff070
+Ciphertext = bf6c2b7661eece3da46a04
+Tag = d016dc02b0f79e79b887ffb06b5d6add
+
+AAD =
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = c181c62d97d78c385e71814ad50536bdd03b5c958415aa8e114046
+Tag = 8a1807dabca5a45acd26185900ff3c3c
+
+AAD = 7e0fa031c253e475069728b94a
+Plaintext =
+Ciphertext =
+Tag = 6d673dc74b2fabf5da9231b7307fc383
+
+AAD = 992abb4cdd6eff9021b243d465
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5
+Ciphertext = 970b1c847dc78bbbbfa1f10d125c54fae0f65635c663cad7235a83
+Tag = 815e6bfe9b85c38a60ec99d80d288240
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 17989c1f32feee6d9c53f556948f5b6b
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d263f48516a738
+Plaintext = 4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a1
+Ciphertext = f77a140021dffd0cc4f09c496cdfe312c77f56e9fed3926517fb38f66e17f01c42be0df49571929fdb477ecc
+Tag = c3a96f0f88d5c55196bd1574ed2d437f
+
+# initialize with key of160 bits, nonce of616 bits:
+Key = 07a039d26b049d36cf68019a33cc65fe9730c962
+Nonce = f152b314d43596f7b71879da9afb5cbd7dde3fa060c1228343a405662687e849096acb2cec4dae0fcf3091f2b21374d595f657b878d93a9b5bbc1d7e3e9f00612182e3440465c627e748a90aca
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 5b49967e32cf0cc10ff2380fefbee451
+
+AAD =
+Plaintext = 0728a8c9496aea0b8b
+Ciphertext = 5d2ffa49dd584a7299
+Tag = 0dc2bc1a41989e0438a750d9fee70b5e
+
+AAD =
+Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
+Ciphertext = d4296468925c818b322ed8cecb68161c88e1c92fce0a
+Tag = ca0cde36b39f15237e2260fa6e0d17f3
+
+AAD =
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e
+Ciphertext = faa97ee569b1563702fcbe8ddc1504a9c12568801c1013bc0be86a94fe3f6c851351fdfe8759036c9289
+Tag = e28c21948415022d87a051ca7d2adb82
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = ae73131e2d7d5e85794feb823ed5807c
+
+AAD = 52e374059627b849da6bfc
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c
+Ciphertext = 09d81094c472ad7f38bf7b8b52682222fc700730ddb832cd
+Tag = fcd9ac4596af95bb8b797d75819074d6
+
+AAD = 16a738c95aeb7c0d9e2fc051e27304958516a738c95aeb7c0d
+Plaintext =
+Ciphertext =
+Tag = 0c4ce904b1aeb434324dad7b6f1ee797
+
+AAD = 3ccd5eef8011a233c455e67708992abbab3ccd5eef8011a233
+Plaintext = 7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e565860627a7c84869e90a8aab2b4ccced
+Ciphertext = 6ee604294b9fa1de514920a31a1cfdcb96168752f972e69aedad163fb4bf580562f3aed29a4b
+Tag = 83ecf5749a4421ba049f9e63239ab52e
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = 04db8bc3e7ed0c574c9d2f68eba76bb5
+
+# initialize with key of144 bits, nonce of632 bits:
+Key = c55ef79029c25bf48d26bf58f18a23bc55ee
+Nonce = 3394f5561677d839f95abb1cdc3d9effbf2081e2a20364c585e647a868c92a8b4bac0d6e2e8ff0511172d334f455b617d73899faba1b7cdd9dfe5fc080e142a363c4258646a70869298aeb4c0c6dce
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9f61878887846361c6b71f4cbb386579
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = c56193ae5a4c48
+Tag = f72e1be094c8fc0a7249ad8304059bcb
+
+AAD =
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
+Ciphertext = 5fe1042236ed2355b61695cadbc3c92608
+Tag = 608cb4cb682165769cf00b56831d0e8a
+
+AAD =
+Plaintext = 95b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425
+Ciphertext = 452852104c1f0ae7b0b530a8973fe7f54a95dab911d0f5578d49a1bdd44f5599
+Tag = adcd896ae0b8b62df7c1af2a0688ed4d
+
+AAD = f68718a93acb5ced7e
+Plaintext =
+Ciphertext =
+Tag = 2aef7cc072a72ac6574c2679229dd36f
+
+AAD = 0b9c2dbe4fe0710293
+Plaintext = a8c9496aea0b8bac2c4dcdee6e8f0f30b0d15172f2
+Ciphertext = e110d18f56c7aeb91a361a53d41f9eab4bbe076a5a
+Tag = 9a1f9bc1aafdf34b9d2a47d3705d7547
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+Plaintext =
+Ciphertext =
+Tag = c8510998f705794f72ac931b600b9096
+
+AAD = af40d162f38415a637c859ea7b0c9d2e1eaf40d162
+Plaintext = 4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c
+Ciphertext = 151d59af3f943d5e53d53c1dc2efc737802f0c7a063beb8fc587d3a57302f56dcc
+Tag = 91d16e22a2846a22dbaec84f237c159a
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = fca1f633ffa8acdbab4a885f2680e564
+
+AAD = df70019223b445d667f8891aab3ccd5e4edf70019223b445d667f8891aab3ccdbd4edf7001
+Plaintext = 7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494
+Ciphertext = 0d4c88ced0ed144daf99d62ca7f79b192bd40fdfd294836ffb978d1906418256390382d5a41cdd74bf769c82ef76b23cb3
+Tag = 4c4b3205abe0feb95ad1eea1f2f448a5
+
+# initialize with key of128 bits, nonce of 0 bits:
+Key = 32cb64fd962fc861fa932cc55ef79029
+Nonce =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1edbe51ec6e8b9d2
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f4793cca1837459bc59426f3bf8e4ead
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 34401af0f7421b302a74429a294e38ca41e4c2e6bd20e20c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 048734635b27f5e95aa0992ae0046012d72e11a77a4df1e0314446944bb69cb1
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = b213213771
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = c1a455b65b
+Tag = dba71e5213ef9854
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = bb67119454
+Tag = 0dbfc6fa7a3f1ed033537e752485fba6
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 24e380ef03
+Tag = d5c2ff8d10fc7a3c998a288e2ea181001cf4d83cf5c338a3
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = b689910860
+Tag = 7b37874ab4817d1d93f339de0b6fd10852ed7abc47d7c1bbf9b438b0852a42ba
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = e308522db4735470bfa1547c
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 4a393487fab60df2408773ba
+Tag = 69bb34aa5f0261bb
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 1a8e3d2a35ee90eb4125cfbd
+Tag = 301cbfa466e2ad4bc96512aaf733e877
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 59ee263775485795105d2840
+Tag = fca68e45124eb4f42da85d0751fa00a1d39f45660dff5741
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 49e5cfacdaf374de23a5f094
+Tag = b8ba3d9e0bd7451330ae78ba684c4ea4d157909eb24dd74db36ef2f91c523a9a
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 4554148718ac8a58ca2058d17b11e60f218795738f1998
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = a523da12c139eb63130add66d4acfeffb5b3602a3939ce
+Tag = 4ba8b91091dfdce9
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 41c261ca06fb3850cd1c797f1d3ca6c10cd9864ded4076
+Tag = edb3818650f5356e82bda4ff3baec0df
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = ff9b3cf2b637a084b808130f4a3ef2b5b50aeee0e24cd6
+Tag = f8b631d4c20c88b3a0ee855d07d7e789f7417ae44f725331
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 5d2bb844c152e4e4410c42055dd0d6c8deb91bda617d85
+Tag = b7d7957a9f326d10442d5cc98531e849123c148ce8da89c9cd035a303978eb96
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 205ec3fa4221621b87f6de34a1ccd89bfeb83d647d978435722844690ca883912d51cf74fe4a8b
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 80984c2511f61b08d4f495a8551d29af7258dfa1185cc6288db778dc1b2bbc04768857d7795e62
+Tag = afb3829f1273666c
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = d51ec769f4a8e7628bd563e2e9d0183c94b577ad8b4d67e1ebcd6f2372cd06fd8c2e03746c0832
+Tag = b57efa05e783d74089fe6f5c2aa1ec20
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 77b4740eeeb364e65829333ac8ffb752c4d6178766b80f71372ab0ac9ea96034699390ce253f54
+Tag = 73537da06ad878926e359ce9ce1539a950c0f18a2bf61156
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 1c044fa51d255d23ec6c1539487916f5959efd843173990e241c846675bdd720d9f84b8f41e169
+Tag = 244f0a8f9ce708878f85383c4ccc9f398225a1cf10e69e5a7dad503ee7138348
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = c18d2747dba0918e
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = c5d183e385dbaa2370eb5e22fab0b147
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = daaa87f237a4b56b65a6a5b2a5ec6cace8860f84d602d9e5
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = e0dd03545c069c571a22748a84d0e804e8d0d862bce6577f1add2f2d43d006fc
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 950543d7e9b3866f7a4cfdf4d1f4
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 9f9d3586161718e9d2e82a718f34
+Tag = b0e1861c1854f63d
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 8d366ec88be6f2704c017ab42a9c
+Tag = 8ac41f95a32cbc8a329277f4f9e97ac8
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 74abf85d6592ed666b042f9bedb4
+Tag = 187e6bb751a2c2b55bd38e4cf8c52a60f57f043c2c0d33da
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 95afb9038d669ed91e76ef7e1bd4
+Tag = 091b70822fbd3c308b5a05df87240835780190a03d9e018887a9b63c4e6e42d7
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = e4ba538528ad7e50268a9d490e9260ee2180d99830d7ddf6468359ba4d61e5f03a8a85
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 03f21a32fcfb40d8df5c8a43e758de74e897cdecbcde31f45fb6eed69e19ffd9a715de
+Tag = 18369e2580436831
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = c60e9a56640e837618eadf7496ba4edc5e615d9986b634f5d96f35cf7dba2a465bc66b
+Tag = 75af9b13a317b153a3c2b329f1d76b65
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = b78a302aa5b1b8f46cc0d0d6eeefe98b2487128b3a80e64b1eb7722405eeaa4c4fa2ff
+Tag = 669e75950fab4536d0517b057cb2bb4ac5b0f7178a85769c
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = d5b3cebc23e2f7979f2ff7cb5d5783788d5e31a428f58b0c1c3d9b983e9f521be7525f
+Tag = 39307e61bb3f2192cb3bc0d76fec130e0a8dc22fd548a864e645b52d8f89709b
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = c64511586c67a0f7
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 8930aeb096d7cf5891a163e3f2846d10
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 12f15a2faae4dd15b05b7ade3cd3ca06d4b5194ab07fda22
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = e775593e2d246950efbff85f00ac4e3a73c49f4093c52aac11ff12c716b121de
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 99cf7d0d6839a1e12990a3da41a88aa0694c5961
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 4762ada356a19aedd6ac0b151deca677ac6b4ba2
+Tag = a23615663049e245
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 0c89f0e904e6d3c71904b78a109655b3238fe90c
+Tag = e4d589860fd3a06ca9b1ff08c6e7f726
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = ab69ebd11162419a1b32d1a83e2b0e70c15fef95
+Tag = 6ee839a2d4b52e251d56cb53928fcdd0eadf4cad41c1fa7e
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 23853f373611c295091048342d18e3ff45054c64
+Tag = 396d9c52a97467c688d91e6c51bc01146f633abc7ba345a5028a86adf180c2eb
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = ebdde4c4f247ffac95af0730c3011130478b471bfcfca2a033100b6e49f53f1b6ff4a57d478ef5ae32e8fb452e59d93f41a5
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = ab66c19a1a5288dd98705b79dbd440d02f35fe7dfe0c44fcac2e4b0e0b5a11de08331097cc54928fc36a16443e37ec4378ce
+Tag = 4dcf2338641522ff
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = cd84407315b0028a7e0a9aebd623e27e05813afe7778d0c7359bd8272d302ea905f354bf0c674347497b6678625ab98e56e5
+Tag = 06552303d4b5d33cf58941f1a403a660
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 70df551a328fc6e3439a31fedbcbb2a8e39d36a9f6d94f57c17bb8888b9c989c5dd550b497f95c145c892a0382289f504399
+Tag = a0212999c013fd64f88d52775ceacf0cf3f5ab0106b277d8
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 932174449c34b3460bdea6287aeacfe40532d9d02549568db7c112eaa45de1662056f9edc4fa704a1271c64bedc289f1897e
+Tag = bab0837988027a7cabe7e10ec62af6da6a208ca7a7e4a4eb5db39867f94beca1
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = c14b55eda5ada709
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 6e36fa4c65b5f7f7c96d0db4cf25e358
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 7c59c596f5dcedd9a912a4121185b197150916905e68d107
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 1a746d82a22ed4bfee5406105b716ca782f6d274d63b2903915b3061d836fb04
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = fe37971fc4e893c8031f8c43c67f74aefbeb87c707473aa220f6f6d3
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = d98ef4645bf3c2af32a53b5a0dc0e0689a72d22b8fcf39303feb7d8a
+Tag = 63975f14395e5e33
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = c58d15683572f3c89d7a9d44f43525f4ee5f393efb72a571e12bc1f3
+Tag = 06e5ac9add0f43031efd28fc7d2f1fab
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = f08971a8d5b9a11f289427719ec6680dfc73431231ca6ac84b6734d6
+Tag = 018736a0cab750ed9da30fb0aa2c8f938a674de3d591e241
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = d27606221dc1d0c50bb6d96398c205cdeb75bf11c26691279a58a79e
+Tag = a23cabe5966be450593a5f1538ff021b4349040a7c3d292ac447afe226a0d947
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = f67300b50564847d
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = e89841b62b0fdc46af0859466f441879
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 5bc564fc1c561fba39309ff6162a005a232951b9f3861eb7
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 5ce1bf897a4c8906b541536ada962826e795aed7a3efd81642843b88fd6617af
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = cdd40e5b6eaea2a2a9ff981a49d00986cc8f8387c40d845f36468d14bb13377e7a1063b1624496
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 60407856af7494bda13a4d395e92aea25333cad047ab703d27c5735d86e32d927a7d178a2e7233
+Tag = 69eb8a6b409e6b8f
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = f1f394b5d6a6d96fe8c111209de87e53c3f42605704d9c98af316ceb28f93e12299767f45965e8
+Tag = 705940e9ae82b91e92fd8898412a54da
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = acf45411a160c7208da8427cd8a13b5830c15bb9c02c1b472e62a22011e87508e5f6b5dd0bebb1
+Tag = cfe8172901bddabd80d2cf590fcf62186caf3c90da02d397
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = c2837e6f51b8b85b2753ae8a08678b30f71278743a7797471374b05c1ba58fbded84e625b4b2f5
+Tag = 954fed1f1bdb214bfd3dfd611dbe4bca4f7f186cf203555b0d4b850f635223f8
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = fb39ed4eae98bf4f
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 9831cc4c4f9d7dd2ac6c4ba83db293f9
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 1b7075e09c2640b56a002ef17d7f22d5a9eb6b4afd5af77f
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = b9e1ba649fd4a9d9abf8f379d65c38632e1fde81dcde8a8f83813c021f8ccced
+
+# initialize with key of128 bits, nonce of32 bits:
+Key = 36cf68019a33cc65fe9730c962fb942d
+Nonce = bb1c7dde
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 18135cfe4defc47c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ff5a190489dfb947ca4a1f32676ce619
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6d6b8e73c071c8b19c960e4a8f6e1402b43df54eb67fbebc
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 56533868fac8fb50f8afe3865907999d0f2596fc1a104f1dd5a469c2e813e064
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 7727108b1b
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 627b9f6f66
+Tag = 2a0540c2acf8445f
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 435bb0a850
+Tag = 0713c8579b809f116f3b59720d5e50ba
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 3b1393848f
+Tag = a15346c9973ce82baf00cf5629636b4e03415540774e6d98
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = c7eeeb82b9
+Tag = 1e553440ae7db0667fee278dc927a15418f101be6d0e3b90a2043a49ac5c9619
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = bb0596e8273a92f09c0d3b96
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 959582ffccdf5279dd507cc0
+Tag = 17ca548a6b422f0d
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 16b0805660db2d0df63c8a5c
+Tag = 47b71052c56f98d497bb6f42b39fec44
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 5f2b9c182900de21a2c2eb6d
+Tag = a2d788cbd44abd2b6640c4697480cc2bc836919a16829570
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 857cab97e142b821b66b8970
+Tag = 8975fa87621bfbb784f4851add7b7b7d437693a3acd27cfc3d0670bfc7b15293
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 7f9754fc750de9972597166d94664d6541c5b9508c7e8a
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 01c71499fd096d6bdb70e72e08c0eb30260029b3b69667
+Tag = 7a55e40333b00a5b
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 5d167a744a506eea750ff6b70de5fbe9f83336e402c6c6
+Tag = 6fab3e48a4e882279e21133e0051f402
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = f1467416382323f3660ee68e3e450b76dbaf3db28765de
+Tag = 0ba07cbdba9a41c251685adce5b99b6f493d3183b932db00
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = d1ea1dc68b98dbec5b4b241d6dff7069a14cc8d47f69e6
+Tag = 932aea18d8dd41e36f01ff6d1a744b01111743905a5ff6d76ef3f88a72f48a8c
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 0a78b2bc198be7a34c46e9b14e0910bb86e7310ba3fcb920f40b3991da631112c5be8508c4c0d2
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = e71c713ae8767612ed0ff69cca12320b5c197dbf2a4c83e88cdb9d51eeb565cdc15963b6f2e345
+Tag = 5fcba90393d1054f
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 39599e63b97bb2634b51e95f51b81f0a2e19569e5376fc70dcceb51439f809b5a6ed40c77b6f93
+Tag = ab7339a2b7818b3bd8dc5af61a179d49
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 126045001613879d7c0dd85c372cca871fa6da4850f18b66455fdfedee10cda8fcda2958834de8
+Tag = f01f180037002b801f80c2b2535e589fe7099e087e7eb01d
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = f1a120a0439aca2cb4110eabb24951bb70ea611039ac5a2951fb31ea2b7c867841fb289b9c65ef
+Tag = 89c8e0f11adf6fb6ebc06fc6d758459ccfe0899e7265195c5f9bdc371864374e
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 6dd904d29991f2b8
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 82dfcd2731a79f683e812bb2e1258e69
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 1a470e01ac8143e617165452254353967eb6e3ac735ed166
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 75ce78823e62b0e2285778c8416b7cf4cca04fbf6d1f599eb45df650995c56b7
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 91528947cb57b5a66cc5bd40f5f1
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 3b36773502b679f8f01ba951b073
+Tag = 0bb3d437e280d060
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = e6401b95da24ab8d2ab593022fdf
+Tag = a86ce02f6c2caa2bb14490a12193df64
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 767f964da5e91ddc829f7903614e
+Tag = 7da73b5e13d901977eaeeac0f3e57b3cb74882ae149f65a2
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = d3a1c383ed53185fad66fffe8c52
+Tag = 6b124985a264ebb7e1788dd79b5865a3198814f065acb84202c40ded302e2256
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 74d07e623298ce7b01af0f7559121b44a52abe510e46dc3e7fe63681f24121edf32de8
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 779f0596687c8cae950ac6c551471a03f3bd537084dd9aa6a1c938190eef899c89e232
+Tag = d3cf4da2f0bb69ae
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 49e54f43804493c15722dec231480096b76973aac586045090e235df923dc75e6e4a68
+Tag = 64d8c861a79d364e8bcdc50b87b8b3d9
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 3ce085694a95e5860de67f56fe92ac79f9f6619befce9a9bad37012c6d4672bbb06b13
+Tag = e1bccb2a79d0379e08db990803cd85ec5675f43ba278487f
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 0f5d00fe283dad73cb1ef3a40564bc2ab94250eb74ff2461c3dabea02f3d89329208eb
+Tag = 992b95910d6c6404ed69f854f0272f4b5f4f6967a6a8602c016b1e443d75cea2
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 4bdf06b79f192df6
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 6d0d2ab25937493fce6bc184112d24bd
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 3538847b44095a8702c3372cd59fce6154744f003faf0937
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = f7120f194f569596e0123bc28c91f2a63490a9f9d96ff8faa778a8c9b45b84f7
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 55a203a173fe8f5df8446b78f42aa0f70246af28
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 4abd41159c1355da6289892fdcfe1d88273e1c3c
+Tag = 8779f4ac967af6b8
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 92abf3cf540776c0a3b6e2d9d6fc1b36f70f0b37
+Tag = 95ce9255f8dfae77713f05162b2651c7
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 00be519c7d53d5a76dded91534c8da022d833375
+Tag = 4576e96d01654e0c90a903ec3fe2e0ee1c55cb2631975816
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 98361becc418d6f77606d12acee4ca898a6223f0
+Tag = a96c5e6d15d558f8f73259a22dadebff4cb846884652dfacfb017e47ad64cd8d
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 1251668a76f3f5f8e7c05c262992d75001e812bd0f9a0009adb1a786e86e1ac44a3117cfa0d53f3b16af97246bea85aa1c9f
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = b32f86bf3d53a6febb142798a4cf27153ebbdace10fdb949520c055dcfff8b371d7f5159236b54ebc3599e217a7db7e1870e
+Tag = d1c0c030801e76ef
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 39af87237c465e9c976ca77fbbcd75aaaedc73d60e7c8b1a013d5949d2cefeaa77ae755fe8089317d04e938d2ed41220f390
+Tag = f9330f411457e3ae88437428bf437146
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 70eac8ff5c6842660e5debd85710e12317cab072efaba9d7560c3a744a15dc26f5649d60a189d48cb9c29fbad969c0f832e2
+Tag = 3bf2fc494c0580a213ec346b9210c821314a1020ec99d839
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 8bc09fcf38fd2f66e6c796e53d6cc5e2a26dde470fe587a2720fb8ee4134e513b6f23ab936d110243b6d8584e5c5b815d641
+Tag = b44f47aca9f5f2bd9af635b66f908ceeec3edda32c8e315efae02756a4ad5d9e
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 5d978930e894d55b
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 4f74f5c69ae9aa4bfe0479d0941fd3ef
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 2100aa7d8571c40ed8bf3ec4d524fd422241fec2ef813e5f
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = cea0625d4cd02c12d3d4e9ab7d21284e845165a2bdb3b02ea222f99679ee4bd3
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = efcf995eaa395ffbdd6bb9ab18e02cb2d9301b5cf14a44f78d2ef0ce
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = fe0518543103b3c1d746888ce29445ac4fb172f6e5672cd033e2dea0
+Tag = fed86d045b4930ca
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 4e0ba9b02fe2ff0570b6eeb090d271bead0a665c2b871eb6c84c08fc
+Tag = c402fbccc5baa0ed72d1aeb2a2e6ce4b
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 6dcf51d78bdc87af23fe77dcf2d136be2f3f3ff792299c786aaedf11
+Tag = bfb321ac543689e90ea5da6701c93678e638cabf6af9d744
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 84a64b1f33869c30325daa8b91bfe1d7af019cc1acc225eb24c3c129
+Tag = 5b06af5af636ac9515b34fc7297d17441ec88d1f4a8f03a0ff1764ac505a6601
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 6914d9292dc113cf
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 0bff98ace28ab294695859ce48ca309b
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = d832cf5d854c8aeed67edc8ac813a70cad2b72655d570912
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 98123653919b1e72ce42016632cc8c449663280c549c1cc440187876a83bc727
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 1ae838c05ccb80da2481371358a1092efc8691409b677fa8f5c882a9018265a10a55fdb8dd238e
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 70ba1d655f53e20cc08302b53dd9dbbffc6062682eab799fd838ba97764ca2e2277a8646feb644
+Tag = e3125b8a748a8709
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = c0a9aac7db5b15dd3c9639ccf5f86af45d26bc3817bb49dcfd430ff7fee953948b38ca8fe009db
+Tag = 59da63f239aa573be2b55b3a7ef41991
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 6ee2f1082401fe3ec5082b28f62e869967d65673d7078422308796d8e53bdbef02695d599cf1a2
+Tag = 2059ce82f1778122b2594d323aa306ed24a6777200e71d81
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 59c2095278565a7b3d196032626e7fd9a58dc878c451530d3c284839c0c5b0e36feca256673527
+Tag = 4861a691e655eebe8b016a30abd45c9da68099954569916f054910039c7713b3
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = f5d9e96103fa92dd
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 8ae8c9f3b4946d5209583dbae8f706a5
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = a3d517107f957fcd20863b65a68060606108451087f64922
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = ed24b41f250a5846a8aa3de51b4ca2b28cdced438dc91d26ab226fc903bb0036
+
+# initialize with key of128 bits, nonce of64 bits:
+Key = 3ad36c059e37d069029b34cd66ff9831
+Nonce = 43a405662687e849
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = bb8cae670a444f9a
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6c271431aed601448b50b99556fc0c2f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = b401aa9fb008f2e3592832e4fe1cd900d9e7ae55faa29767
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2900744030294e92dd7691b56c6766d36bfd37c8832fd9d42227f5f72b7b2a45
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = c2ed9f853d
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 962f1ba186
+Tag = 645ff3df1e4d8007
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 9b28083270
+Tag = 41c97300f25b0dbfd2019426946d0c0f
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 490fe3f7a6
+Tag = 82b1f5d5f2ef7409404f31396344917c9809cc68faa54700
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = c48b4c0cb3
+Tag = c39764e316c1e9d53eb78e204e1c599e2c5e579911db446615efb6e6d2e6a5bd
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 07e9d73075afca0a41e397d7
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 42d2f0bff8d3228e1b1d2673
+Tag = a7f96d0549459efa
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 781ad542ec051517618713ba
+Tag = 5b4775fd00c671f1a4ec0e0579a00ac5
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = da06ab1bba801dda0439b1b4
+Tag = c5dd63541465a3976d688f0e53ac35ec61b4ff3b1b8b0bb6
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 9d75acbd748a8f8769388411
+Tag = 61f5559f4cb260aa6f8aeb1206e5563649ece4ddeb21917a48780785625d74de
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 2d8a520ea47decd36bab0de9c1be0834e63bf6307c33d5
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 5db7f880a159a03391b57aac99bf9a6e99461e4baf52b3
+Tag = 9bea9ff7c67500d4
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = ce45371ea57c14cbb0d526394b5dbaecbe8dced4c8547c
+Tag = 34a1909dbc291e3390809de24dd5bacf
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 19524c57a7c0ed56acd78c03133e06f5e8e5bfaceeaeb8
+Tag = 0336ef15b78500dc645d96e0660acabe8c436ee35780de58
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 0dc0fe5bb33f51818c436de58da6cec169cc9f9e7768bc
+Tag = dde0723f3333f3379a477e3cb4902732510303890210a30eea2e5b2af3750c8d
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = a9ccc1fea6deff1a15bee00939d5cdac53cb24b33cea3e4d0192b0cd093daf9571735d1d5ca61c
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = cc0b4b25efb27edf0487c1524f86449d1462cf1435d12c524b5e1c60bf63af8c247386d947e011
+Tag = 2698b87c3cb9b424
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 3a87d90bfdb3bf78447f25e37019881195584087a4526dc87ff387d98425f6c639c0dba3eb8037
+Tag = 477f73e0a7b3df9805977a92b9626046
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 44424ebea55d06b118c4f5ee14df12a2a6cc168f2626af5d8f258e3d3c1bbbcd7e0318ac112981
+Tag = 6cd88ea1b19b3ac6f336f546e164dbe14c40a04b9a3b59aa
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = bae610856c7984f8ad813e12e9d90d6e9ebec405d536c91fb1e09c76193fa1395b5ca5322c0aaa
+Tag = 7b550aab50782c58e5939346c6e832b77d78527a8033be4a110384ec755e6272
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = a0ec5f06843713c2
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = c58d8dbc0b63d5196b612f71ae2486b5
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = dfab9fedb0ee74fd15518f9dd0aefaee3aff55eb8f8d6a01
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 6e3da5916a20d00d03f255dffefe9415dc5c8625e4f7bc31f4ef540e6d106a98
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 33fa26baa4e33f1ed937005dd4de
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = e286d926ec5f4288542c1fbe5613
+Tag = 74fb7487bdc25f99
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = bea0bdf45d32c92873c169d72e08
+Tag = a4c01aca6839aa727d3da5ba73899601
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 0a225a00cf804f9c95a682298c66
+Tag = d701ccec52b5b05d0a38af7ecde721c1c11ae9d83e55a5aa
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 32dc78318f7dc437fbce3e5796df
+Tag = 109b8887012957fc648de2ac83c8dc1666a58fa19e2b374faf314c3d7f3c719d
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = d66980af8b4e00cd39b4996e56fc8f8e882f415b8e2418498749eff075796cfdebc72f
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 8deb8c7fec77ca28df4995b8858805bfba2873e242151b024576115efbd93199437a69
+Tag = 8944ac084a02311b
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = a51eb9d8b5fa16b54224c3f02ec59b5b68b0869aa4a6fbfde163b868a506c7d917df7a
+Tag = e2c1b964b2e86e2670680410b97300b8
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = a703541870d08cff1400d436935e9d52b6725728715927001a8201151aada8cb1b967b
+Tag = d4c354c4c38403aa776a36875718add86a0284d4123896f6
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = f12a3b3b474e888df4daade699ace04277e4ac5ee0ad242d27f3fd59ba41d6839a5fb1
+Tag = 0f15cc14a32444ade13b70ebe90d2f2331dbd8bf7527c41d7e1ab95c8c622404
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 0d6d75e0d4090dee
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 6250e1efdd2287a9db4852bf7d74c3cc
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = c0f95dccd82b8da0dce0b981bd953f34dc46e82e4c443f74
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = ddb6efac4da0ba17591460c815f2748549626d3c57a8e20ab59e3fb5ac9178b8
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 164cb1707700ee06f768cf4ed630307bebf1200f
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 2b83513451626d47143c7fe3c7ab4b1838450658
+Tag = ab8867bd0e7307bb
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 1dcd56b2bb25cc91bec03c834fcba2337d651003
+Tag = c93a9801a6071eefcffdb553008db142
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = f0a4c5c83e9e7083de3c653c5f1bf54959e00219
+Tag = fd933e383da3fa832958aada8036b84ea2ad34d4e61a6ab0
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = e452cd19bd48779188d555af5f8462789148c735
+Tag = 06feb931a5aa4876668c201aea661671b5a73f54b815a69e89b747a33ff056e6
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 739bbcfa11cd0d3c5ee88405695a5569b14e8ade6538ad79ff4127693a93c57270179b1d0232302ed43b4c8e6d6a0adc20c5
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 69d643e5c7afee35be5e5c5f7a805cafd009d5795427863c0729585ef3b58e748a69d51bb811b787f58cefbfdfde16f78653
+Tag = 96b985df416efdce
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = fe948af0129faa219d0cfd3af49ca419113fa76102850ca35fe20e9bd5befb369146c9eaa45caa9f14f4b0fb87b66ecda1a3
+Tag = bd8c56e26b0d81955cb79653ddb6ee4b
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = de1e95a6322634b87a263c0f430f3bda94f59d32d512835652ae92690ef38211165163a62855c39ab6963b2d0fa456f4941c
+Tag = d057029174b1e3fbc8ae3749b144cc42bf8dd1d3fcb79bc7
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 1a87fab66a4ddd6023908d65e511cc41439ef5ed9e6a36206348b1563f008f6417fab9172fb764d8b2d05479e3bd3de0f5b7
+Tag = d46a842bff3a2aa0a9d32484413b160bec3879d829dded01eb021c2e38b08e17
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 4e223c2f85663433
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = b93625bfdbc8fd2369888eeefe7946cd
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = ce575f9a9e35d12132478d54b640750933c6c8f202b37ff9
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 46b77249e1b3bdb699a0e6f9a0ffe982756a8c91fd276d1fdaf50adbb8728dfe
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 6cc3949f140e2746d0e7c8fbca951f5ed9c631c533f0a575ed79a296
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 8e3ad352cd131e24b70c4026a5e4200d693505fbc2248983fb1a8cb8
+Tag = 083a226b08bd2410
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 304de514f7962b91e0c9fb42da1bcd637b99087d0423372a991913dd
+Tag = 8ab5c36a71802ec9b754650895c34181
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 202c65057311db08bdf451f34568fd9ab55c7593979ff4479bbeafc5
+Tag = d4ffe58991fad318dc57b5f9b901dee33a0c89236f7f7f7c
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 601b6694610f842e7bf0701567fe851a6bc55d4c5532acccf7ba347b
+Tag = 21d845676830045c42be76d73d2e6fa114e172e6178e6af53b8b1f90fc7bad60
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 50a1bf9769bb09af
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = b21bf175c6d887a6d8a69afe583061fa
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 35605ea41e4c4311c135013fe52a2b3a37a69796b23f09eb
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = b719f1f375baab34fac2c5e9580ac6a257696e092bc26bc3828688c95bbc984f
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 7a4df27b591e29e489feaa61ae38bae7279c71f83f3df37ed611a33dde0e184d2fe57dcd1c8469
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 707571bd5db70ca656c8487ee0340847ca222977f78f0fa3b78db06dcb86e521f3c8bb94ceffae
+Tag = c890c0698035e52e
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 80343352b61c342a618f7c6a8e01288ff7926fff8cdc3ac1de068215821d70de8f5d4928aa9294
+Tag = eec4490d33f905176ef9a2f0184b9cd3
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 4ca1f7f5cd6aa3f13f5aff82f4996b5ec28a9ca09e6778a21d531957237b5b1daa827b32fe768d
+Tag = 2a0ff965eeea6795dda447dcb0e3cabdb224f68a2ef78a6d
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = c2f92005801e1d75863f5b1d697a5b45f0d78804e87a4abaa4311c3f4f0de54f81c9ec28da9726
+Tag = d6f4f9ac74312d5509cbcbdc1db15d7a2588f5164e80d8e7d6a40c51676e41ac
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 8e71d75677b75be3
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = cf4f103ec3a6ef5d51f2d96d42f387e7
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 8f4ea6485f823265e3821533bc24f3f8f405cd286327c4bc
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 68cb3d04316866518692a88c9a76c9bfdac1686276eee037214e54aab35e300c
+
+# initialize with key of128 bits, nonce of96 bits:
+Key = 3ed77009a23bd46d069f38d16a039c35
+Nonce = cb2c8deeae0f70d191f253b4
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 43ce8bfaf133706d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4e16a75f94a2aec45dab3781a58a3d6d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d8a06e08575e5c2fc33885f05258fa24a5a579a4b0662422
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a0d378aa16b4c5b07dee0e7540a277a470d6fd79229283201d50e59d12151669
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = dd865d1dcd
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 3da70aaba4
+Tag = 9ddf84db314ec847
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = ed4fe999c1
+Tag = 4d22fff3a5bfad952101739f58358540
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 16687c381d
+Tag = c89fcb3ff3b479f8450fbe425d13843767e39fa837988003
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 4defd82958
+Tag = b04aba9a094afc12a38e42d62bf8880029a9a9915b078058af82047e3eb3edba
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 4556a790db8c9dce32249536
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 79e36fabe592513ccfd0d922
+Tag = 5244f51bd34cf03c
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 2978c803f995a801748f030b
+Tag = adb68f45abff4a1c2cda5aab23db4fca
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 588f191ca33b7a89113899fd
+Tag = b1f61b1a96ff5aec180de6e572f00bd99ce5686b7f0cf8ed
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 0a6805bcc3b584cd9738e95c
+Tag = d2c7e7ac9d811eeed70884449ec92474b16352efa31f8e11067227575222232c
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 235c6ba7751283f60d688665a73ad7302b31521f112120
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = dfbaad4c26cd675ee5103fb7e307023baf05298573460e
+Tag = a5e333060f5256c1
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 06b81f37006d7df571b53d523bf2119af25c359819407e
+Tag = f0def310c4e1b755c7da95fe6e11e7c4
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 2fbba9f846cb65f817c677a3ef492b46d09b19b2a63b87
+Tag = f265bbd3f9db50d7b676c7a7041a3524c106fbaad34dfc00
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = dc7af5d783f293ade2aae99dd2f76bad41f4482d3bb559
+Tag = 6a890daec106d93314bf35f6293595e15a2bd9478697abc45ec08fa13e9a38f5
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 21614137a2301f9e55be2616bfcd1b3658aabad5d88b5bb2bed7375f747b5ca066ded0bb338321
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 46b26b4649414c04966eecf292fa5e255a8063b5427f46a6424502f075291e42507f013cad5b6a
+Tag = a9db28f6c8493f40
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = a770929cc648f1ad57540bd47ec166499b9511d1b592b791812a78872bcc16ee070c9741343261
+Tag = 4004479ffd9ccaab158817adc0d3b345
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 77883f1f634f9426ab35ceefb424354b7e9d8c3c0c9554dcfb0b9bc5814f5109ad45ce458c18c0
+Tag = e9372e76c2496e4985dbb71b3c477ba1efc4b6a7f117341b
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 9651e328bc65257e186d0fa4a9bf2bfcf54b48f70c318f7f08b47db3aa6fbe87314707712849e5
+Tag = 375438799f152265c639dc600bf7476bf247af3dc9121afc645697ec3b6a6d59
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = de0d57d834eb49bb
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 92033692187e4bd1a54a64530429e763
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 8eaedbef2533cd699168d5b2b6c34de9eabf6d4112d116cb
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 8b0057c876114d8bd810b2cf4f928e55051ef9c63667905018f5b3d131fc79f4
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 9c10032caa8a3b1d09602ec8fd77
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = a65c0c466e1b6e31ce32e2c26688
+Tag = 3c730a4f2f352649
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 0f9ee26df2acbfc86ec75fec5d69
+Tag = a09e7f472bc844ccb87bb5f306eb0066
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 28406c0391f6b5b3d1450ab1e35d
+Tag = 1cd289d464f1d0d89d005a5cb736546a706621760028e74e
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 645d1b9916a8b32748caed1df833
+Tag = 109d1664798985557f9ebdbf301a028bdd6f3d198abed6e8f68a007101936dce
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 5e035bf5f9f84b3a25b568ee86f12c4e2910bfd1695cf599e10e06db3dd5c7076364ba
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = ae332600718712f3192a6d636e0eafab1a7388e2ac20e93ec30dfd9f30fbed2ca9eee5
+Tag = 138295bea154f06e
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = b6bdbf08141b2b6cebb50ada6bf8a6a9a728259b337d8fe16cf0d45b688a75a98f834c
+Tag = 55fdc46f0d242420c709fc48967ff48b
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = e011c90a53fd50d8a0388a677a11482b6651ef9b087291f2b7213674d18882fa69216b
+Tag = 2093dfd596782908c4193cff31b479ca1ab1ffffb4566843
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 3cd72fc6f9d377b1a964fbbf11472c3af45fb0f0f3198197811a38cafae329c61d791c
+Tag = fc17da2a9e7a964943cabd0cefd188e8fdf6ecbb6b0d57728e29b6272dc79fc7
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 0f15b0b812d52d2b
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = aa0db4559fb8247b0d0ab8f605384a2b
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = b35f56b5dab1d479474cf6924baa70601f41e4bbe61c93c7
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 9a78175f0cb6de3564c2256833f1ddf17c7df093c43a0eaff57d8d85311dff05
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 657b0fb2cfd192eb125f460781b319f2b9c3e601
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = d8ce75d2f4301baa65d09157c082c2a1674518e0
+Tag = f612da4c877b7491
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 6624e8224b50b73a50f34463d025a9245c6eb5d9
+Tag = e32fb28eb6355d7bcdd44cd36960f962
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 9106c2f87babc796d9056ac6815b2efcc9a61dd1
+Tag = 149beb3149ca55ead33b5e945168faa9c1193620ccb67ece
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = b618e1e4287a5a6e985304bce8b35b8791fe5c54
+Tag = f883f44fdddb9ac759a2f153e3071b82387da05c20dbc77ff1ba4caabe338367
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = e69e2ffa8e8053e8b82df7bb3030f28045c597d71f9bf44acc5bb84816328a0fa29aeab22c38ba506b64640d3fdd41467289
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 023a8805e9b439ea032bfd050ed092900d9c0ec050a9258194b0a7ea2a78123c03470d3f1381e0f27a86b499239fd81c4821
+Tag = c92edfe446425788
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 58b96c0713199a7ab6779b98c954bd6ebbfb35f77bccc84a6c0118204cb3aa08b06a8036abaf6b9faa9ebfc614f83968950f
+Tag = 384a474a824971bd6087586307f8c798
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 7d5dc4b6d98e0f4a061d43f63d8520ee9c00f422391a2e66dae460cf0ecb9d198f9bd767f18dcde9b07d4310ba0244161001
+Tag = 8b74dab85990629b41fbaff677e12fff9e88ab0288c7b19f
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 0b3c0206a677493058de39668b3883a652419f67845c5c22bdb7719061ee9121a0b6c934871e48f3836eca63ea9e91e2db35
+Tag = a653a2c25848f4adaa659193d02137ca72d988b3513e345580f5988abdbf3ae1
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 87a25603b3cb728a
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 94b4d1082e702176dddb85378a6facaf
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = b1fe39fb0d2747890aafa5809343114fb7ebc587a27f533f
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = d492fca6b1472b0e2497659ba6e1aedb82f3f8f18f32282833b95ad1f739db8d
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 5bdb361cbd169f9c483a0a1fa13b5cac88a9ed8221692f3d6b40be56
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = ada9a53c338c2bea11ebf6083c1f7e7ba95def225a2a7ffcdbf22bd1
+Tag = e27d3ecdcecf0fa3
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = bdabc9b9d5b2340a95798d092f0cb36f85213409d822fd0fa617deaa
+Tag = c6280e421ead65b1cf89754de01871c8
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 86a2da007a0fe9b23c324e74a482d4b7802810b707d96e6fd67b4e16
+Tag = 5be734d3a8aa8a9af6f8bebed1764a79fcec0c18af94c654
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = bc21005875bff2bd716c14837f7c599e5e95490d45091fa16f00637a
+Tag = 90539be5a8b8320cc239ba9c4da89b63d01e8edbc0dd3d527a89dab28cf83435
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = e43d0f196b9edf28
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 7df97553960fdb6f48048a7bebf43c16
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = abd87d5c39f13f2649ea81361cfd4a084b76ca625de0bf96
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = ae984f917978aefd05b2ccad7e446c0f85121f43dc7457172faef445650a4eb5
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = d468a50b46e1d34f8bcd7484a4b50268cf7e992db05d35eb5ea2b6dbb3bc14d5c224db73ebe6f6
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = ac107f11f63e0c301c2a5227d36a3a16acf74b0b494555991a5f67f8875d47a1fdf6fdf3853e22
+Tag = fdc0a65c24eced46
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = cdb2624427f5f8f98d06126b0352d9dc595c6c20ab8f6c612759f5390029fafd4706189adb3c1b
+Tag = 73852385a5c5de80039bb7b7f3ef54e0
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = f27c3e25b951cc776b9acb39f7888818bb1a7655e63ff9752daa912a01ef82dbd196c74f7a81ed
+Tag = f53799a7c5f7085685f93e66ef3450e31550e84308d7c52d
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 3164457673d80486d4a94ed7b55653a571103f69e889463f90fbd9885e22e0a040308d1c363158
+Tag = 8208fa66117e4b58c4ed795a524de9f1a776b2ade65fc641276620b000bb2627
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = a1e3dce011537aae
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = bf969cbb99ae135732007611a5bacc50
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 4437038c7c053287c54853480d3c86443e5dbfc7adb76592
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 71d2aad08b2699f11f4269351fa3848cc8e27369eab59e4bbc99494dbf246543
+
+# initialize with key of128 bits, nonce of128 bits:
+Key = 42db740da63fd8710aa33cd56e07a039
+Nonce = 53b415763697f859197adb3cfc5dbe1f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 223191c7c53c6571
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9f91eeb9ed868baaa015642953b4a002
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f7f15d09822a8557961037e8d57ce2ff244fd183f7a8322a
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 25664e2a5052e5713953f2b6b8cb4b096f0730049873bdd1f8bcad75900a90a3
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = f7e5e1af0e
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 50df6cc694
+Tag = ce81af06e79dac97
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 1701d75495
+Tag = 22136fb044c3e98a0aed75ac5a1146a6
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = ef5c3f7727
+Tag = 4faee06ca048e6181ad0d1e04a63cb1de7c00c43e729640d
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 9bf1e4cc9c
+Tag = 83fe86c19ff72dde1eee53c84505fe3e832a6720dc0ca386646495277097ce92
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 6c05509cb25038a81b7138c2
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 4bd603ba22f9bb8ad5aec265
+Tag = fb32278305c2be88
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = afc8da32ed2a111965b0745b
+Tag = e31254cd72a2e1cfa4a9ca5a8fd2e405
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 625e4c0e230f7cd0b5e2f4b8
+Tag = 4f073052d0f4d3ca7a81c77b4f75424aa26361d46ecfe21d
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 3939a21a39260f7f29cb6f56
+Tag = 8de9d7eb91252385a98a4220f904338bdbbb3de8628f59dae5db19a0e4624ec6
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 68909cc2ae7390f2e196c752acdce04e93a36cdc8fd7aa
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 4970e50ea040bec9abb39f8d3c08ed5d714ae047b0d1b8
+Tag = b84573847bc540e2
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 643876328e3dfd9a3e9b79c78c324f168c689ef07db638
+Tag = 543c67570a0fae8210e53d082df64970
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 36391eb8348482309f42637a94e9c03550f5e14d1d404e
+Tag = 2f276bd0806b8d15deb6b4b981ef25474d16a15d888e9a69
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 27a8b9f86597b61d40a4519daa07f52a0d070188e66fa2
+Tag = 4ad1e2290941a42d48ad8dd8e036c08efbb49949a7b87d64829e85d12f501a82
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 12ac6f2ca5ef84ae49c532d82b1aeccaf651c07fb26f1e359924cb88ecab0ee5109ecd0bd7e123
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 6fd66c6aaf1fc19b2edaa29cce24840f268c70269daca20f3bdd0bf1e342e20fa981d12c222a35
+Tag = c37145bf5982f1eb
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 8bb5647fa1c703083608a7a2faf6ba21c67f530f5cef88fa6b7b029a953822f05e495859bbc5f1
+Tag = b697b9015f71f88b97310ce8d31d980d
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = bd7b3cb78a08f43f60c0ffce22234abaf34950a68e6b85da26d2cc0bf936883007ac5885afb355
+Tag = 16e8d034574476ab6043ff47eb3f9e50f35fffd9567067e1
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 59b4dfc30e8a62aef2c0c960c78e95ea519e8baf668fcf7688072963d0722c81b1fb89784b8cc7
+Tag = 997644c2622fbfe42f385d8483c49105b9a4463d4c852170c4e940e3dddba743
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 3cad2e441441c19c
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = ad649482919a8c8dde7ff0e62d25cde3
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 79b25717ad4d440ae343cef7deb89519a6967fec9d48405f
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 82411b49cfddb8382b3c2f4d42fed215f9d74fa1ef24c142d16761b6a2c71c62
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 28508d1f80941aa6fe570bc0a0b8
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = a09e7e0cc5eef3866086e5251ca3
+Tag = f1ad524ea867efd7
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = b871e0205da28d3bb14d1d61e0c7
+Tag = 72ad093555ddc10264c8238099465d08
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = c4c6f11697409d5ceadfcdea24fd
+Tag = 835e850ecede7bb9c1c59c55b7fd4e40f8ee8c28b76aaef1
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 9d63102117efcc701c85d88fba84
+Tag = 670152686ec4fc9c9b259bd3a0ec09ba0b305e130907866c4ba0a17660f839cb
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = c92554500426aefd0cf8dd3214710f0d60e5a40a237b24e4d0a5f4095fa0da469b0f96
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 7404bd5ad3907f82c95134934f853cd10160d64c96ee73e01abcfa687b0b7b91c1a7e8
+Tag = f563bcdf1f38a129
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 58828e9f62fc371e3fc4e79062e3688bcffdeee73156e67be60e58b6ca733c8e56934c
+Tag = ccb3a48071028fcfbe12a633810f7043
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 08214d8ccc276cd666120bfd1c3955c044b1b374099e4312d8e0cae935dc630838eda9
+Tag = 40c02006317972f12343a8a197842a2f56ad79445a083582
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = f84d2019d190d69ff7db4024da85a1998ac6ba2362e4468590f2a1b1e0718b7d3119fd
+Tag = f1d858f331e0127ddb483ed5a9e191021b37b9411ddc06aec62742142a03214b
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = ec69f818ea164950
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 105c877edcad10773907776eff09a134
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 1bf9d6eb4a6608726d7dc8378a33033ba127e80920df26b6
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 1549b22ea07e2533d81dc1cc2e61d3adf09cea5a4e0dac347711eac3f72592bb
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = b48e2c272e031dc5cfb6c4b33d866bd1f66aefe3
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = ad1c1c1f0ee8b93d6a673aa6e511a783f53e9ddf
+Tag = c4e0db712e38c2e6
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 179b3b610b9723f98825d6a23f5c83905d490594
+Tag = 143a9630239d1447265d65561b336643
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = c8bdb0e3c09bd1dd76ac9545a1124d0805b1677d
+Tag = a3eb81923f4ec338cd1d4796bd31fc755324ae41145f9436
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = f7205ee46d6f7a2bf93c50c78a3a619cad4982c4
+Tag = 2df55758f6c5ee355d12ba330cc21b7ff0102baccee26210d3a6c1556562941a
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 644307b13053d1e803b2e383ed04166f0157b9a6e6d0683274ca91cdef1d6cbb599e902608c669d91112d09bd8007ec752c7
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = b5a3cb7a8bdb92b29365255552cad9d6b0a62cf61cbf4800fb1eeec31294fea53d31f5bb7da601ab17baac7c12ac0974adc6
+Tag = ca8f675cd34ddd81
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = d1511db980bdd8ad5d8ce56ccfc10a526f3fbe75d50de234344d5ef73c7d854ca4b5e3b8b719cb9882efa496bcf1b9e1627e
+Tag = 7d94b3ec9b0f1a2d7a10b2938b5fd9c8
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 2a0fd2189789d1f6418e54b1065ada7960acb664a2f3c779559799d8b7222c07c592001a3a064cdade63618eed22d3391185
+Tag = 518e4d50330c55214b862aa0ed6de0d1997173cb6421d369
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 0cee9c7f34a5b235d0a4f30f20706724c6f8d9d4e4ee638dee32d81002c120aae2245ff49b3db3d99c5fc72c5189da0c673d
+Tag = bb2ecb79585f88c2bdfda81669b2cc9ec0d345c62f888a6bfca91a1e9d70d493
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 1fd9343ddc227d19
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = adf2bdb6485dac910cbae1e36ee61dad
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = f7b7c42aef0e58bf8a8edd6475b813aad66321a5a227058b
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 229286c977cc9d3bcc13b7d7651a9a4142e5b595b8a2513cce4d617acd881d2e
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 88582b22607c44131383d09d75e7de2120a08b65e1f7c4cd3768dd63
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 7bfa127684803ca644fe2f89bf80ffbd111338ee1ac7d361a00002e6
+Tag = 32aec15dde93f99e
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = f04ff7059ef501752f12b612be52f66b6bd85f8e45a093795a7da7ba
+Tag = 38b697205c20967e85c1969995c68d36
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = ba54294cebd95a907866b759877beed62299d97ddb372646efd78d5f
+Tag = 85a7d7964489a0534c5b9e400abd862dbb31d6e47b4c1e99
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = bbae5c4df9e87d4c6ff73290f1a0f82fbfb6ceb9e2a4fd08520562f6
+Tag = c88f623ccec3f339d2c3ac2b2ed5d4dc8d254b8355f7e453b216b333a6226a6b
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = dade80b0a9eea221
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 27e8cb7abb25d3a685d41b929e147a4e
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 836ba78f93336ecdade96df89d188a73678549813cd9344c
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 03b1a610a5e7ee274e86f1c38bee5c818477e5269872c1ef184a92a7d2ef0848
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = c5dfe7e5bdd2f8b77797af041430af4191274054c084a18d7c5c97a7e7c7b0520898b69158df5f
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 83040e50358f77747fb9036f1f2a4d2b4112a637bed0121464e58fedc842ad00c3cbf70ff03661
+Tag = 9c127b350253a399
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = b35bf0e58225d9ec3a3d6cb2866e445dbb8d77fb996e821a6c2cf66621087d670d648d3235f0a9
+Tag = 69bf09b76e8df7efa6a31f53cf686eae
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 70fcd2f20e6ffc82d1d2f6ac4fa54370abc1108ae8d9ac8b7bd76bb6e34c434b5abcb490b70cce
+Tag = aa73b7ae2c790ed5e40deff0fef3fba746962394a64a02f5
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 2cdb54a04aa4037b490977dad943cc4bdcadb3d2695a4f8b6889b5b82b48fb5c6fe004e381286b
+Tag = d50bb8f0f936f86d358814d21e2a6ee3a2e3caed5913c6a6d44ff1ac995435e7
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 90b99daafd7c5503
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 41eeb2d39a666439479620462563bea5
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 40b8bea4e6b5a43f15b87ad0d7981846ef8bda1e4f724696
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = f78b7437a1ad91779e5e7b5856f7f426c0091d821a075d1a7da300f7a2a8dbcc
+
+# initialize with key of128 bits, nonce of160 bits:
+Key = 46df7811aa43dc750ea740d9720ba43d
+Nonce = db3c9dfebe1f80e1a10263c484e546a767c8298a
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = b1dae8de72ffa313
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a0fc809fe6a1480c08b1f4bdfb2d4af6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9018b05ad1e4f64ff25e1c1f6ee7f14abd41041ac986418b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 086187902decc2a534dc71313f6c8d6edda40c59bdcc4aa714fc2b11e2014938
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = a8a1b1db1b
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 1b04f54a4c
+Tag = d87f5b023d5c934c
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 8109bfa013
+Tag = 49ebca99e6ac798d04b9d29e0ed53c06
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = be214bfb7f
+Tag = ae79b4b26d77f9df217d6ec9d2ef359125900f2a1cf5364e
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = b51486a145
+Tag = 5faaf8b24b2c7985dec65339fd74e3595e3e91beba16633503306e2182afd999
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = cfd5e8556294f6ee29ff8eab
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 673251876bac230192d012bf
+Tag = 6ca2514878766b46
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = d4552f7c72ad6d831e185c63
+Tag = 7546207eddae971f2d7aa1c8e2430fcc
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 62a0dda4a4b381ff0fa8579d
+Tag = 1457c9e4bbff4c660fd29044d9e3436601fde83c186b3d54
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 630cdeca8c5a4060822fa961
+Tag = 045817b985172bb59b211638318a84e0443f64c8292155135ac24e223c32ea3d
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 21f762d7cd54f4935674c2c51a0c3a952fc4a861955c82
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 5ffd3bec9373d49000b76abc3b849c4b1c9b8ce5b4feb0
+Tag = 17fa84d2728945ae
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = ad45d0d6e981e51a4731f49df9a1569144309d25f7a925
+Tag = 3e2c452b8f7fe647e49cc4c2fefa0d83
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 0dc7c5884177e212d18658ee065bfbcf0fc6408b5effa7
+Tag = bebce9a8d90c5564e1b238adee46cccb1f17f2d86a32e7ca
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = f1338737f08710e68d3b7b50e80ae165df902a47465e48
+Tag = bd36cad087b790ea3499eba9ca1e83c93445d6857f299a358471f2a5054fe6bf
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 9eb061710005dfb9a9c3f91b929ac667b995aaf8a6e58d5fb5397c318ad0a1e1fb6e5089ba796c
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 24989d2469814fa26477074e113a5576811db80301af936a7a3693e85cf7cb323d18ac8118e5a0
+Tag = e684d197460c06e6
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 0825a9f858a003b4b6c0fbba759580ee315ebcf223fe0dc0393e9d85508465f511906c23c8b9dd
+Tag = bb5d553819abe08c8aa40781f742742d
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = bf3b9d1360591ba23126ae99110b707c5557ea729dad7b78e3df00ca777419161aacf383a4b586
+Tag = c37c05e2902334de4f3cba45d4f3d8275ddaea8964ad9cdb
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 94e2865a9339fba5ca438efc6338b46ed1bc987b1713607371247a6b5196508b14c50999d592ad
+Tag = 44fbb4243ca7c22a6a22eb7e58b8b3e027af7e70a3fdff5e60046c512c74b9bd
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 1244ce2faf92682d
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 50f407c4adabce9e7737eebb63b3e308
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = f35971931d64bac45aae16a730b7a1a65a436f8f2f510366
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 21d303d4300bbd0c8fde980b567a04548963c35ed261f6cca71a5d0af9d1da61
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = feef983a5faa9ec246ef2cfc093e
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 921dd8ece95283b576484aa2522f
+Tag = c6f32d31a853592b
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 6dd82ec25c96b2817d60f91ac8c6
+Tag = 20199f65b4c3289649fad4ac7915b4b2
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 9b35501af46c734fd3e00c646d37
+Tag = 80caf0abf68d258a164affbd7dcaea20ee1a28c6ec75d91d
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 5c7d7fd95aa24caa14ba579dfcc7
+Tag = 28762d3cef7276cffb789bb3fedba2ae667507cd0263dbba2daf87579258f855
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 2ab1ac2b7375b2b96046767e9e79e0369a4f705d61f66bc52e511fd6c6ba99aa12c363
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 586f4085e522da8e4281c0100df2ad11493da9dc0a28750dbbaf550438e5a9a5323ad1
+Tag = 7a5a47cc3508bf81
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 2e156c3e09c63c304e115b82c98612d92b76cc6590a67305b8a3c1940f63c4c2a27c3e
+Tag = 31ca5dad979cc5e0f31d323081d1a92b
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 75d2f4222f980fddfb29d4b449f64f1ebb7dfb3b96dcf20791eba373aae0fdcd5d4282
+Tag = baeafc93f025e93e7e8a8b9e83fab69cc47c4238ea042fcd
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 4138a4a4358f45e43376d9f06d2f4aa3d936bc02abe8a029d22305757a19e74f79fc71
+Tag = 68f821c02131c32e7eb5db67164e3f07605fba77f39d49c5b4c10f31a2739789
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = b2c8e0db57581e3d
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = f02cc842abf31ef6cd92b95dc12ae943
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 0f96f44b8670f61cd7150d90b9dfb43c085714b39f07ed3c
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 5375df4f314edd3bbe1bfa33cfd09631f138ac3f7b004886b71a6157f417a179
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 71623d16a5fdc12e5b2e03e2a0ed3a1d3ea3a42a
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = b65f7b323b4c2ac99904200601ead7302e3aa89d
+Tag = e3a4082ad2656d95
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 2082d92598726c0df2c7a218f14048ee2bde0fde
+Tag = abe6062182c167db25ad763634b37a17
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 3a0d778311e6515bd7ee839bd64ab1e8b97c0035
+Tag = 569864e7bd5b59bc30f80d28fbe627abe0e73f8bf0b355bd
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 17dd378d2fc1df467fa937285e87f07fd9228a36
+Tag = f0a7ad23c3fe2938250402beb0b2e6b19b5e73eadddf68025a3b3c2b805e57ee
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 02fba160e793b7ad992be2200a8a3205568d816581eddcd094720f613acc25271042b29f459d85df4e5036ce3d2cf7919834
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = ee5ff4ff8d74a344ff8b464ef60e202b889d4e9c07b3f5da4a078e7fa043a111475def8f0711dd8116790619f589a73f23f0
+Tag = f9e36a0bca85aee5
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = c2f999cdbb4ac64d362dbe063af5000d3bc2e86aedafa0e55509ce312a0b138aa9e9a2b2d47f61f564f84c95215707011eb6
+Tag = f8ba9972567486392571ff2eaadd9fc9
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 5148cbc0e7523a682b6f9970fedc438f88c1dab3f518de1a062fa620f3c285bfc23cc4e31de3d0f194437b782d82cae95fb8
+Tag = 16915d13db3427ebaa77cf3443aef794f9b85d974ab55f51
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 4ae204007baafd6243e744c37bb6f17a11fe7ce49edb040471e26b5c3cba64653e7beb2a9e20f8f87397fd578bc3ac0cf3c2
+Tag = 39bcce358e9c33971cfa97d0183adf2a0079613fd9cd96bf0d704cea221486b9
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 30d1a68d690d4da0
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 8c6ee9fdc57d58e6acdce1fbe22c0cbf
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = d9b9a1a13951d4242d8dd3847216c75c2d7d8127c43cc430
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 9441b9001bb5f2091d00c1be80381066283b24362c9f9fc42de15e04c391a47a
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 60358da5eecbcfea6c89d2155ea02abb32d84ced00d352a8cc6faf70
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 1e3040b32e5f4dcbf2845f41b5650cd43c7f8a4b8a6b5f1e5b6d60a8
+Tag = a4c30e260eb1f786
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 1c78bcf8b46af3163b72309c31d96d08fb62352646a8afded6e95ca3
+Tag = d364f924c0c32468d96b23adc61a2b93
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 76c9eda128369f367b6b202268c85a3630bb414829ba3e807eaa22d2
+Tag = 23a541b7e8d0f034f6565dff7d12fe4f7ae289b70cca26aa
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 127c1a62583fb0dfb8ec5b1da9406ce3941208201047536866557ae5
+Tag = 56b8b214ed37c303f94f8e7a802b065e5fe3d62f6e5b576aacceeb559da54cda
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = f9c0037612024ea6
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 7f55c2bef0304b84791b48347f976d94
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 449df921f0d4afa77d573a60019f822f46e826ba4dbc2926
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = fba52c6e5889d75d4b672db2d79bb287d64bf4e4988789a3fc2188e0bddb92e4
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 6a96164f43313b039723b0d26dc0aebf13f432f1628951f5570b3f627d652aa10ecdb1116f0db6
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = cbf5052f64aeb2780d15980ecf6ca2eeb9aa2802d8a215358b95fead2120ba8a7da7e69521d3b6
+Tag = 905c3303780ecefc
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 2af0818d6d8e714e5217b5f7f66eb9bad573c039b7332f2ed62c404e56b25a709cdc84c59e05e9
+Tag = 32072435470c7be3ec7e855a902ab33a
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = c397a9760a09ce66c73cfb312c36bc44e47c93a37e22979a0d152a06ac23513207559737896f2a
+Tag = 878b0e58d17c44788ae9923809850fe08b011ed144fe4d00
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 964bdfdfdabec5fa71496b6d4d2e54393901ace10416782f99b97eace26ba498f5d861c6d2524d
+Tag = 265191286f5a87cbbca2a3f2804492bedbac8c097bb71ce1e61beb4fa8e417ca
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 3c5d2e5d2d9c28f8
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = bfa975cb3edbc92dbc229b7f5320be83
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = b7dcc88f1d42fc2768ac684df3765a54ac41c0525ed0987b
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 7c2aa44124b7ae87d819e4a60c890fba1a94d8029e115046ad243752442da53c
+
+# initialize with key of128 bits, nonce of192 bits:
+Key = 4ae37c15ae47e07912ab44dd760fa841
+Nonce = 63c4258646a70869298aeb4c0c6dce2fef50b112d23394f5
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d7f0f3c9ad1f47d7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ffcb232d855e0ac3b55f35faf274db10
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 76043378c78bd1145bbf81a799158e0b297a4119af9f24ce
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 96dd0f2e9246a4e3f77b5f773f2fc25635c02551dd8e63315527f4e9b2a8bdb7
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = f0fea1e740
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = bfc4254722
+Tag = 1cdf2952caf3d28f
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 7a1af0a2d3
+Tag = abc1d7add1f81da4b4868ba6c6fc9737
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = cfda9a9360
+Tag = 3a609b07e96a634deaec8cbfc9da66dc8c233cae5c4b8041
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 1cf49c4d9c
+Tag = 29af3be2bb9b5686ccf95f8ff03e6f4e636635007933c01e63faccb5867f7d30
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 0f0608f376f1bbf1f8e1d9ec
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 8db5e38be24fc27fc75a8631
+Tag = bb3cdeefca19ce59
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = feaa6551af3ac4e9cfdcfa8d
+Tag = 23f4a9e91908b23d967eacec24c0955a
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 522c9920dfaafb8735ab73df
+Tag = acdae32da7dfb097482afed6073489360937292fc980c30e
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 9d2d9d7c6f48a0bd12db8d9b
+Tag = 72af5b41112990bd4ac91c3a4bc7c2b02b025b62b6ba0a7d4fdea3ead0ac696e
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = c135a39aba8fd4a709c3b7571674afa34174e8b40e3b3a
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 27f5f0d7f5908e3981e771f7aeb73a3ad3d23e94626c9b
+Tag = a8e4eb067d76ca7c
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 2326a912dd618819bd4bd6f00b42c683065693dd8d4431
+Tag = f2c76a33524fce9832b241dc18be93f1
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 361a980d88958b0554f0c25b042c440eb0f3cf6c310c04
+Tag = 393b484d84ed5c9f6f3c1152f0260fb8a93dba8107bf408c
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 0b2eee51ee87c08a3482df0be30e2a17ccace19fbd6adc
+Tag = 05ccf71689ce9924957944eba3bd5b5e5abf0e919dbee28519ee32326b375563
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 07e620f198413b2c54ef55a276410ef0b37ba7f7788bd4bc9df38cc13c39e2fd6ee57d21971730
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 3f2c552ab766336c0ea8cd99fe420604c65810829682920d06f3edd02f4b1e57ed466990833103
+Tag = fa3a88341071f990
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 90f78403624b8869f1969f72c0695973dd3df36329841cbc0ecc90fab2049eaae86a3b47d91cc7
+Tag = b59ef0713f4e62e5da58132f9fea314e
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 398363e125a02cce2ca21c562fbf24bf114607053a977fc02a2d822af56e9bedcae7281d42877c
+Tag = fba642b804f64f8e4c1e0e4e6ae4562934f72e9f7dbbdf07
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = c37e02f3dc3319773d78673e98d1e6cc9b0bf09b67950c5579330389293b43d52f4be451d8ec6b
+Tag = 6fe161d0381c8d5b7ebfdae6f80896a7e1c3661ffefe1751483d81ebd5ac0c6a
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 2c051ffabdd8aacc
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 18f7652daed7e4f21c16f23ab275a1f3
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = abc08e65cb31de93ef70a98b21ccd216b0cae787c3083278
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 648ca229a55d2ab1919c1e3b2dcb2a9632e7299cd025b5e549e51d11f9d0fedb
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 0f98152fb6edb15d20f5b8deb2e1
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 2af8bf6a2ee5679564de67069415
+Tag = 660c8abebbee4dbe
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 932013fb42aa35c7465827d31ab7
+Tag = 9e2f8eb2ef3da9cb9ab1962555606fa7
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 7efc4484b03d14b29b892a273000
+Tag = 70301c994d3cffb85ef4d6c0d3c5b377b6935fd3be409daa
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = f0a3d586ae34ea05e75ccdde2ed7
+Tag = 8e3350b4e3bb498f790b9c7b6b916f94aae585fa16db8e6f9c0c11646e404bcf
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = ee4b30cbfaf1800b1dfcfecdf42131e223dd89df3f340dac29029bec1bd7dd2e5569a1
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 17ecb2fcdca6ef279b65f8a8879bf79a0febb2c81d24f35bb3479abb91a11d2c18efcf
+Tag = f6afa7361604f7c1
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 26bc15e4797f2a428511c91f79493f97d1644918f2af39a4b2fa960f35675f9a08f499
+Tag = 2aaa267ad3d793c2c9479b3ed7b5b6f6
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = a86d55732f0f9e97bc7c668535cd1bc9d6dbdbc1c1701a3fca1a1b9f3d1c4ed888918d
+Tag = 16a24a305b9e49fa13d2b8c0e4513e6d6a3e506d7521b856
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 0243f7f65cb1cf4ea6dd2c1e3ad5e165e93a7050506759247b5f3ad884931ec342dee9
+Tag = 4713ea7a43fbbf81d906eda6592a65b3bd3c2d49b67c53bbef2716c38fb57d3d
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 462fc3bc9b7c7233
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 87a98e33befc0efc7d0b957d88907bc2
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = fbf52758a930c3bdb3805bc06dd508953596234099b24e78
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = ae8f2ed96a7cb5b4cec5aee602bda27da5aaf4511e94e74cbbe57c63ed0b53e4
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 6864233a074970d965df7c09927dfadf8e9c5bca
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = da731cd9d05588f6c61330b843d0de957ad63fbf
+Tag = 9f10eaaad7e43cbc
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 0e7ba8c0bb902729e4d0564d79187e965ea302d3
+Tag = 82a4a9861e05f4e98b355a0caa23f4e3
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 3605e085f7e960f23f583371c2723a001a320582
+Tag = 6795525c19cae35e5a1794160b6d8f4ca1095395900669d3
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 826c331cbadb31f22b0f6378f6a1d5d7c7b423d5
+Tag = 3cc77385f7d74549526a7aacb932cf0373ff9b54c3f65fe9db17c259a76e87ff
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = a53821aea0381fced8e18df637d4658ba5004ef93ef385ee43d5919396e5320bd3b6cb9adffcabd9b76ba6e874fffb72c672
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = eb9c67cc9f3e9f719bfb0a69ec1d6688df2d1c2b699f6be34087b35244cc4747c6854fd5093cb7f4bc4f5b7b600974ecf2c8
+Tag = 42099852a80c5ff6
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = f1afef549c371bb401e472dc7aa9b557d485527d0bb1c6a11ea5e5bc4968a9862c4060379589d791c45a1250c90c4d035aa7
+Tag = cb6405bafe76ca18f842ca092e6131ea
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 58f99d4dc3ef7b84b8e02fa41988fc53cdb6ffa5dbac9dca5231c94bdc990caa665c6edae6c06efceefac7dc4a89d55679fc
+Tag = 841fb58b7f3f7d5023773d3c5abe08c0c3f7c351a0c1773c
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 3b40ce79080a7340f35b0bcb37089bb810f4f1a8d608d6fc93c63247cde10568a3cf0e7e4aaba06a1b96ec93f288bf6e434a
+Tag = ea26f719a01e424cefb8cfd3b5f8866f53812377f5af3b6e4513eb1cdaacd0c8
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 6558b0208b83a1d8
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = f0e6cb84c73540a216e02e2e15d7c465
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 18b8d416d03af87ba7f991980f974adb9901b66ea9a9e2cd
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = cc4e62914c28b03804e9fcbe3925ffd8b2e8d723040f762965b3d0dafbedf26b
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = d2abdce5fe47380d62be333c264c9840fc7a531639fe677fef84708e
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 91b8a462791bfb2bbd7f46d7e4a482d44fd06507ed4648fd8584c676
+Tag = e8c8c7104fa84d21
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = ecbdb9235e29f638fa07badc80831fa3a9f9f234b077e74c8ff4afa3
+Tag = 45f8504bf69db62d554f758b78562de7
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = c346f29c92efe780c1480658c22308a90566763202cbf2c94a106dc1
+Tag = 360acd68e6539340bcd2bf088d3ae8bdda7079a2dbf65ef8
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 0d4b5b91994c4c7ea523c26c456b3e174c125ee8fe7016238bca3f06
+Tag = bf998b492d1e798ccf1e29e07648be438ee222f5c33f03f1def1e852224e4b7f
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 5822a2e3d83feb14
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 9e652591fb089b2cb670df1e91260f08
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 6459bf09f504bf81a86db57430bf0c603694b2bd10ec2796
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = affee7d56c9842470b3bfadc4ddbba8bc19096777b62d50f14c419dafc299545
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = a166b9153db08064ec04f1cb0e23d057e72724ea330068af4e0d7f0b9e200b03caefcc70ab3b1d
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = d6f12e885464d3b6f6964fdd7d216fa1bc6490ebb78b18149364002dbc549779b66c6e1a33fb70
+Tag = a046ffdf03b2a3cb
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = c3ec5f5ac75271346d1b109256d2150dfb6cee9c40827fab34d3b802417297305e25947a767069
+Tag = b347506fdf90e756266588c7bed9c76d
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = c86c18378f15b9ea69cbab264efd5691cf6b66a175eab7a1a365c3957c751c2429922b2803f594
+Tag = 453afa91e8138852b4dc7181358cf0c2439a75098dd642d4
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 3e4ec38ebbfba982664fd6df0838ebbb7681960157e95b7408148a8e9c2cfd3575fd2122a049c3
+Tag = 56c67ba4decb6e86bf169c97a5b921880fb33b066b51c242665e4d7b4bdb1748
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = f5b25acbddc9e7fd
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 01bc05b67471c0c9270cd23d48dbcc1f
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 789f7fdd885ae979cc3303c1bf6797e4eda98f5d602b8056
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = f856b48cf9f2b420f22c15dce94abf37f73a33afb4d714788cdd902efad284a3
+
+# initialize with key of128 bits, nonce of224 bits:
+Key = 4ee78019b24be47d16af48e17a13ac45
+Nonce = eb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d9eff60
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 07af6cb8e1fa8ca8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4e6b1ab20843baa6dbdfdfd4342d066b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d949fbe6068f6f9c143e3d6b364135aba3e687ed79cc2a8c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 0c0bd4052b33219b45171f762f9865ec5e80dfba4151c64955c49bcde5380c86
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 5d6e33b09a
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = b8ead93788
+Tag = abf8e40cdc00ea00
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 6c6d14a78b
+Tag = 86d3b14938e22f8fbfcca382a09d95c4
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = b934d081dd
+Tag = 2193dd83555fe4471619e37ea60c05723e78ed2465430942
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = eef2274aa4
+Tag = 6383dc8bdbaa3fc760606a235d831e41bd2eb50cdb4fd093f229745660124921
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 4892ecc0180d8edd0305048e
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = aef5c78b414285094cacf60f
+Tag = 59f3e316f314ca02
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 4638b9cac6ff4c30a84189d6
+Tag = 55c817d262ccf025532c0210caf7acbd
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = b74c0e452f82833c34e86082
+Tag = b14da069660e80ebe1ad9c59bc75f9fb778d8f7757003325
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 1a29fd168ba3fb83477cfdc2
+Tag = dfc55aead2cb72e7eb5a556bfb0f6b3e570f8b9c5386c6b0934f1d9d398510e6
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 5c758687c1fd6c6950f1173e89140d81cf68197e0e2fba
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 71f1f5d5a0b1c8855ab5525209be18aac9b31d4b2fe1ba
+Tag = 888a3439286b34fc
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 1298e6a4817871e992fef6bda1c3419f9061a72761e4b0
+Tag = 968e1ba187c36fef2ba2d781d8778abf
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 611e28bb302b5a5106ec544020e84ded0cf98577b4aa97
+Tag = 587be57a21443a788a4e9cb403b444103c01f40c71fc3dbb
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 4c8aff80c64ec7de70fbb72ccba913f01ada30cbfa1bf8
+Tag = 60d0319950a5d75fdb19179c21f19f76d2c250cbea39a02848d09f34c1845387
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = a6ba4fbda0767e1d23856a18cc1a818fea94b9a09d9f4c10c386c866b390ba4e02d18a4a0f7d84
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 13dc5e2736e4a011c0fa9b9820ba390beb230647d03c1661dcb511367d1423ee9cffb8f860aefe
+Tag = 5a49efb884c1a984
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 1ed8ddd12738373e1618ad93daee04d095752d1b06e9358ef8cf51de2eefb172c82ba98d053122
+Tag = b1839a03fb5cf4d6895fca77e283b163
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 6b2bc9c47451f85dac022d525c2e4fef3ce2c363f743ce7b245676c332aed12247325d67c6e18c
+Tag = f123062e5bf34e9f38d613a3dde44316d37e63344f95a012
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 1f69e57ec97d8122aaabce3c6c3644f213d5e0cc855cfb66e7576e27147610cf81e2978ffe6248
+Tag = 5ce96d1b1d272156219075d4ae1916fa55a76f1c163e7b484c06fa953eb08a19
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 3b75c49bb8325c04
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = c33bb8938504efdebbea996ece48a5bb
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 993a8f04f4ef81df83923433e4bb3f108e56150bf3f03770
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 7310407dc890386af158ebca63b6b94e5c5fddae172b5aa6b92af0e0536a275f
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = b37de4a318143e7e9c2c06fefd87
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 8308fa31f6fa2b24ffc9a15ab521
+Tag = c11804730f33bacf
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 68eb45e478bbdd2fe7d95e8444ce
+Tag = c321d1ea9e897b1dbee93cef0963065c
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 5a9d2d5edde08fe00335439b069a
+Tag = e8405ba472127e400e1e8a61d6c6e10a3ea3c250199df24b
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = ea37a4f978308997e82149133da1
+Tag = 52aadae0f48272f1eda92cb620ec25152fe9179f550e5ff0ebe6c6e4f3e6ae83
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 3b810fc650c835b941270e1abf77b88cd2aa3e92f78297bae0c4ed5a5a14d23fa98bee
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = fd9523a7d2791be8367494d1cbfd793d2dd5f0c8724d3725e0b61c9fe1d40645132819
+Tag = 6842a8473870f700
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = cc5d0fe77c0c37d2b848fc937a39bed136f43ca3eaffdd65d761387e485111ba62aee9
+Tag = 8ab6f954d0af2e9d134fe107e6bec948
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = b3cd375371c1cdd838b34eb40bc2bf99d3b5df544e6c8336106520f4594bfdbcbd6f92
+Tag = 944f4e54e7ecc5c07004dea46709d0c69750ddd7f8d1d314
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 8b1a925b05d98d6e1c19591a87dc93963c0832c64b899ea4643f2dbfc44b08e49f905c
+Tag = 7b647e2e39d6c5453e92e895d2ce6c33a8d48764a0aff1baee068223c8ae5b18
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 8608772ddd553283
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 6adcb4d4e8bb12e3e67193ffe8f921aa
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = b4d9b56ccfac2396b6a52c164d98cba4f2265614d047c969
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 02cfa62a2b1f9cc2254c3aca69485e665c4bda8e35e755a83fc98808e3cea83d
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 3ae4610c65b0116c2217a9b71db0d7eafa2c2f3f
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 2a96b56201e7a413483dfbbf24178f74906e0df4
+Tag = 5e52e10ed3a306e2
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = e766cdcce6d810466657aebf8ee8b93400af458f
+Tag = c8b86b0f91c4fadb29a124d1f913f6af
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 6af8b9a7ae02f48b4f45ab7898ca9b1540a62439
+Tag = 5295c6462eaabf29698aec70e3781502187dedeef5fee4eb
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = a089a4fd91979cd9a0ccc22433960cb317ed3d49
+Tag = 38ed779cc598cc169657f3dcf5e2900b27aceb3441fb38802419e1ad6b1862a4
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = c81afb12994dd47250d6be6e5d99798c11d3dbc5fd1085f76fdd64863523729cdaa44e8b0207fb70a2729ecf5cee024450f5
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 263cf7487d291e70b49cff651cab6973cf43313154a8a3efe69d9c5525c8ed0c1a07f98d61475397cf1db64fb893fd595de8
+Tag = 32b15fc668e8424e
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 5f5490b46065a6b43d31177a031963f349f604ce791944af5fd8f41bf7ecff6e9702cabdb667137721cb936ea36202cb3b70
+Tag = 889a6818a365960b656316274b99f640
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = f7954a166581d17cf58b4bd201b94d154b9c94deb325051a8c046f53c905277db14d3263039f194938cb9dba42f0d6f01097
+Tag = 68f5f15252157eabd9b93f5bc08e1c5e0685ba2938155ff3
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 714200278092506855579d38872e7a1ecc5d1f45efb7a896dec7e0213c63f01e0ea72f267559a5da2f384760734d2b5aa07a
+Tag = 5fcf469cfb77f45ca8c48f484217606cb1fe10282cf3e21ee3058e90dce71b12
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = b076ec0fa8abc7de
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = befdef258e2e554c109d54a72e8f6697
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 19e57aec6d79eafddfd9673f402e982a084c10056001063f
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 4db029b71031131757174b189de73c209918e56e1d0a4c326592ef293ee1c89f
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 0d295f69dd9927a84a35c2ea46c2f2d69e15b07673d277f8f48be64c
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = ac78941ba6dc2c076f1a94d71b9e9f43def3bd27da96e526c3c9bee3
+Tag = f699f3813365cd44
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 400b49474d6d25aa4f89a3e5e3f0da8d7addab6751c8df049167b428
+Tag = 3c1ca9f11a38d517b2dc93a13fad5d97
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 3e5f971e20befe6218fea2b470fbee0f9cb913cdad80438250a0135b
+Tag = 4f20f32b72229ed257f41e6bf74a8c065b7082b1a5fec109
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 0facce003fb126a314ac953b0e087eb1b9bf3ff326b6c096116d8a07
+Tag = 8f54a82cf272c992438d208a76ff80578e6ac0a803f2f98dffdfcd14ff48ae38
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 3a9f82609f478403
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 4786edb20b49db3defdd9721e55a0151
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 7da471e58884d208cc9e4b857b95b8cf9206386cab4de3ce
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = e923de064f97f53a7c509e3c44a94300165a82242d713ea0b3006c758f60de71
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 801a0fab2b8331916fafae0600635083eae6a78058c0f74cf67f744b35d250e81545063d5413b6
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 446580e474eda56b3eaf8c995f656cc086eae94ee3f55e69510e9f9a1e48ac993d09288bc1efcd
+Tag = 50e8fc8ce40ed162
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = b86bec4343295e7aa0034e29d04f14e44c94669db53f5f94501e0d0ffc1875228f8edcd7328133
+Tag = fc9687ef36e98ad775d19d6c41700ede
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 9e49772631eeda86d5c4d4f0691524e80f4693314edaa3d48aa3bb574215bc7a04ef6f2400b75f
+Tag = 3af1c2ac78a3a2cee9f96b361c49b73b9fc2cc2252a45a77
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 8bc46b53472fc49293d84a5c7262e350712082623a9f1abb07be7e7ee37b798c09b035e6dc1d3d
+Tag = c951120457fadfbd5b6eab4f3c51cb5f55f1291ab6d1c74e6c92521e530adc00
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 07645164810139b7
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 17d74a14578c967217b037cc8c1cfecd
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 2e6ea308e73be427416eb15a90e9a4f1091401cbb549fb6d
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 2e92dce0b9891b122bb3255e45ddb9584f647b803abac2697aaae10d8071cab4
+
+# initialize with key of128 bits, nonce of256 bits:
+Key = 52eb841db64fe8811ab34ce57e17b049
+Nonce = 73d4359656b71879399afb5c1c7dde3fff60c122e243a405c52687e8a8096acb
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f2710729d48335ba
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 05df61f79f4f226034aad7b4a61ff05b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ea1b9e509d14bbc1499512ade164b87124fc00ba11e0d563
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = fca2a6337b65f462c027d0ffec6e39254985f732f37b3cffdbeb4a7ec3acef8c
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 8b172ed186
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 5353010e0b
+Tag = 3f65bd4f5d6a9ee1
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 2fd773e61d
+Tag = 4bb1cd1b25f8ec713de0a4dbf3d1252b
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 754dbe56fb
+Tag = e023ed54ff397494035ce4d384c55ad07ab487456c843291
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 5f98d0f91a
+Tag = 57a6e7d76089389b6cdbf1fadf7476d162af82ae6091a8c174cef7b655cd898e
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = d14813139d02f8fb0d1c7e9f
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 945da7ffdd38dd8b9a20b788
+Tag = 4cd17693a417e58b
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 41fedb58d1f041990bcd4f75
+Tag = ac6aa35206a3ca8d9c8d2607a4badbb6
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 63f6490c8ea5577202a59728
+Tag = cc4edf0b4ade2a681bad86ec45d0ab3da63a542bbdfc9f7b
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 1be10740950c83497c6d71b8
+Tag = 608960e9d0913924917cdd329098bab490223458939df750f28d132c7c0be915
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 3d008746500f19ab79ac1d6431a9868734f7a59d9bc014
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = a21afe511eb26fd0acadd02b7783829e8096e1c1a37d8d
+Tag = 20ddb7538dbe5068
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 95c59a463b0e2cfa9084f8cc1bfbdf267343221d8649e7
+Tag = 97467ad73f06611a2160770895864ae5
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 32063db29be53106ca8ff7ae744be5940ef29061ff71ff
+Tag = a8e381dec5b1e71877bc0410889304343117287e7011edd0
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = c0a608b417f85471dfeb8464640ba511c2eec928ea2ccf
+Tag = 571a6bd7fd5e56fbce6b917c0b2d33013b57658c816fddbb84b19d3f56bc3390
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = aec95d65a9486bb78b9a8119af19cd235ef96083f21fbf70276aa8ec7d63a4ed3cfd029ddeb567
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 6f2ec2839ace2e97eb96e9674f792d7cecead24bd5e50ece6d43c2d9276a0b55508677e95c750f
+Tag = 2ab17069aae5a96a
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 61095f869086563d908ab09dc3d64e4276bb38a754f4293b4adecd5840e376a41f020df5bd7056
+Tag = 60c3764525c3c7d3ab79880fca72f7b2
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 8b50fc839e13495cc55136765e8de9be32fd2d5ffa4b9f5c4ba41e813a5d1ca2820b5c318df52a
+Tag = 2a78232f4bdae7218d50008161d809064cfc0d5497a36af8
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 0a2dee9ecb8e3126feb1a8e0615261ddfb0ab5c61b15387a4c20a0b169b61ceb4fda9c0f378e2d
+Tag = c5f0f29607b48d093b4fbeeb57d9c84e458a6c9111d763350ca6ce0192b9325b
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = d8c4ee4663ddee36
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = 9b8eb928965d6ef15343f12218752eb8
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = 36c3480a2787a5875a6d7a6db1f12e49d6381271bef93963
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = 7b602d4a43434c301db1d2a7354a14bc2d60e2b176c1cac9e720f3a10a906a22
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = e5af4665616b05c8fc9c6c9233b5054a
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = d1d4afa33eb4e4f9594413bbed1b8574
+Tag = e4b9f99b21472d8a
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = 6d10fe2e3742f588a172e7caa9566e55
+Tag = 66d5f1bb44a51f5267d5b14d16c17519
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = 564636881f1dc0642741eef6ffe40dde
+Tag = cc64b231b9313de338f48f480657697c815c0eb000a615f1
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = ef51d7197dbe1d6f7eb5b4c897c121cd
+Tag = e1cb6043e41344f26093760964921fa5fd49708a93e76789912c2f0a0fce756e
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = 052c09c585acdb392a63914f89cc9f402e166a2be7d9aa8478584ef767bad4cbd64249b9d4081d4c
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = 13811858ad383e82b8c3b514f67d87d36cf628ef24e1553efe0bc967b28d7315fa417e174457c5e1
+Tag = 02e361fb90a07e1a
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 0597deca67b688415640538201e51e89c0300f3222a2940121a61437287e6d0650360453b7d24c55
+Tag = 763738dbef1b2f0f6da46fe756e1e74d
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = 2b7d236d59ce25d1e1da010efe5fa7312bc976d7765e8bd285b71e10881cf8edb48f783fdc98396d
+Tag = 3f69cb0f70b3d10a3309ac46e8886f2436992b8d62f2dabc
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = 3c75e43094195f79cdf15748b81d6df46255673b00c7abdd02ade272fb7f67405df7b65f02d48602
+Tag = 62f4d0814e45ccaf0ab6c7e9dba9f3710ab14974951da7f09c0b859c425479c7
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = d74a2d91b477dd1d
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = 187de5a9d45c1cae07611d695d83860b
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = 074df63774e1d1fa8787c4f7092cbc2330a42768d6937951
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = 51bc3d9ddf1f1769f81dbebdee312dd89b85606263b49599567820fc5fd1e9a5
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = 72fa57e155c0d9fc276b2c604849a1c03083516f7361d2ba
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = 245218cc9e3a7f6a315d50f88f4019751cbd7ee0bab456ab
+Tag = fd9a161fc1880eb0
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = 658975928b2c7e088f4ee9f85439f62ad10e1f23dc02a35f
+Tag = bbeb6bdae203f81e94276be09f17203c
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = c34fe34dcb71ab7d2d12b959b4deff78b8c36c9761ca38a9
+Tag = ee5bb0d92aed2baaaefcbbebc82d783533608a2652f5ddea
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = 56eff0f36421307a1977ce40189461215aeb3b69891029aa
+Tag = 5e46f57f5b29b868c55551242cdc21c2b5fe7487c2055e695b30e6bf46824517
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = 5037cae94f7d5965
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = 26d2f434f544ce4fca5fb0e30a020efd
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = d756bd0774c8db78593c11668e57dbf3c33445427a8a8f11
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = 9180ff629faf3e007385acbfcba439342ae34ba4159dfa1d206416c498a23e04
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = d6faa9540e7d39f9ac01b5f97b7ff97e075ced34550cb7a8a86c055a7d21de8b0598
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = 7fb1dcbf13b9708ca874e658cf736f75dbd90fbd7019da9d04b34da9d539705018f9
+Tag = a558e5cc86d3677d
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = 6cbc0339c41de9af03f62fd2d1ec3e1c46f807885bcc0098cd9780967942da32298c
+Tag = 4bdf67a643d9517249621e6b68bbfd83
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = 07a637faaba6f6814a1cc3ecd8f31e52d5cdfbfd7a8bc47717347c3d327408c6781c
+Tag = 8356740ef50a3519df85c082a4ed0f4c13288894fb056907
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = da6ea9fcabe8200c42cf2df2efa5abf516734bb77c62a9484ab40892c4c5aa839fb1
+Tag = b8e7d8efd4176a15894e87237662e15691a3c57d8754dba473b7c8904fcc2369
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = acf8fea1608233ff
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = 9552543699bbf1f556c67ccfb4fb2b75
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = 19da437c79a67cedff4c7661e282ce662d584a17a98631df
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = fd24668c786323a45598812d43af2c52df5f9a46df2075423e447ea3d2ac8e42
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = ff57619454fe11a92344fe2198b55c1d79cdf5f908c258f44cbf2d75284495d827f3aa78cd6c37b3cfc41c2e6be70158
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = 6bdf086d1c3eb79834b53fcfeecdc7994ec8d8952a411ad382788a8b016d7ddbca49d0f779bb3e4542c35b320981b993
+Tag = a175ee2fd8d7b40e
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = acd716ac51ab0a5551033200569512766dd84b8f2fa821ea515b0a34be62ac7f35de0e16d3cefe8a86f9c2ebb8a6636e
+Tag = 748662cfc2d7e7276321d6293a216509
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = dfd9397923db166d98de3e43228f97e8e6e90ba24146701cc1c748f995815f9cf252a69a1aa82606a3b5bddc740bd542
+Tag = 6daa362ff78af123fb9e95d6bb0cc998c707c90baee16903
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = 1d87338422da13992299b9db073d7e9db6cf64c437c645db393c76f606cb431ed24e2145f91ddc9bee6483026605b884
+Tag = f345efded4fbfa4949f98b20818f73a87fa75970bea8b453e4b77aa1bae60fcb
+
+# initialize with key of128 bits, nonce of288 bits:
+Key = 56ef8821ba53ec851eb750e9821bb44d
+Nonce = fb5cbd1ede3fa001c12283e4a40566c787e849aa6acb2c8d4dae0f703091f2531374d536
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c5c6c5bea95d79a8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1774c9b5b8a5f1eca115548ee7b1040f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 998dd602042f7da4f68e075d29c154b4e3e48219698ab911
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 556b3273150300b01630391168f1ec919ad644fe3eb4e625674166c9dded7b78
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 30d3e7da96
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 2310d7c3df
+Tag = 615034ece58306c9
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 088a67fc68
+Tag = e1715da425fcb088a6894f33117bd734
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 589a0cc3a5
+Tag = 10fa23300cfc6ba9e8acdfaf1dbdf159dba3474404558a95
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 35e68be5db
+Tag = 83553b3fd01c1a1aee72c1837257c1e4bba143114dd672b3dcf958a9d7d51434
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 53d7b5bdde1fa9f686f190d8
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = f063c7ee25d106f620cc01cf
+Tag = 52c7bdf7f4bd3e77
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 7e64e7e4e6a75d6ba3204ff4
+Tag = 85997ae90c33a0c3054bbea9296b436a
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 1eac9dd5e45441c3e31c0500
+Tag = ce4a6cb907bdf87f48dada658fa347bae24d51b92e71d964
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = bca7e19649edc70ec1baa2d1
+Tag = df9df1500b4d9c0b19bbaad687f56f858db9ce686c08129bf789d61949b9c482
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = fe0aa48fb39da4408c561d7defe3c7c6a2a5136549d163
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 66001c603f361868e584e4d3d4ac684832d59b70341bab
+Tag = 8df647a163fa0df8
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 36034fd016365bf7aa5cb29d4c582d1fe9a52a4473e617
+Tag = 6c582f84b0be1fb4bdad8979614e8bd3
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 31542aca6b1e1ad4274466802487d6eaa731faa71db5e2
+Tag = 255fa3964dcc4629bd3c6090a3cda6ccd3cf856763f0a8f8
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = cfbe878174267938c2df3f596728a178907e43508451cc
+Tag = be8a039ff0da30651e7fee8783a36d94bd2854dbef39bb7859229b16f81f54c6
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 8cd75319ffd1b9891bd245f2abf5c5e516383344431198509107c4e6cb08c3960137d204b70530
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 45051c217b3a5775725ceeb7d2f6b6d441086b1f690af979f3a4e01f379702b407dd9c2ce3550e
+Tag = 10ae039a2f4be611
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = d1dbe82fcc9d0c2a85d110938f8cff4d67550924e64bbbf21ed9354658cd326e240bbbb0d56fe6
+Tag = 0666e66d3daee70fd6a07188c30dc2a4
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 4c6b1fdbb9c6b8b4a5115923b10ccb2a0228c26fe61403695f6f1cbf04ee85d30864d75d3d898c
+Tag = c6ddbed256435d0f81a49804c5416e608da0d57a315aa54f
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 41cc041f9f770688a318a687378365b698c484cf96ba436247e17891d1bf459cda947898d59ece
+Tag = 91ab0c42db695b008a9fc7d0204a241b0077dbd9669d960a639c6bb0e0e06879
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = c7497510524d1c4c
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = 3e972a341caa5524773658f96c716124
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = ec6151b05d94b91ebe1a2439d639f096d44cdc6c01007ff7
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = 4f6772a54aa5fb73aa6753d05692f49570d22e09b63ce544db6163460836c44e
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = 767dc3ddcfcf2cb3c22dd7ef638a09e4
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = 7ae7f90b05262cde2ffc2d29349e4a0b
+Tag = 8f566b557463f2be
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = b63e0c6365f75d11b2cc2507b277462a
+Tag = 1a3c76d42d6d6c64859b3c101c5cc382
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = b9c5d5decbc1f55bb4fc38619def547b
+Tag = 073a6323ce9d290d8bd8bf6579b276818fe025173e6c715a
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = 29aa868f7f510845986997d5730de9c7
+Tag = d1c2f5b985001f9c70149a78ce18f9049c6c9475e0e3b2f1936bd9e80343827b
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = f07fd6943568d44421658aafd72a1f3b3a6a19d794bc721337380cddf2d02a3e68903c6d673280e7
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = 89019695cf23d24ec16691b89a4a6cc84a31ca5e12c44b1faf0ff865273883f4f3ace0f37c187b30
+Tag = 21c17ffb61556461
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 22509777003ffe85e862b4b9a768285628716a6d52b545143fcadae7857743e8ea8e7f6e53930bd8
+Tag = b0556f891bafc311017acffae33fb654
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = 3e2afef668aaf014a7a3b2740239cc43aacd0b5017ad0de5d1546a5fd05ca2aa5201f86d10535bba
+Tag = 5fc66458862837f58def486e55f4825ca4c36c24479bc6d9
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = aa98c62f2595f45d6279711c41c3a3653b3fdb86e4e27d1b884cb3ba8ad9aa602fb2a7ab48e6293a
+Tag = eadacb160034e311c36f92f4853d74595de183ff1e3705889878ece7fa1db628
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = 4cbb58a1277c6504
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = 58594e6be8761f1537cdd5e6db9ec5a0
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = 5809c0b40342db99c645d6ca9c11ef98f4ad8ab0b8edd906
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = bdd2f465fde610b9f60af7c582e0210143f417e9795018f5ead7fbea07453fca
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = aca775a661efb6298921d41e0d332ee7bb2c502a3a83771c
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = f7ccb1f2edb3ae0e5e8c23e8e235505faa9c34a4c3b47e3a
+Tag = abbb1ba64f3314e2
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = 97e8cf8a517c5f7054939c97a32342879ffb9189457e5370
+Tag = 3d4466931f3897553cf133a68ea11682
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = 9b669c3a2e09e29ee54cdc6b86c21e5665af4102d460f36a
+Tag = fdcb6edc24badd1413bf594c990e70a067c34fc40b4f577e
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = 4b6ea1ae241986210269baf3a4ed46c13ad43dc12c38bdec
+Tag = 7ffd129b50211c69cf60df90e493e53ad3c3014a533737829272c337431fc014
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = e70fbe0d8ccebf6d
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = 3d493086a27aaa4d5d7a8dfe33c022e7
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = 402c6aa9e8f357d7a122ab9af220c320b8b789a7704630bc
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = 48a13e2e854ff0a80ea78a7f07ce1477bcc8dd47e5aefceac59058924b75d3a8
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = d751cfd03332339d0a39aa9c877a26dd1b0e50688a66c671cbf4c58e5b3ff7028111
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = 35798435cdf43a4482838abfeef944da1ee7be8169bd6778e6ac3c12a1ddcc73cda1
+Tag = 4c015a5984966eba
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = 590b869941f77407ac75754816617c738524b07c6a760233fd54ce761c04a63c63f1
+Tag = 060ac9bad209d702cd2b1cc440b7ba01
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = ae1308dfc81d35ed3b13c4f5e71eb3f6b68adf2318be21fd61f1f9ba93a9486470bc
+Tag = 0f7ed7cff773e57d487847784e00b13e7c3f3dce4ad30981
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = 430aa70f74857ef20d1adad6a7365bd7b7c34b09dc103a897a42f9e9a4baf41ced95
+Tag = 2e874cb34ef23adfb55855673efd070d260af1805c69dcc2fc9d0bb96085754c
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = 6056ebe94ceb40af
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = b22c7878d3ba18f46f847d470061e5a0
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = f952e820a666294f68e6bba3033bf9470303e27a2e63dd58
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = 76272c43c7957da5fe3e92b0074eb344ecb3e3789c52ab864c03f2f174016d15
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = b490d165e351bf138d3e918e38eed66e15b482bf18fd3142ef8be0e084a7d0d8ab3f9bec302bdfc6d948d78a8289d745
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = f828a0c512bd9f095dba2d3aebc30f2842a8155ff0db7117e31daa3fe08f2df10583fe6e0fa1f6ad07e0c7603781afb1
+Tag = fe2856056141ccff
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = ddd270268589fda5d922f5cdd88a3bd732fa7e4bb1bcf09bd57df603cff7515ea4b39db8d5de003865a56f1d74bf57c3
+Tag = 51f2e72a2759c48cb66ef23e24e7bc71
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = c8d1475ad69438e82345719d05e6d6342bf7f216c0158f0ae3bdc169d7faa259a0007c47be1c8221660c91a6b18aa499
+Tag = 20c33ed18b7ec51305cf9163c4de391df5523b68cabe705c
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = c57ca3f63cff655df35ec72aa4b0960e08b1a9248d91a212c7bbe9a5061fc0e86261fce29a2243c4634463f2e6ce6cb9
+Tag = dceaf09c01b496cfc407a8e00ca19d739d77e35917276e74670931178184e266
+
+# initialize with key of128 bits, nonce of320 bits:
+Key = 5af38c25be57f08922bb54ed861fb851
+Nonce = 83e445a666c7288949aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5dbe7edf40a1
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ca33ddfb797536b6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1c73079b66ffd361182f1c4861bf621c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 56b86b1b1fb177a645435f779f8bf775ac26bae4fba6a64c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 727d02d329489c344d29c23c379c693c82c87838e546523d8cd238107b64156a
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 9fe98b2911
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 74e5e6996b
+Tag = 0140762fcc06d467
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 12039b4182
+Tag = e12861fdcc89dddd759974dcc76c38b5
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 7000b80a5a
+Tag = 4a16d71267b63ca4976ab92584a2e0614712dcde59ee0233
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = ca72406f47
+Tag = 1d47d83ccf59c78be949d56b47b89f02201adb4f1e6db98f0624a7634523961f
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 5510c6a7306911b2477d8b9f
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 4ffa0854ebefd0c7ab65f8f8
+Tag = 485d2afe1b587944
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = a33778c44539b6609514946c
+Tag = 28586452553f8b3f3cf343e8cad91bee
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = b404f55f253d97e08f704676
+Tag = e71168b698c7dba8556259332befa4767d697e6e927ca6d4
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 15d3328a30ddd563b27eea8f
+Tag = c0d1e3800676cdcb55605fa8274aadb28e7f73a1620b016724f1f04f73088e8b
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 02dbecb4fc04bb1b092bff282c3e5d1e782a0f86a164a2
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 0526cdfab8b19f958869bf334a6f3325d876c0ce779edc
+Tag = b17dc9924d351598
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 4d1bb6699773b97d7c0abcb6d7ec01fff71f7d0cabe171
+Tag = cebf6238c40b5787f1fc5ce6e02beb05
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 9f5713a0a7252de6029957fc74d97f6c275b72916789e8
+Tag = 60f2f15ceebf5eb8d66a567b3f2cd75a2e7db60169096880
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 134ce8f8a2b9fed2fabdfa26f3f21e1761ad16144b692f
+Tag = 36fe9488541d7e955f2645776a2166af2fde76895a3105608e6fea20d98557f6
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = d9c5b7690646674afb12ecb493288aa6ce6c44779773953433a041b5d96c2f21bb28e4723a34a5
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 1cc8d49b2d3480bf7fcacf00844b42646fa7100766c152b404e3554e7e2544fc68a130387826e2
+Tag = c0b52b841e644de9
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 4f12eb251ab7d2a960560aa982d772530672ef91f716d8bc84bc4b0ca583365f827c3f8897838d
+Tag = dc13496b7aef8896c73105c65bcaf306
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 624b0f602613b09cfef307729aa9eb2679d9484f5c4ef1ebd0b894fd6d0677cd5cbfb1e478c2e1
+Tag = 41b028b2efc901d0d3894c42232fe1fc1a397937832d2f93
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 09efcb3dd1184704c0ba864144a95a2a4d06c7d8f1279be389632cd01ea6cca12da6890ff663c8
+Tag = 234b33868824016bbd3e8994273d503d3162b4971f316c04dbf7ee717e01c0b3
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = 661776037df165a4
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = 4408a95550aef48b5e8333654fdbd908
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = 508d31285962b0e664a864c6180fc2c6bd2a7c1584d258a2
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = 6ab2d9c5a73be283ce9909e1dc10aff117987437bfac3df5a4543b69a7e39abb
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = 915e9f82e9d0db06386c0913bf0f55a8
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = 6e6bb08024fdc64fc9c014f665bcbf10
+Tag = ffabec3dda4a1a39
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = 2bd3001e9264aecc479505b076ac4c31
+Tag = 3b43ee7071747a3e75368aee357dd24a
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = b78d7c827169531c9159fa2b9aa45016
+Tag = 02fc7dfc012eddeef2b2f195645443da96aaec78f5db6fec
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = 3b2266eee1ac689c65687512c6c6145f
+Tag = a547b84a04f724b866dc23617582dcc459bc4e34661f1708e3559d8d496eb6f5
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = a9e39b7bdb90e36e5fe0c62f5781e559d1ed98fd310f25c21b73bcd7a2a3a420c3fdcd2b2ec49224
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = 96d3133cbb35fd6cc68f76852b617a7164ba309390cdcdf58a33551d695d27e7964d9e68d574124b
+Tag = 384bb7762ef39ca7
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 7a84bbd13a9978b4b8ba29cb0548876e152d67cc64cf336518e4290a14d271f169dad9560080d766
+Tag = dba76df6bbcb6294be3bb756a12a4135
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = 680b61017152deecef969f60191bda1aa1969d2cd3c4f11bb4dbd7880cc5211c3c9d9851af55f661
+Tag = 6979e57d64933e2baf686173c74e6632e26cb51431cf5065
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = fdfb1ed4ed16cc0f820dd1643e3487e37753c24bc440c33c284448c40016e2b2bc26f9bff7d56c00
+Tag = 2000ad10d2dd39c34147718ae01202408ffe5f64581fd5f7c34fb781c4845de8
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = dd1098476bf17e4c
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = 93eae63e1448b1f8a6101855b24b1e54
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = a19b7f1b8900ce7bc48e69747c1520723370fd068a2f64e2
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = 6ecf14a3a3a0df5fff3104e9f05b2fb7dde3593098b2eabdbe0aff7a7e03d88b
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = ec1f229f55cbdb88e7708e75c17f97639bc92acc3189d68e
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = 49cd00ed6dec76431e30149012cc6207f7a2bc28f719684e
+Tag = 2d5a57d7b224f253
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = 9ea29cdc25b4b5105428f7a6560eef13bcbd84d735c0151b
+Tag = e99d3507c9d1b9a21dd7334bb09a1104
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = 8ab1b2c6f1a84980cd63a3d06cea95c36bde5ffa52217a5e
+Tag = 39da88bb7075f90f41d3ee8bad0140d5c6b71d24cf386c8f
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = 1e7c586e47f378aefc1b3e760e3c4b25daf3c9dae002c251
+Tag = bc0b2eaa3a72a23e3cfecad4bfccbf9ff5811e4803d74abc1a7eb4193ed38c39
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = 261a1c995f6e335a
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = 73f428904a0c6d69be09f545bee5cce2
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = cf54064eaf2aed338ed2e63d246f832a172bb3bd4d3787e8
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = 0ef324e6c67609ddbd10a3e77ae1fe3585987a82a8f67d1c34e4f4eb885c97ee
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = c84b968e6ad66477c06b6b0011e369fbf59b415215b2de386af117f8155cdb0f32bf
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = 7079ef6b91b46e19240b676a326a3f096ce38c987dbd9ca4c0644bf1965b7cbe2c43
+Tag = 89dc265e95fbd569
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = b551bdbce444370f4708976f776f7895fb91d229bf83489bf150f2b2ab8fb5f30346
+Tag = fa9d881c1434f3a6fdec6e7568f1d0fd
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = 32fde6d652a5ef6d34d6d6c3700856ab5a51a1cb32f73159ec2de4d4111e9bf5b752
+Tag = bbc9003e96b190df97b0a9169239bf1038ace263a669e3cd
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = a5f9b66a591853ca2d6dceb422f5ca60a949ca3030de509d910557b689e74b7eaf0b
+Tag = a6c15f3b83e2c5d9ea6e0946873fec7f970937a710ed50db6f36eb7c259dcf3b
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = dcd0aac73137b69e
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = 91f21725df146bac0695ddacb582942b
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = 71405f7b04285854d53a44a29b43631d13fa067e6607dfa7
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = 97ce6809130359108f0bfb007700c5a08ab0a8fe52dc029c74f7290a6de63898
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = a5d2165c64a02f4d6e1ab039b6de97824c590ff28776af5042f6be04ce7ad353e0f60c403f454ce63384fe946995ff9d
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = 87f4bb7bdcae1901fbfc611de352ec136c7aaed64c6ceb41e213e9a2b4480c56b3da8079586868985e96e0a3e1718146
+Tag = b866bc21e5d6a2ad
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = c9698e89dc05fa5f19279164ccf3f385a71e2023f2229ffbe8a16fe68f7c223facfef36c7f0223dc6b5ad46881ab15ef
+Tag = c0c1aaa98c89d1e4891a891c77b4d583
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = 6789ec20131c73279c58d0f292c3874a3f31c99e28291ece4c4bf352d2e3fe5fff046c1a25d0735a1e56a5e684eb43bd
+Tag = 50824b5a7e5b3785b6343b7801ace9e7fd896f4e6fb24c7f
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = 8358535911b9ecfa003fbaff1812dffa9845b6397da010d855b1a8b02b857a63464398ed2bd5f024078ca75b88701f5d
+Tag = ce74291153b2d53a6bf36731d487811fb89ee7a3206f5ece2ae40c814538cc07
+
+# initialize with key of128 bits, nonce of352 bits:
+Key = 5ef79029c25bf48d26bf58f18a23bc55
+Nonce = 0b6ccd2eee4fb011d13293f4b41576d797f859ba7adb3c9d5dbe1f8040a102632384e5460667c829e94aab0c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9095ab88056d9146
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = cd1901b55cc4f2a4041bcbbbe0dd35f6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 5921f0ee3e1484af3e0590e57eed054540d9bb46f69ea3fb
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = b2da55fabc64c49ce0c77595b4d6b023cc7951c0cde51dc49642bf73bd28e198
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 647adc9050
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 6a4a2e40b7
+Tag = 7a54675d5ceb7ccf
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 0ac8103b73
+Tag = cd3d309a5cba528c701ab53662f83609
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 9971b09bc8
+Tag = 71bda97eeb94b1c6317a64cb6c4abea1fa1bd50e4395bd3b
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = f91ff8f347
+Tag = a1ae9c1b010eec9ed01aa9633959b91b00f3c71a735fa624f0b83f62bf00fd78
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 9849ae407bf2c116dff5283a
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = ef59a8a9396fdef4fe2b3caf
+Tag = 301dcec17fbed803
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 5e20e819cb3606a882d031ef
+Tag = dc350032ef3aaa52c455d263c6339f4f
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 2ee016b1bb6c7c583a6eb22b
+Tag = c84555684ddc323637993a2102b3a5d567d594ec7a7a40ac
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = dc1b6471feea44d4b14da28c
+Tag = 231d7ca2fad911de5d4efb0cbddbba5fea130492a48201a26a5293112f5972e1
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 3465b390e16432e6c7b9cf9e4cb95c9d340abcf42c109b
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = a22a8f19875cfb4c09ea54f31c863906ed604301ff9dbc
+Tag = 799e99d55d659548
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 5a741a9bc76f2e8768ed95619b11694d5cc172852f3fae
+Tag = bdcf2c6c6c51ab5f52971c56700202c0
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 6d494a844352654d787c64fddb08b8bfa932953c5cb4b4
+Tag = a47136085a07ba6fcb33528183ea7a06b3f64342856bdba8
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = fd505b7db367eec75accebaed2c02261f92588c5a9306e
+Tag = f6cbbc73cc2a8768f562e8197bcb639663bb4d295dba2b0090c15844ef6ec153
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 2e48fc1e0fb92129e240b6d505d99f47cc69c095da32509981b7e887f65810e3e8e23b3056c2aa
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = eecfa14918f19d939c8878c13564de14d92db25551fa1998e8768cf145f5b6168ddfb1451afddb
+Tag = d2efeb104c5e1b35
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 71d65a6518819a96462f87cc50fcba6d29cf5cf463bd01f23ce8f0f010275cfbccb56b8698d0fd
+Tag = e145afcc58df9e30d70d5147c377d52f
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 79f200c6fc5e09c2bde9cc7c0632336c61c3407cf0023d1ade9bd0f3b3855600d9f17220643351
+Tag = 9fb8a2c85ef7a3cf44d7c380089f627d71eb2528c0c424a6
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = eb067a523bb19c4cd50f21a08c1e3386862d05a4b9b934d7295c0882ffa3e4c35fd6ef3ecaa4ad
+Tag = 1e85f5fbe13f7f4d8a513b7670f707dd8221860b94145bf802fab598ca890d82
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = 61891a19ecb21f4e
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = 8a137d9f92906d144f9115bdc26dd5eb
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = f26ab4caea515b82c22884c52cc7aa8f4d863e8a80763514
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = d46d7d37b4667db6ac5365e1cd9baef1f748c7ae83422e04f204e81dd46d2bdd
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = f378e5a334999eafb690d60ef005b6b4
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = 93f4388a3e59c1a8610d75f026fc3461
+Tag = 5c5f6748c91abe5a
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = 9270b19cf10e26a08846d01fd224cf9e
+Tag = b0d654ad48a54574eab3ecbf00b2e1f8
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = 17e9197d832da322a11d7d3deb469c5c
+Tag = 026c9c8d31d4e67f7cc0a6ed68015f4b6bd82be721e15916
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = 2c86a5f4a6ada77ea184203a4a2f4cb7
+Tag = 8a174be661313ea476145a2ead1ca0105589aa5a417308da88493feec0726379
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = 1046c6c2b55588d5ea05fa991411b0db1b6ef0f922461848f45986f7c3633d45fd5b38013c5e61d4
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = 712cbfd39d314f2f488cdaf6c6ed5e83dfa55e4e9ce5fc30a411bda8a1d4f3d79f2115342c3d54a9
+Tag = e69fbbeb811044ea
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 5bad8c0d50f97eee3bb4274d56ffce35e2426c16fa5d18f62eb6acdb2e10a05a899e6fcf3fc3cc79
+Tag = 569f1346e1ec614f5203c1f1e0c29b49
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = 9a64704f0705efa4298071012291d87716c36e04ba7b07c393c171e63e2eb8a282b4566d5f505afb
+Tag = 8a4482f26bf20f7d074038c7eac097e794f418e6bc504982
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = 3a608506fabdbdded6e671ed967dc3652215e033fc2b18d2cdfca8488db3f8e59ade80d282ef3d6d
+Tag = e8a5da8ed9908328067b34a3f5e6731726c5b3e1e344a0cc45a97f741ac8fef1
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = fe22dc298ad6075f
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = adaf247cd04317342f52d8e2c637a85e
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = 4d94d8c7832ab0ca9aa1205453a8863b9d38a9e688272354
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = a58913d6d5c8e908f3189e5daf2717195eb0580e97302ba0b1540bdda28badb6
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = bef8dd3916dc999a570a7aabc36ec7c47109db5f053be4ea
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = 3ac8693d5ea9b9cb2a326e2fa5de8ad7f6c5f5ca58da512c
+Tag = 85e74aac3ecad962
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = 5f3f3a3fd5e2a47b4c0b59c2ca45df4e86a9bdf124cb9522
+Tag = ea740c13c8877101ec46e0042858bf29
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = 518665302f57a5a96081dca312fd47c53043ae1ea117c2b1
+Tag = 6352a12fd3bfcde31e26f94c90f1f56697bd66cd7913b6e4
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = 21cea94b32cca9e6c51718c44daa75fb038037f0f0713630
+Tag = 373e1dade9da8f5cc68e5363e243d18051abaedc2efbceb2fc87bb1aa0485f62
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = dd4a28b1ff77fc40
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = fb0463205d685ca1c0a71af60a209b81
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = 2013ae999d65ccf2b77593412bd8fa60055728cc4a9d694f
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = c117909e78aaecac32da42ec47ea1b2b43cbe4fdb2d57c0acd87fbd815cee7dc
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = 874f25f0944369eb582048b0034f39541a7af5cdea8488af5c8b45d847e75494492c
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = e8effcfe4caadedad50cdd7954bfccc055a0afa3a4b64fbe20b1a4e303baab002be7
+Tag = a3e5283e4c3bbe73
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = 2075dee222f85b14cac6f8899de098caccbc430579f0bf6a03e7aaa1d7d36cae2164
+Tag = 38dd1bfcb2bd622682bac4f63e0caa0a
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = c737d7b76921d639f6339a04767040f97b35927a69ae96778ce0a4caf6a3d221c73b
+Tag = 90f5f8f96d86b6f24bf198e5ccf4584757326500bb9d25c5
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = e1e1d3e071ef2a2ee9b5a409f06e033df768e13c9ad68d4550a24e6170ac1bd5e152
+Tag = 3523d1f956ef84b72c7cf13f1a906f8d0c33b6208d8556a167fdb52f7863cf4c
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = 977514792ed9b5d2
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = af077ed45e3bfaa13a83eccf3a3d4a4e
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = 7357852d2aa461a2bae725deebb1fe22fa01ff1777640376
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = 5f574d7c0c4ba13cf4ce12e961c3da82de4910c9f5b3f30faf1d3cc1f9c34b80
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = 1bb2e95045cea49ca677b19ae2dd2cd3e72a5b635e3b49109fac0108e2bb4143d8f090ab6e79564986a0ade00ab4a181
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = d674845f104248ea84436cac2786592e3a5d9203b0df5c90d85d8a0f84e0328c9f8e7720f8df4ec61714232e66035fac
+Tag = 8aaded9b6281e650
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = 9518054952f144c6d3c2214dc65a78c71bf9b95dc3f570da1591c69c2c913688d6f064ae77b608a286ed855effa49237
+Tag = 66be21f1ee954e248362cc08e11f8230
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = 1eaf2262578f9707c305b3e1207415185f6706bb4eb78db669df274236860175bc5258a7eaf5b6b6e36fb9eac46539db
+Tag = 5b6f39baa1c5abd932771a87be74bd149a178cdc6ca9416a
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = 5401257cc0c50908ea81fb01368b4eebb3412cc0888fcf8894e5afc677c5345641cd58e2d1f25fc75669def03011db23
+Tag = f666cf70b3a1b7774125522c41ce8668e0b35e41c7a19e665293535ce6c429c9
+
+# initialize with key of128 bits, nonce of384 bits:
+Key = 62fb942dc65ff8912ac35cf58e27c059
+Nonce = 93f455b676d7389959ba1b7c3c9dfe5f1f80e1420263c425e546a708c8298aebab0c6dce8eef50b171d2339454b51677
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 525856827db6159b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = b5c087510761cedd51c6b678280f51c2
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 24977b98c1e8af6b9830755ae2df66f386eb3e107fd5f132
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2938918e343a6560b0ca00e6aa5f491bb91af03adb6dad635f201d547ee548b0
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = df204c4a29
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 7448081856
+Tag = 277a28ca20022a0e
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 712ae4e233
+Tag = 10674d7c68eb6bf0690f844f8f14a40d
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = d77241ff88
+Tag = 489f0ae1a07e4bc69c24a7954dd447279e5c89896323eb8b
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = d26f022e3f
+Tag = 5ed021f70dd6634c11bffbd8aa0bc40324313fd4da435a308d10286e184483db
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 91352f1ef667ff3f1cbda25e
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 68809e96e9878351d02f0f00
+Tag = ceea339776cc65fc
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = f5f7421060eb386eccc7102e
+Tag = 0c8cee7b74ddb47622b8b1eabb9b543a
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 363ef25949b857fa888bb7c6
+Tag = 75dfc097e27b2a06406b1c712007260230767495d1ed6545
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 9336eb02b9e3804d67ca31a0
+Tag = a3329da064de6a5af669a3039e5a465b350cd502b748d07da7c59b19cddd4d2b
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 902b505846c3eec8933a620f75ca69ccb61b7306025669
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = da66fd0876ae3ae9b6119079997040603cef1e2daf9d2d
+Tag = 6baac2922aca882d
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 4c0e9e080d9100e6487331bfe04de1a475e5282f9da3d1
+Tag = bb700b0b73c25f6f11801d3ef45fdcab
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = c988f4e9cf5ce34db18ae0ecb1024c4ccda714dae9480e
+Tag = 50b4328ffe30ea0660674e7a759fc9b7114ba1b69cc32982
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 749b7427b56434475317784609985ba2ec942d298b9ec9
+Tag = 31c559148e388a7c23ac2249a188e7bb22e151c4a359c0a304639c5cbc41bb17
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = c6f58433bec060953a4c6426f0951c46557eba375abfebd03314c0a97fca0dad901c5feb60eaec
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = c11c6a509a8cf2bef40355363af7d6e556a56ceff0e34c61fdf25d5b2ec070dc874417caa4a6bf
+Tag = c2dae1d287f519a0
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = a7bfd651648380ef75dd33fff83bf83496d0364cd9ea5314b3aada3368fef6966d65b7ed0cb9eb
+Tag = acf7b78a1eb2a812aa12541b7b489401
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = f79abe1dcfc6232d4c9054c767b7ae08264bf07490caeed2944e099548384b26170c3f79dd46ed
+Tag = f0c9c62fc225083e4eb6643ba635351d9945d50eae25619c
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = b263f1b5c068f29a63281920ed0213b8c269134e984e4215c985a093c833ff41d4530bbb57daeb
+Tag = 52427f019fa21f3f4727c0f4448dc5f1b225e62833654ebee2565d326550a336
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = c6a6728993fc1a25
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = 2a794c21e3adb655e7dcfb7192db3fed
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = 58738e2504b59e30cfce0517495055c6453af6ac164af736
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = eb81deba0de73b08044114dc1a1004ca7ff026b0ec9c4a13b319675a3292465f
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = 9db93be7bba19dbd18264342cd368f94
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = 1eea5dd01f61732dd7204ed51907c93e
+Tag = bafa87dbfdfaa1ba
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = d34a0ed31ab80d7004e1cd3164847b5f
+Tag = a8ae7446a1502b0fb9ad654544fd4f11
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = 44ecdb1eeaa2eb1a1e640bc317d2a45a
+Tag = 596504fd7fa6d34008fcf4b42e150c6123e9128beb8d9594
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = 9a0e374c02ab28043c6e0d078a430350
+Tag = 08238bf67f537b85b27448ec12c44e5a55a2377fa8507a5d5cf4ba8e51e5af71
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = f861a83cb74e410dfe16fa3f0a34b7eca91a292515edaea114be52cd09a93de7cca7e5a66c860a33
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = 8fce7bfd48bcd7b3557687b003152afe16ac5f9fa72bdf955dd89f21d0e3ca7d0c9e1593d3e6a917
+Tag = 19be05b98289efa6
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 34609f04f1a4ef39d32959cfbcfc09d5211ac0a5beb703dedb29bb1de829418a038abf1b09e43069
+Tag = 442650eaa9508a203bce36475491e8c6
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = d4c336e30d9ab01661befc8e4e1a46edac251c5a6dc6326f3a7ca678b4e944d9c816b4645c90d80a
+Tag = a4e43e0e22e641dd8a66c9a2b2f062c65c4e210740500948
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = 91c992b1f9ec0a4d5e18731ec3114cbe2e8c5ac848e710ea8a6430ea17acbed73440fcb92a9870a5
+Tag = 7084ba889309b9ecfdb824383d507dc2670bcf05979f5a6e281a5cc729873eb8
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = a44efe66b2cc8d1b
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = acb3c41a72d7dc3486ce20447159260c
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = e85e71f0a46e4320c342ad1753fa10d7ed54c1d0c47b2639
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = ade2a284636298ce483660c6e4232dea3cdb209acd00b92c9ab30151acdf8390
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = bc9d05d0d16cd0453bc30497abf3f6063dad73c2760b8f98
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = 3172a96be6089df823508ce1f3aadf75701b72a530c015c1
+Tag = e87d6205b1fcb523
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = 14b3f01167e09ace2e276f1452818ccc463b8f9fa5a42bad
+Tag = 8fae3f51ee1a00f0e6cd8ee6087c7943
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = eb3d9577fdca3598585b7db43d40eda18181a5845b0629f3
+Tag = 7798ac48967615274fddef2ad07ac579d2fc2cf57c9f3bd0
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = 2c7b6207d9437b4b2157e73ec4a57606a30e78506e67ec4d
+Tag = 2acb59cea24c5370135de9896f1b008d8bd19a1cc739be5e2c6864f30ff34c41
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = 21d710542b96fab2
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = 300843391de4dbfa083c0d6fac7ed1f9
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = 4d3b098c39a9476c95d271b2885b4a07d009dfcbf05f7b45
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = 85e76632414a58a73f83919f8bf2447cc8e2c5a0295a80d298c0b7413457c339
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = e69741b2cc5520eea3a1e3e2b6b133f4029c3bd92171f8c1c7dc83006551d1d6ddde
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = 56888eca37bca7d352603eb027aad4837c2088386511c2aaa0d86c12d67fdfe1cc04
+Tag = ffa4105caecaa8bc
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = 54c08debc4081c937a28ce6e4d83e115292db2ab6a519f8c8bd91d83676a153a3827
+Tag = 2b40826573728bbf6aa8495fbd777e71
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = b934b286195bed0595244d23a8794666276b011112a8db3b58f87a4466ce04b784f1
+Tag = 0983e2cd83485a3d7c0a76106c1d0465120da6d3bd7b45d7
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = 790caaa8a5366d8598bbb52115f3e1b5c3d6b7359cf8f7760392bea006a598e26b25
+Tag = 557488a4bd66985b6350544c568eee9166e4c91a822042cbabbe2686c63b0cf8
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = c141184adc7397fb
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = 2e015300a98eb3c0f6e061ac1c511fcf
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = 3a1e736a3c0e4f8103ab4f88b88104cda6de950db62f8f78
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = 46c67291ae6c97f1d9fd97175688a0f72d73405b5ba41ff2ee3d92de3a06cd35
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = 43d2ff937589625573fea307240dff51695e29ee7548cc1eb090685088f6c41af46373a02dabff3dd5dea3015d719c63
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = 16e97622d8bf45595c8fac7f0517df60480250e8f416a92f7750e3f12299889247b5055c90981e042192b10f71625a77
+Tag = aa03846e463a6e22
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = 1961fac698bf60980d6bb2418cf9119a713719b6714a2c9d2661375e4e6efb8aeac8267d1b36e6ea102a11ce3951adb7
+Tag = 2a953f3285a4c58e5e8237dd5c1a42f2
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = 07fab137e01e4f85823c98d2c7d671e51268ad3566ee7ed376fd5baeeca20551a6152fc9445291f8075d293bf9e21331
+Tag = 414f898d72d995e80756579ee5ed041509973aa76cc78ab0
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = 9b7582119908aa810d5631a9d03dbad4982c9efcc2514ca230e46959f7b4886d705e6cf7d54a73bb6ceeedf70bb76175
+Tag = 12c70ac14cdc28272d3fb391b565baf811c26f7389faee07af8d808fb11193e2
+
+# initialize with key of128 bits, nonce of416 bits:
+Key = 66ff9831ca63fc952ec760f9922bc45d
+Nonce = 1b7cdd3efe5fc021e142a304c42586e7a70869ca8aeb4cad6dce2f9050b112733394f5561677d839f95abb1cdc3d9effbf2081e2
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 12a6779a1e37d228
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 8b61753ff3d658b38c18876c812cfad3
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 79b7eb5468b432bacd76f02f337d11a9b2b8193eb2969199
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 157b4ea6178406020a4205646c31daa53d2ef0b2378ec04a8b361d083683c569
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 6bce8aa5b6
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 55783ff31f
+Tag = ae1105fcba9671b6
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 20d149835f
+Tag = 8a0b87cd963a33caa6bf6780d2446eb0
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 9e5972b949
+Tag = f4a81d2f32c16080e94cb08d7ddd741a891b5fb0ee894f1d
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = e56f8652fb
+Tag = 8f8319c4c40dfaec53ac767c2a95f22b3a45f18030e61544ab3406fb0bc010bb
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 20dd4d06c6e318d530199e62
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = cfc3432c3844beea858764da
+Tag = 6557d8c1ac88ae70
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = fd49a67b079c969a8e8727f4
+Tag = 4b5fe59e67427372d2fc77fc8778531b
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 482da86f4e621172211f64f8
+Tag = 09d5b2358b3c46d9a44a051a74a5d2fc33138e1d1a7f2d2f
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 74c2ad06e194d8e4d6270a46
+Tag = 8407f75c54f814b12276ee8741e8de3a2196b1fe8ec4bf9100b5a74efdf05775
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = eac2de6dfa7e44462bbc68e67a1a012e2fd3645a329ad8
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 90788fff9c3537e5568efa7eab99ca536611639d834d18
+Tag = acac27d927c02bf6
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 0b3e5a57737f30efbe649064080f4fe3a7cac88f84f697
+Tag = efb79bc9c11fa4159d13991c0648c05a
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 6aa29bfc976ade3626ed6da4c0d99da72a4104d367811e
+Tag = a3db15e0a261f778b59a6947cc85dfc17bf82cc218d5974c
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 4b24d54ff916308fe337b3b51a2bf81c2513c03a21eeb4
+Tag = e132a30413d8cd978fb6accffe7585f5dfa20ca3c010b4a1964a539b09cfc94f
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = ca9797295c872f09a769dcb7aa254c5544bb67aad523491e9f9c4e5d71b7edc8d7a8f9499adde2
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = c069f4e76067b948f6c10685fc2d9ce0829bd3f30698b7886cd4b9d8a37eb3cc51688774a5f979
+Tag = f48ab902fb442f20
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 1fceb312f847e53bf7e78ee7a51ea578603bb8aeab9bfd731068018ce64f85f1e188deb7556b12
+Tag = a44a2bcde5f511859fb4f42afe7e9eaa
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = cfb708fef7dd68317c231c286a5aa29c290192fbf5c337264e5bf6181db9daa9a76901f2d2b586
+Tag = 7eff9dfdd5881ebe3fb6b6adf773dba6bfb1467d487339f8
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 4378fe1bf0962bfd70bb06d77432b47753328e74f8dfec674ed361878f65b917682fb88abe2c2a
+Tag = 8eb36c00299be654f86e91293bc22d25e33a1061db7c4e995d7ce0d6341bf678
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = 698e3a98dff30e9a
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = 56cefa572c0f1f890dc0d9be2631bd64
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = 08843f9a4c6319b560c6e4d52ce5a4987d3f14ea6cba5c8e
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = e4909022aeae41e60162f746a72f9250ee6180607d94d1c995cd43167f4a4ac9
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = 5b96d792e5bc00dee3b8519d007189de
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = b1fcf55ca810513fee7a1622df4db60a
+Tag = e7bb4f199de29e6c
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = 8d4ed2e7d76793b0cc0d77a4b5772b64
+Tag = a3f65a9d16dec3803d09c79d9cac9faa
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = c62d99cfbcb87b83a9145fc0c2acef92
+Tag = abb4839b5e0e4cbcdf0e8d5b40335634d3ec84e4f2a80e4b
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = c22d191e69c7b51e68bb8d3296eea49f
+Tag = 0baa3c222e984667fc518837904bf727bba83a003448485469f3b05102bf3ce3
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = 98527f248b94af0ec7f6231ae990701c66000d43af1c7c1d4d6671dd6dee4f657f3fbce82cdc81bb
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = 210529c5ea651fba497bfe93bda029932426fccac949c2459d1084e4dcfb2b6bcaa26faec190f98f
+Tag = b7da40b8dc5feed9
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 9efaa971e28dd7ee597373198bfed16ce63f6e6b6e5c01b3d78d90fca8657868e4097876c895ef06
+Tag = 1db7dec1363aa7a3a61e1f54e08074f9
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = cead4703797e453279ab98076f4247d5678ce218b1f158e5f3942f40394d878e5fca6523185d3007
+Tag = dcdeb40ad494b38ad8fab0a3c8acc469ca8a1e3043d3cd3f
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = cd1439f763556cd4728bd4f30a24b4c5dfc54a1fe192a3d8929be8b6d05b98f875b84d99929cd113
+Tag = a81948fff19a41e153e149764b4f13a8fd9a2df2e09184f0b44e52fef8827177
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = c47b7667f8af2ccf
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = a52313563c7334570b2f76a1b8c8a885
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = 385804c692f10931c3003996097955bc64bafe84e988dcfb
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = 2348f1ae5f234eede45f20ef8bdb393f2d1685e55ca31b877c63de6cf26c9aa8
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = 2e600b28995aa6014311c6ef3a6dbc68530973920a00abfe
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = aceaa86f36041397c8c6fb3f3c54222e386feef030f83a89
+Tag = 2cce2f1ac73fa7b8
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = d1a01bbde3c9fdf8473ba0ea0f477d74b789193cb8b1c368
+Tag = aa334cb406366faf487031061e3521cc
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = 9ff5241fd9b66789b65539498d8579f57d587281a34ede47
+Tag = 73a039a938a8eeb07423b4c73784e7fe4c12ea72cc9b4cb2
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = 5446334d5962479471c4b0e9664b18b7784ec202976fb12e
+Tag = 194f432ddd2d6681aed305057cf4a780279024b8623517182dfae18cb478b759
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = e8c10dc25361725c
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = a27bbb1f5238159a9d4264ab1a109c45
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = 5e69bbffebc5c3bae4ee4993a81593ea9b6c0e85cf3c7393
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = 63be0fe3c78e3780fe9d391ee90ad9ea528df99c0d1cc022cd0a383118486ce0
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = 19655b5ab9403b4c0fde2789faabd21dade9922bd41f56b2b51e89f5814288c33b02
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = 402355fb82ae58b8b961742662dcd26135a874cbbcbcba5f8dbe9b123f4d447b6749
+Tag = 7a30cf7654080fed
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = edea55693bc4f30dbcb525dd5876c075264977e1de4d6cd0eef58d8e331e865eb154
+Tag = 08515e29d7a30278bb29ab9665e960f4
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = f816dcf63a2bc08dedc756d4c7f94e093b62a9747d5d1f7bc2d08a7fd168c865d8af
+Tag = 17450537ab740f0f86b3f2117a14c3dc4c3d14c6189c8f28
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = 07645db4a57b8080e67feb2c615e482c1d52990df0ad96d8982d064733d2d48b1180
+Tag = 2086f6f4342183f4a0cbb90fca828343facade1b29573f7f02d9939dfad5b8dc
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = 6d6e817f3eb0f398
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = 7d54efd22f2fb9cf6edbd6c1d90a411b
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = a338c21c178178a6ef3994d9f3ee7b03324da8cbe1450259
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = 82f42ec962cd631afa8b914894bfefa98c0c8f02c88e27c642e98fe9e39a3bb1
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = 86959d17fe150621c76674bc67f56a845339d2fe56dbd12452df99879b53a6659fb4f07a7e7d3296345eccd3ebbfcaa0
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = 01b7bbabfc72314edadfde04082a7679c176ab977d7599f66fdb0899e28f0f8d86b7e508b061cdd6806ef3c9b6333442
+Tag = 82c0f14f622d13b6
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = 93d19eb9f9e77af1f1c413eca7a0914fddb3b751c88bbdfe297cd29752a84bda60cc0e730bf1423818b9813f267dfa6d
+Tag = 99ce65fa070696a684e669d320aa4718
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = a9a995d9962c0b4d93c1003db4aa57f3dd9212d9ab712262159888e84d0aa9d249183491ec6dc90e4f9cba2233681e98
+Tag = d654a2eb9a17af81606b119abd26666dc20b3dc2d63860cd
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = b8b9df9e52cd3749bc5155f39e98360e6fed2bbd1e0c6220bbbf2ff6d490ad2edbe8a2ec6a666155351eef77f62e979b
+Tag = 5c54cae91106530a7708f1fcceba0672f198d7e3e71a4f64d47162dafc9af9d9
+
+# initialize with key of128 bits, nonce of448 bits:
+Key = 6a039c35ce67009932cb64fd962fc861
+Nonce = a30465c686e748a969ca2b8c4cad0e6f2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5268747a8096a2a8bec4d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9758999817788d9b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 057c215ae15b6d0d29716d45886e47d6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c89a42f92e17c8aafc1087120003b22935deac430a41bde7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 5f9308eb75b237890949611b45dd7f13c6118e136a471d994dc52f48ce9a9206
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 580cfbca43
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 4074297169
+Tag = 9221ba14403729aa
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = e9b2651b69
+Tag = 5a849bcede829dd43d9c615bfe7e6da6
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 03898e58c8
+Tag = ab41c8a012dc9adb2773566a601a06d1ed1857267162047d
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = a1900b8687
+Tag = 19bd230bb4ca67f2bc819efff63dec0fa384050e2e741ed2f28a9f28fc1d7a2a
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 6cbb8afad730009732ab95fd
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 81f8626566add66f4823e30b
+Tag = 8ff61362f479dd53
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = dbef2f80374e5f3bd0c510b0
+Tag = 959ec792d371ed176a33aebde7fd325c
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = ad64fa4cb23861939f6d63ea
+Tag = e34fb54f9bbd145a106f0648de6861c8ab9ee50a37d87d1e
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 3b66b9119eba27687e40e2cb
+Tag = ec8b482d23090681a870a9b00e17342b3c559d9b1be27f5a677ebe5dd0522735
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 96bc9cedfa557759eb46610e4aafaca20b137d41cb04e2
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 3937efec307cb51086d72a1544593258ad8d7f94296769
+Tag = 88d05deee5c174da
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 5d29ca620e3936697e82540f30bc7c23ac735dea2e705e
+Tag = cf30bcfa457b64a8a1ce572bf009650d
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 58a7d035277f555c38af592e60c2f2b2f640d442d1ab23
+Tag = f3dc27929aef4fd9830184a3e1cb4bdd171f6d3f2a856584
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 9175017de59e2c852bf73d2bc8347b796d30d28e5b2700
+Tag = 94a9e543cb52f8450afdd16a9102daefce01a589cc206d540323c83ab79e35aa
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = e8f3f535f92deaae234c18b4730c258af7a603cf3c223b8e04e85ec4a0f2d4b9c0900977a43b8e
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = d6966e4865376b524abf28bff294034010088e8e9099763fee8e463ccf0708f0ceee507242d88c
+Tag = 1043026bd4fb6dd5
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = daeb8bfe6c869266536a424529534e892508cab532141db2ac627f045eb475dd84aeb16e4b36e1
+Tag = 3dee68febd3fac535df6446f93a090fb
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = dd4b8bb93783eeb2584f274acfcc2e9c1c7ca2b72eb685860444aff05297ad091fedd8212c02e0
+Tag = 75320d3e5b1e3a87bc5890fa7f0d87d0c39bf73c860f45de
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = eef5b8bde78219a2bc11d05e37504a11770f1175fb3198ea5c45aae4c7c02fec39c05e8ff55097
+Tag = 90b076927d49737925960e5c41f019eadbcdb33d9ce1f6321493b3333e5e2384
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = ba14032943fd1f6c
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = 99219a4a819b47217c08f5637cd5af3d
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = 486387331561381965b7a2a1ea37e39c4879ea9f43ae513d
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = bd13549c9137923862525465d193946f9279e652f4fd3676a10c80f082a04944
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = dcec63ea9631020b65adb68adb62fc3e
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = 28cd49c9cef255462e521a56e47ca30c
+Tag = 474ddbb46a336ed5
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = 07312679e2cc3062d0ac9973a0557e90
+Tag = 7764da7db83789e067fd4babc79ccbb3
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = 8641bfc3a0ac8e6e339beab7eacf7c28
+Tag = 4ad7be46ffcd5fcb7962c0fdd73d27b59cb8b43d21923f48
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = 2883e4bb292a5f4c28716bbf12fca35f
+Tag = 061dba0fd05e51306867822b7b8f776e83339d1d2cd12f2eff8f5bdf46da8243
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = ed4ef0e3b5ff8b9fe7af8584975691b0f741f4667921715c4bfc6f9e00841125ac0b7027c4e98fdc
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = c17a0be19ecef63568814742eab5a3da4d72ecde3d462629de360395c3a65edfd3ea647022e37b91
+Tag = 1d4302dabff3b206
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 50240b060f8d1bb2301e029678cb0253dbc24ac0062c229038b7ce6818f2b21c6b34e1d82a22d3bb
+Tag = c1f293cd32d404eadfa1a5251e5c4190
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = 031907bdcc7c22d8864e99a0250aea358ee1c7cce89e6032ae636f77efedaf49bc9b51b91e10eb6f
+Tag = 98df71b827f43a36e9bd3a02b0dfec93faa36d3abd96fb04
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = f0a69ce614a50bec93ed5bc04599ed9c19f08a59a8f516e79438fc80c0fa40467294507f0b8d31b2
+Tag = 7595b6c41961028778376c473320f371acdcf6f1ca0b44159dfc89eea8bbf35c
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = 7e3c17268e5b4130
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = cbe41f0da5960186d504af2523679d6b
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = 7cb812b788af62687a7046cc693f042024445a5c00d18942
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = d681e245c35986bc840b391f3b0b028a541c4ee6bb16f4832057a02cecd15e86
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = 01619b637c49b66e2c729d20ccb28f686382f8bc2e801148
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = 13b46948883dedab6130cbf6d1fa53f3253f86cf9b658b6f
+Tag = 892240fcb4738f4d
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = 0f6a32e85489ec8870bfb99592a51b4a4bc26af298c8aff9
+Tag = c928dad44f8f17a64a04e0c4d06347e7
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = 2f3584aa5b0af7eb6fb61ae493b94b27fc4aca4f5469c598
+Tag = 383b4d05f913483ebc39c0138e9cd039238c37bdb45db59d
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = e8124d03ee91aa327824537514f66c75ad73da29ae3449d7
+Tag = ff7d9cbd6dd279995d3f14f188ade39bfcdfcdb4ebb469814b9ba4cb8458e9aa
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = b9badc1458afd178
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = d6163449ff7b502f3635a8311d45ba42
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = c48f3b76322091942b484cdd277d4a8c343e4696a7476925
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = 9147154c47b29105bc3c54993d489d19a50c96f9b27e8ae195bb4204bbd3be7e
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = 13d73cd3d407ca9ccb79d480604d9bdab1bfde8eaa373aa00047b48c3bac1e770db9
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = 4e1b28a38ec0d2267e79fc5c8ff78d77905df7a5d7b6034aff4155bde7e4a5ceb9ac
+Tag = e272a9c8829fab61
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = 14dfef95e07c76ea8b5610f9037b88aed661b60ea37ddf7faa41d4962bb90e3620a5
+Tag = 95af617fd8bcdb711a73a296fea6d63c
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = 2d60bd7cc93535b3a1d000957b30ce36f33fb06a3ac0601909e0b9c88cacb29b9adf
+Tag = fbc4f3726af27958fbc0a8fc77c3036bd0eaa05c63db346b
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = 5b1708111fea0e44bed7243168bb29b5accceec2ab31525abdcc9214580dd6e74481
+Tag = cf2036ed3a778f73a9bf6cd8272d04aa3387588fca55fd40f5d1cb4dfd093245
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = 1c0c30756d790018
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = b51492a8c540ad5f020f4c0d36bfffed
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = 2278163f2cd5cd244d723ee94f48163d5f12754536399823
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = 375db9aec8caa87d0971c616bc9d384ce2607ec945c8b3354e06bb06bff8ad51
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = 812c6e8b787f47c411451de7030736f7b7f6ebb4eac10cf14e13936448bb7646d3b7cf0ffe52250f2a6b3024469b3173
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = 96496eedf98b67a364dafa3cd95dec59559a5dba8414170fdd5a0a8fc0b30ef2f8cccdc9765310a567b2a5c03cf696ff
+Tag = 8e8a171c035681c0
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = 63f33ec68fea88e7ca9dcb411e8a48e8184861f031ec7bf77167dbfa3e9d0f0584b8d1fbc1f8879e444792451f1e5ba6
+Tag = df76c405f50f1db72aea8615ce6cc370
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = 5a314cfdd071347ad70e7fee799ece66f4866f818deb90ff0b2588987dd94e6827a7e438e0d8e035054d953f78492a73
+Tag = b15e6cd81286edf133d682326912bad68b22415d63d04156
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = aeed29a1f76fd7e44929da75d88ef497ace26492de2f3a0e11487926f5d18ad0f77935ddd2f8c708c9e0e3af69acc182
+Tag = 98e078f657c9031f3ab0621375b439336897d8c7dab631440a6b0dc03e76e35f
+
+# initialize with key of128 bits, nonce of480 bits:
+Key = 6e07a039d26b049d36cf68019a33cc65
+Nonce = 2b8ced4e0e6fd031f152b314d43596f7b71879da9afb5cbd7dde3fa060c1228343a405662687e849096acb2cec4dae0fcf3091f2b21374d595f657b8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2e968b532c240c5c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 21ecc1630948e4c90ca600e79553973c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 98c9788975f20d7f42f35d6a28c69d0efc5e6a922e666237
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 148ba7776e9eb1f2c07fd217d9a44cc2c1c7195995ff0117abe94f994b357c66
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 75d9135cc7
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 662a6443d9
+Tag = 19f26384d7ff1fa7
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 25926b71b6
+Tag = a780b647549f3b0a63770a184045ff22
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 5fbba14e25
+Tag = 6fd97e22d8cffa3d76e45bd370d7f4706ba08fc24066ad11
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 5dc00a8804
+Tag = 395bc36c2cd2764b16822fe9992ba5c8c3dcb149d98e02de2ee9230570825770
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = a9a4ec06f2ebdc56b5cbaf15
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = eca9a7c6cffc2ec3017aee43
+Tag = 98e83712783ca023
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = c74b4788e6823d24e469ec8a
+Tag = 46b240cef697eb53fbc591999cf01956
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 6ba3f5006c7a8cc31a2c404e
+Tag = fa12e9a5ee233df5e043fb7932ce27cafce92000122b9214
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 6a1b0e19c85c9a69963a2b20
+Tag = 1c509776675853ac6b7dee4a08c59fc9756609fe5bdb40622d4d85064b25f253
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 55d3717be41d1c817f8e14c5fe3b6bf71e19b0874ccb75
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 2e5f9c8cab76e6314f4119fee19f3b09aae350f38ab8e4
+Tag = e7672b02176f589e
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 7433c038b5b137b20b4ab794c9521347b134d7419e6ac2
+Tag = 1ac1aca6f3ecc9c634663a1583c5f2b1
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 20f90db184f36501156cbbd3e3cc46e196bea2f8bb3579
+Tag = 31206b68e0fc17b97d4d54924499c133d1ac716484de15d0
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 203f8ab714f725f23db7ea1dce30025e524c2abcddd496
+Tag = 7037ecd30c52cd0cf14e9e826dfb52ad9cc701a1421e61450642205ddad80bc7
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 45306c6c1f6fd9537477a0502985fc24ff8dbf6ec9591740b5604d168e8d15e77fa0087d6860a0
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 95ef62729b21eaafc7f655e852bcecc259200aff2fafa351740aabccec248c7f14243adc82c299
+Tag = c1c37219bb467cf3
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 4c0ae00a890cd98535b426b5d7f14ed793cb9d2df079b298d87940aad0c921ea1262251ae0e967
+Tag = 77da7e0ac58e3d3f003d11d2b6a9ee1b
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = ec3f5ca178be6de5059d1a521754afe601e207efa3504f40271de8a8480338cf910adae46ccb85
+Tag = 6a7f9c1d407f68c6166ddf02f40aa577cce5e0b0d5e1b8aa
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 592e66a56f4f8a8f26fa4eb77902d222457d4a25600a561526e7c269aa85d7396107a1dc6c412a
+Tag = 4f6419979c41fd47c118297d6b41928adc34245437f0ae5dfaf0820c7412c668
+
+AAD = 009122b344d5
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 08992abb4cdd
+Plaintext =
+Ciphertext =
+Tag = e0a832d48dbf7511
+
+AAD = 10a132c354e5
+Plaintext =
+Ciphertext =
+Tag = ec5fc248f4be2494c52c85637ff598ba
+
+AAD = 18a93acb5ced
+Plaintext =
+Ciphertext =
+Tag = a6d635ef169390953863832137f86730ac8407060b680dbe
+
+AAD = 20b142d364f5
+Plaintext =
+Ciphertext =
+Tag = f7912fd84378022bba1bfbc808718aac23acb037bf7d56cf4abf98c60e4c10fb
+
+AAD = 10a132c354e5
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f3
+Ciphertext = 88eba2aa9a4af92e45a95e1af4ade2de
+Tag =
+
+AAD = 18a93acb5ced
+Plaintext = 73941435b5d65677f71898b9395adafb
+Ciphertext = 5ceae1747ee4ae2e3646f934a9d73397
+Tag = 6edc19959dfa3e06
+
+AAD = 20b142d364f5
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e203
+Ciphertext = 92fc79476539ea0f44f0aedb4bf76c6c
+Tag = e8f2c54ffd1747e92c18ad9703ef3003
+
+AAD = 28b94adb6cfd
+Plaintext = 83a42445c5e666870728a8c9496aea0b
+Ciphertext = f9aee36b73ae37b77c8844ac89301af8
+Tag = 068ddea05f4c12e5c1ef325f7e9699b25e2f6a428c9b73e8
+
+AAD = 30c152e37405
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f213
+Ciphertext = 9ff493b53f6d91ab4429a3a0a3d87917
+Tag = 79c2c84f956594130ece209f363e6c29f5759741ee1d169a851fa9c88d52fe27
+
+AAD = 28b94adb6cfd
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = bf085ffd76e336f50f29bb713cc18e40ff83b27ce1e08f93dc383ae1b7b86ddaf277d5a445df27b3
+Tag =
+
+AAD = 30c152e37405
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b7
+Ciphertext = 95e8c97999cefcec20647eb58a58217eb1c770b15c64102e15cc2709475cfed4f1c9fdfd4627eb44
+Tag = 6ec745675f472145
+
+AAD = 38c95aeb7c0d
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf
+Ciphertext = 9fe79bc9bcafdc98a9d1e6b29cb07c9232db3d92fdd01bac2fde95f8c78ade091b5d1a939ba79ed3
+Tag = 3399e2802f4d287f687d25269d28865c
+
+AAD = 40d162f38415
+Plaintext = b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c7
+Ciphertext = 0b86580ada6a60459220a03f017511e5cf43776e14ee52faad9feb86365e10393fe9e8a0b8d6cfff
+Tag = 93cb3df1f959f4223bcf3d886a8a5196e542c458b9a291d4
+
+AAD = 48d96afb8c1d
+Plaintext = bbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf
+Ciphertext = 371fffec33788da58ea3500755e51b669ed5a347420afa2e84df91c510498fe68c14bea689e6f06b
+Tag = c7c36aed179ccbbb8e555cecd943a7aab8b7584eec23a76ee47078a31f30e356
+
+AAD = 10a132c354e576079829ba4bdc6d
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 18a93acb5ced7e0fa031c253e475
+Plaintext =
+Ciphertext =
+Tag = 52dad0270b6623a8
+
+AAD = 20b142d364f58617a839ca5bec7d
+Plaintext =
+Ciphertext =
+Tag = 0f000661230e4ca8859d7d9afe9d5e40
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext =
+Ciphertext =
+Tag = d519a7ff11ad67653b21781475a540c740d08e5f76fbbc53
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext =
+Ciphertext =
+Tag = f475de9ed8e41d951f3d9fd11dac1cd613c3fbbcaa0ad7a2d61f7fee1371620d
+
+AAD = 28b94adb6cfd8e1fb041d263f485
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f
+Ciphertext = 96c6daf7b561cede194ca4af615c40e9b6bd9f87fd9ca470
+Tag =
+
+AAD = 30c152e374059627b849da6bfc8d
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f67697
+Ciphertext = 20bd04b14a84818531a15e31614eaf59a29c4bd494f43496
+Tag = d32ebcd078b31d7a
+
+AAD = 38c95aeb7c0d9e2fc051e2730495
+Plaintext = 93b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f
+Ciphertext = 4b9186dc00ded8b08f52dfca29b020b2922f5f78a25add47
+Tag = ba81c1c5aa06ce1731fbf21f6aadc646
+
+AAD = 40d162f38415a637c859ea7b0c9d
+Plaintext = 9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a7
+Ciphertext = 4296e5c1245f2ae9c424a2903d8df4c2350e404d4207f518
+Tag = dbc394bfc66537682116f33bf3880e6b8b4fd4a1d9ab35bc
+
+AAD = 48d96afb8c1dae3fd061f28314a5
+Plaintext = a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf
+Ciphertext = f5739f3bac2ac0be2a1348f2d4c71ae1f34e0ea6f77c9a1f
+Tag = e1c4d8df8ec2d23a8ac6a8a036e0d4cbb33eec86dc92180de95a03699030126d
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3d364f58617a839ca
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 6cfd8e1fb041d263f48516a738c95aebdb6cfd8e1fb041d2
+Plaintext =
+Ciphertext =
+Tag = f7e0a1da59385e82
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3e374059627b849da
+Plaintext =
+Ciphertext =
+Tag = 84bffaebdaa0d4b8d9e7500ac49723ce
+
+AAD = 7c0d9e2fc051e273049526b748d96afbeb7c0d9e2fc051e2
+Plaintext =
+Ciphertext =
+Tag = 6d8388fdc7a61c5fdbbc17660fde9916d957cd8e57abdbfa
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea
+Plaintext =
+Ciphertext =
+Tag = 0eed799393d1f232e29615aeb7bfcf024a76677d28703849b838cb0a0e5e02b0
+
+AAD = 8617a839ca5bec7d0e9f30c152e37405f58617a839ca5bec
+Plaintext = e10282a32344c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f112
+Ciphertext = cddb3bb0321b62e947fe4bdb58645f3ec35a887285a16c5026aff611baf64766c36e
+Tag =
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041d263f4
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a
+Ciphertext = 565e4c777a9ae58413ef1e0644c9fd4b070be592dffebed7d1e75e52c90e3af4ba65
+Tag = 45737a341492d74a
+
+AAD = 9627b849da6bfc8d1eaf40d162f38415059627b849da6bfc
+Plaintext = f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbfe060810122
+Ciphertext = 0130f4e1af648b6b81b0e53b16e1f403ee5a86372042d840258114bf122d0f1bc80f
+Tag = f28afad84ff4d926d138765496a206ad
+
+AAD = 9e2fc051e273049526b748d96afb8c1d0d9e2fc051e27304
+Plaintext = f91a9abb3b5cdcfd7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092a
+Ciphertext = 3d03da024e8b1d4cb89afa1e69fb96942d6bdb6a810bd9910a073c7c35866b027dd1
+Tag = 17fd451ee24c3c6596533494a79f2898d65c2a60744a896e
+
+AAD = a637c859ea7b0c9d2ebf50e17203942515a637c859ea7b0c
+Plaintext = 0122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132
+Ciphertext = e5c0737da0df43548085b68fa2ce063b9584125f6c22c9ee35385fb0648523ca4deb
+Tag = dd3b763c5ae17da9fabc6d0756999a02213398d6148c71fb5bd89b3316a0ac35
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c9d2e1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314a53626b748d96afb
+Plaintext =
+Ciphertext =
+Tag = 68067324a0224c4f
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1cad3e2ebf50e17203
+Plaintext =
+Ciphertext =
+Tag = 1f783952df1078349fba5a94a950e32e
+
+AAD = 58e97a0b9c2dbe4fe071029324b546d7c758e97a0b9c2dbe4fe071029324b54636c758e97a0b
+Plaintext =
+Ciphertext =
+Tag = b065ba136fff737d3f57e955c687ae409f189fee02a72ac9
+
+AAD = 60f18213a435c657e8790a9b2cbd4edfcf60f18213a435c657e8790a9b2cbd4e3ecf60f18213
+Plaintext =
+Ciphertext =
+Tag = e67df19a23aa0ce00151cf55c3ad9bfaf2fbc2cb1a698d198bec65bfd3631afb
+
+AAD = 70019223b445d667f8891aab3ccd5eefdf70019223b445d667f8891aab3ccd5e4edf70019223
+Plaintext = cbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263
+Ciphertext = 005f023d81a5c34eea747cc4078fffcdead99b27e186b809015c85b91734b5025033f12756454d0e0733a60e963702fa
+Tag =
+
+AAD = 78099a2bbc4dde6f009122b344d566f7e778099a2bbc4dde6f009122b344d56656e778099a2b
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6b
+Ciphertext = 6a9a385f60d1ba58a10a69449f746d7d88fc01218327959b45db58c94208f7a49a3f88ec0d6dce9b739cb6871e8e59d6
+Tag = ad1146517b248942
+
+AAD = 8011a233c455e67708992abb4cdd6effef8011a233c455e67708992abb4cdd6e5eef8011a233
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273
+Ciphertext = b64b76eb8b1848c9ece5734c2eec83726376be44e40c11d7630351e9c222addbb8f16bc42eb77a9df3cee43108ac47ca
+Tag = f5f532c62ba2dd35c7678019998f8e3a
+
+AAD = 8819aa3bcc5dee7f10a132c354e57607f78819aa3bcc5dee7f10a132c354e57666f78819aa3b
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7b
+Ciphertext = b3acd363677ba16eddc279deea1366b1e9925c8a34d543499805cb8bb714c0cd537d9a6c850420c7615a23c11fb6c6f7
+Tag = 702b5d720e47d4f604ae7d26bf2445bb9e61eed373e682f1
+
+AAD = 9021b243d465f68718a93acb5ced7e0fff9021b243d465f68718a93acb5ced7e6eff9021b243
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e26283
+Ciphertext = 01b195cec8af4cf69a49ae6be943a6fe6a06b1813f26ff68c0cd03f29f5555e4ce686efed2920629578113a6f0f980d0
+Tag = 49451bdeac2f4b282316fdfc8a5cf0fd5d27bcd5fb318408855a6a231d380ff5
+
+# initialize with key of128 bits, nonce of512 bits:
+Key = 720ba43dd66f08a13ad36c059e37d069
+Nonce = b31475d696f758b979da3b9c5cbd1e7f3fa001622283e4450566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757b8197a3a9bfc5d1d7edf400061c223
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1db6359d874ef164
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 920774e5d0bd7fddfafa579fbbab6b78
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4a2900e68aa5ce845b86c3d9e6eb9bae96f5e551022e4ecf
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4b39e36497fea7706fcddfac0585748448b36bf1ceb15f26edf8267a97b3b8bd
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 20cf4ff4eb
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 3b161d33d5
+Tag = 37bfedff21230d4a
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = e26e4dde9b
+Tag = fbc098f72d5e7eaf54f7be69eec253a8
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 17223738fc
+Tag = 56a92a0598106567bc820dfda937a899839e9d6ca3030c61
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = f4cf998da6
+Tag = 8d3475906c3af9ff7af0714a25074c693e051efc2a169f50e85ece6886ea61b4
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = ef92507f60ecad685244d8cb
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = ca3e34d8f9cd40143cd06eaf
+Tag = ac5fd3d039c90047
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 44e7d80df582efd94a1146a3
+Tag = b8406c42b1987a33e241ea8505fafba6
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = f0217e0f542e3a01269a5d4e
+Tag = e8516d93e5a9bcb597f6c5639c40ec4dee6c02a1cf45983c
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 2a40b201a8d717a1d5832315
+Tag = 097badffab950455b921b2242e545c0d516be4a05233a8bc8ae55bdc01baa769
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 53ae4b41a9520174fd1af616bfd5a740a51d5816839ade
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 07c13cf236d058563f76bf4349c5a0213ca19ddad0be35
+Tag = 02d9b7fa37c71927
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 66e3cda5563650e2c3d5de96d6664f8422ee8d04dc7a71
+Tag = 48d9ade8b9d7c60afa7419184b08bc3b
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = beacc6c0e6deadfdffea9bf5b8d254e81e1b77182e1b64
+Tag = 8b1e7bf189da9797de69a48516c91cae1fd6bc6c90de64bc
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 2ceb7cd08160a09d3ea2098f905cc7226e862634aabcd1
+Tag = 714d77d371c5adf0c69b0ff97432cccd94551642062d0a404db288fd6bb769a2
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 9652811e594f8039ad1f86a83514ebd385d41d93732784427e8d446d1b2c82df2aa3380675c884
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = b9ec1c4fe07470190cd68639e7217a7644485c16a09887a7fc3edc608dae45c38c9697137f14d3
+Tag = ea7e18cd5d3e027c
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = c0e8315fb80fd220431a0afda707035253a81a52fdc60e3cb511fd157c449e6750bae07535560b
+Tag = 5672ab2f702bf46ec5c7d88742cf6ee3
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 29c3d53918f1d3afe6336932257f4f7eeb4c28737b58df42b05680d23140fcc2c752869b77cfe2
+Tag = 1ee1abb5321ffcebd7b2ce9f2e2b9580217543e0f68724bb
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 15b7744c9b28ad97d8eb052bd0cefab282f156bbc4226756f37e6ad5d99656d7fb0a583f6bd6a1
+Tag = a260b528799784f6ceb88df1a4898ad7ea6abe3bb4f11016991d4eddcfb2d6f6
+
+AAD = a233c455e67708
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = aa3bcc5dee7f10
+Plaintext =
+Ciphertext =
+Tag = 1a635ec630f519a0
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 03b46f2f44cb87b84b7670ed5298fce2
+
+AAD = ba4bdc6dfe8f20
+Plaintext =
+Ciphertext =
+Tag = 5c0c7b646f37fb1448e250e8684f628fcd171622e21422cc
+
+AAD = c253e475069728
+Plaintext =
+Ciphertext =
+Tag = 6bb9e27019af6ed726fb77e9aa3520622972009988340e840e3e11609d8970c8
+
+AAD = b445d667f8891a
+Plaintext = b0d15172f21393b43455d5f676971738b8d9
+Ciphertext = e8fcabfe348ed3717fb8f9474f9c74277812
+Tag =
+
+AAD = bc4dde6f009122
+Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+Ciphertext = ad77f3283982ee6695ac44f7f50a3172910e
+Tag = 09b6a45caba41329
+
+AAD = c455e67708992a
+Plaintext = c0e161820223a3c44465e50686a72748c8e9
+Ciphertext = 1202ccd883c08a9ed968600f7c70ffcd9c04
+Tag = 9d9f065b3e78af360c1ea227f74b89c6
+
+AAD = cc5dee7f10a132
+Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+Ciphertext = c18d9e7f4fbe077f54e9f58cac8a7787eaad
+Tag = 8ac8ce54d7b28615a75e484cd1735c1903451d2d552767f7
+
+AAD = d465f68718a93a
+Plaintext = d0f171921233b3d45475f51696b73758d8f9
+Ciphertext = 774a943144d72f7c724d30b80b06b09cb663
+Tag = d57a76a996c38fac86bb82eb8be3edc232c3c82965a9654398deb1bd9faee648
+
+AAD = cf60f18213a435
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+Ciphertext = 045e1b4a314160a0e3c5d209a5edc14d721fba3f0dd46bad4154985f9bd9c9a509bc7101944c726bdf92e74bf0
+Tag =
+
+AAD = d768f98a1bac3d
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+Ciphertext = f62f3e8d1b463f22b1ecea1a8ac902f0c9a0c38884f9c15cff79144cfb40e38c3cf61d335f590455051f63478c
+Tag = d7dc559244c20934
+
+AAD = df70019223b445
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+Ciphertext = f8a2ca1eacd55c48c9d0a7ba9e7645699bc65a656651ee2a0514f1aa8dfefa29c162953e08ec800da219e237a0
+Tag = e6b38b6784d1781627d3fc07420b8d79
+
+AAD = e778099a2bbc4d
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+Ciphertext = dd17f5f207252cd41daff289df268436095bf1625aa90178a108eecc5df4ab13ca55783e095f901ca51009c24b
+Tag = 3d181c6dc135524268853d39031d6d3325133d5609ef28f6
+
+AAD = ef8011a233c455
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+Ciphertext = 580555bd7af26ce1da5b644b53f20b1ca30c1ae9f48d378382eb98eb938704a001816b23e203938f3bcb61969b
+Tag = de58372710269354d293934d9706635236663ef19333aa6dd2f1d2f09560fd6f
+
+AAD = 54e576079829ba4bdc6dfe8f20b142d3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 5ced7e0fa031c253e475069728b94adb
+Plaintext =
+Ciphertext =
+Tag = 71dedaf4a04a6e3c
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 54e01a9797e8b1a1b9877eac7b9bc363
+
+AAD = 6cfd8e1fb041d263f48516a738c95aeb
+Plaintext =
+Ciphertext =
+Tag = a5b92c78d6eebbe9d06891411b7eb94b05e8d8f17f3ed75c
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag = 345eea8a99996ebd83754655ecf885a55413a1d14ec99a258203ed1a526d20b6
+
+AAD = 6f009122b344d566f78819aa3bcc5dee
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = 88825277c06e9f2f261ce9cd80e2f34a614c0c9fe6fc3d5481c099
+Tag =
+
+AAD = 7708992abb4cdd6eff9021b243d465f6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+Ciphertext = 11f6acfcd0b9129eed41cf7ce0c052bf9072cf67c2c36c986a2e76
+Tag = faa0e0d1a31a4fd2
+
+AAD = 7f10a132c354e576079829ba4bdc6dfe
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+Ciphertext = 047cf53af36163446600b1b660b6380654ba0b5fe1be5c496de423
+Tag = 2af2e837e9f32098b8ff4140bbb6603d
+
+AAD = 8718a93acb5ced7e0fa031c253e47506
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+Ciphertext = cb5517549700e5605210382e964bf5b7d83d9be7996202cff4d2b6
+Tag = c9f35cb0b26e78e9bd83cae73e3914baadb979e668551d51
+
+AAD = 8f20b142d364f58617a839ca5bec7d0e
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+Ciphertext = a3553d80b551079bd4e39123fc1e1cd7fa9bc7274da08746517995
+Tag = 7cab374ce716d80c633edb57bdffc5bbc609300980d474b394b929a7c4577e30
+
+AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+Plaintext =
+Ciphertext =
+Tag = 8565b93859e3e87d
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = 45cbca14e03b40d81facd550a4c6cc1c
+
+AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+Plaintext =
+Ciphertext =
+Tag = fc2a09ac0b72eea344288a288b01126eab58ec9291cfc278
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+Plaintext =
+Ciphertext =
+Tag = 39a36c8e290b566a1abb26ccd831ec8311a37d60a2bf68aec7525359b417c639
+
+AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+Ciphertext = 358db3b4925edda155b5e372242b1419134bf76130c3ca52f52e9a8654806f5b80534d5bff2e97
+Tag =
+
+AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+Ciphertext = 0133ec6b1e9ec894663131c3278f21a4607e35d2fd95f7be896990968793982ba4a9b93bf0be1d
+Tag = 7de6daf307936051
+
+AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+Ciphertext = e4c5ded0f12ed0e16f3f9c60aebf8142b76d6f89766c74bd53cae055173923b688fce458b7ef35
+Tag = 7ad24334bcbff725baf6f3cb9e51ef9e
+
+AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+Ciphertext = 53afe4579942a894f473849dfbcc0d8453a13cf34e68825ab2a310c72166bf1371f98fd6088ec2
+Tag = 814ac84034161e49097fc4f4b47f1ec9c2eb57cd4450a0aa
+
+AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+Ciphertext = e197ee1d330a9487283e02a3fcb77a97acaa40df20d2c63265a7ffec68c87108b4bd199626be20
+Tag = c0c4b4881f569e4df199361926dc45aee15175d7bc15eda80a6d56eb1edaa183
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+Plaintext =
+Ciphertext =
+Tag = 4c03df328d936b0b
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = c0712d0b419853d885837d2d04aba49a
+
+AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+Plaintext =
+Ciphertext =
+Tag = b0dee308b1123276a209a59e6855472e23fdfa36d60ad7d0
+
+AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+Plaintext =
+Ciphertext =
+Tag = 50eec58ae17057e92a5f9b0594969d27525138f63fd6d5eb8d1c5f4f3dc13c9f
+
+# initialize with key of128 bits, nonce of544 bits:
+Key = 760fa841da730ca53ed77009a23bd46d
+Nonce = 3b9cfd5e1e7fe0410162c324e445a607c72889eaaa0b6ccd8dee4fb070d1329353b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667c888e94aab6bcc2d8e
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2786a8719b8ec5ed
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2a775ef941bf2f4ab8f6d97ac8b09cb8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f7e53f4eab8c923efe626df48de98e13c8c5419a09f17624
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 87d989c439d4184b82eae0f06bd0b2988b78d725d42788f4109e82aa588cf342
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = b1f954b389
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 809d4134ad
+Tag = e30257ef164d07c1
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = caf39b5870
+Tag = 946ddf9cb56ecf87c06f3d38ebe7b040
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 867ecefdf3
+Tag = 5b321f1f411d771cb7c8a7791a9c24413c45a459768cdaca
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 702d3cb36e
+Tag = 3c35fd62cb183e933b119a36738df6299dcca34500b69964c12852d1734fb933
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = fed51f2441a8d7777d1b9b83
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = e43659d5799052cf7970ff56
+Tag = ef7f403ff8f6d8d4
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = bf7973d6a8f4a0b56524b4cb
+Tag = 015ce0741178f8220746a67f749eacb5
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 2a3c08bc454b918d67d13dfa
+Tag = 7040e57e588cfe371cdb79351f0ecbe5a525740d6df22ac3
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 1fe619ff0d66e376385b4a5f
+Tag = 4b6ddc24073f230a8a256ede6da623d4f34e0fe7a680e7511c8adb651f24639d
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 174639445e661693c1bcd454f2053fb9dd85129d378be8
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = a4d4c4d509adf9cda987efff3830c88a1b33522bcc6458
+Tag = 6cf66bb2a3e7479f
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 07ee2cb07a8d7daabfcc8e3db5b78afcf7e04579786622
+Tag = c65a878300537e9509b1ba2255e02b56
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = fa8406ad020b89611267dccdcecac93566a15950cc22f2
+Tag = 211ae104d70bd68c0d3390e17d7f47c65a541eb3aab6f9be
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = c224dec062f0b06865927c4ffc8a5e0cb9adf8a97921e4
+Tag = d71f12218d6961a41506a00cfa579e06839c0ba24d11be9bc7a8594d59f56935
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 4e0a3b4a0f88347ebcbb49b40dd0d3cc60f7bfff0835578364236e806d3dcb323281ce6c38b1cb
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 8eab765be4866fcdac8b84250331048b42068ec664e8224ffa160c3ca834e440ab3b92236c061e
+Tag = 71fe5691db78181e
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 454e2b4de3e5a3266ad2a9929a9df162e889cb2c7e86edc0832f7d8cc4ba2a2f23657185f94668
+Tag = cc9316176f848d995c1eebcd726622e0
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 458f49d782ff183756f375e214d42dd0acd630e9c9a477ef984819aa35c0f4061b083d387c5717
+Tag = 5afa26863db7cb1f7ceb7d560e033656b438cbe3b49c59b0
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = e6c164fc11aa3cb90af1165775d177305ffe88548c074a3d4bea9ad6c2b4b0ddb45422e8d4b7e5
+Tag = d74200c9c9b2d8a37ca85659e404ddbd61be639bf1f444e4b6801d34c541de1b
+
+AAD = a233c455e67708
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = aa3bcc5dee7f10
+Plaintext =
+Ciphertext =
+Tag = 04ec05b1e131bb4b
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 28abe951f5d7d5e06d9bdb0b50639f68
+
+AAD = ba4bdc6dfe8f20
+Plaintext =
+Ciphertext =
+Tag = bc0cd2d51becb840f1e63270334847d09bf8d3784b972593
+
+AAD = c253e475069728
+Plaintext =
+Ciphertext =
+Tag = baef4b39dff66794f507445450755945c3368b158ba12622a8b7b420df57aef4
+
+AAD = b445d667f8891a
+Plaintext = b0d15172f21393b43455d5f676971738b8d9
+Ciphertext = 18450683cc7706dc06200e303187b80e391b
+Tag =
+
+AAD = bc4dde6f009122
+Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+Ciphertext = a30aa6a740370692921ac3eda2190ffe4bcc
+Tag = 5a02c13abf545e9a
+
+AAD = c455e67708992a
+Plaintext = c0e161820223a3c44465e50686a72748c8e9
+Ciphertext = 8814075fa79c1bb30dada1347b2f44f64077
+Tag = b431bf505ab7033d8658ee561084f54f
+
+AAD = cc5dee7f10a132
+Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+Ciphertext = 66b3aafac337e58357d1c453b3dd9c41558c
+Tag = 0cde8f32ef882b23129b43b212b1aaa3a003b9d5da1664a0
+
+AAD = d465f68718a93a
+Plaintext = d0f171921233b3d45475f51696b73758d8f9
+Ciphertext = 5984d86d678ae7fffa44c6debe1056041be8
+Tag = 1f405735a6698480275534aa3eda33ba9430cdc78c15f5cf6275540c3241b3d2
+
+AAD = cf60f18213a435
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+Ciphertext = fe0ce2d44d2be1f17eef8e17eb1e630168e64c1a15554b052720eb29949fac25e27dd2e0494dd87de7bf1e9a22
+Tag =
+
+AAD = d768f98a1bac3d
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+Ciphertext = b251dee471ee93eb5f570112f13fbd6e958e8cae517727f1965d48836a2febc7f43b50169f57acae67b9185ab4
+Tag = 189a5264ec74acc2
+
+AAD = df70019223b445
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+Ciphertext = 5a422c2bca2b16a098ee86de7b328af297608348497a948ffe3f36a22aba57bdf62db7d0ffdc10c889be9d8788
+Tag = bfc77263062a91cb701821fad99caecc
+
+AAD = e778099a2bbc4d
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+Ciphertext = 225acf38a6ed9a07f1c7963e9b59556952029647f5da4fc2dd48be7283a931efe2b013a42e3b475361c6e597a3
+Tag = 539910630a33717641df9d0389c680061f12e73015f123e8
+
+AAD = ef8011a233c455
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+Ciphertext = 23e1d0e72ecf49277bb8eb1cedb7bdb80b692a03402c1acf26c458123efef28113883b63bdeccde1babee0b65e
+Tag = 2fcbffd7ea0cb2ba91e34eca3ea6c09c33ee97e0cfc17b5d3f8b0ebff304d03b
+
+AAD = 54e576079829ba4bdc6dfe8f20b142d3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 5ced7e0fa031c253e475069728b94adb
+Plaintext =
+Ciphertext =
+Tag = f96f3b2436ddb490
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = d288aad6a16e72a5b3eb2c0c7c45dc06
+
+AAD = 6cfd8e1fb041d263f48516a738c95aeb
+Plaintext =
+Ciphertext =
+Tag = 09179dc5725e57c8507c9a6d57ebc3b38fec43ed7340e186
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag = 0f1bf4ada514183ac3e7dabb523528b0a4a58aee53332beb5559c79c81c09104
+
+AAD = 6f009122b344d566f78819aa3bcc5dee
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = fa0a6a21e532d8a95cf526363ffa64cce64287b0e0aa342a578905
+Tag =
+
+AAD = 7708992abb4cdd6eff9021b243d465f6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+Ciphertext = b4a07faaa0142cf27608b7e9b10286d57138fa9f1055b580a702cd
+Tag = ad146d2faace8bfc
+
+AAD = 7f10a132c354e576079829ba4bdc6dfe
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+Ciphertext = c03075b1895c77ada741e9b437049504319c0dc3e41d69c4c9a449
+Tag = e54becbf69dc2ecaaebcf056ac52b41d
+
+AAD = 8718a93acb5ced7e0fa031c253e47506
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+Ciphertext = 7733d375b1cf1cd11827c543832f2ad49a9ec014067474b81a265e
+Tag = a0221768921fd88e5bdea6e1baf0c7d9a1a311d91ed627a2
+
+AAD = 8f20b142d364f58617a839ca5bec7d0e
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+Ciphertext = 1da6e2eee24eff20a966d8748294b16ba216e4194b802ef397e25a
+Tag = 9185c0d50f4cca5c4ce57aedcd18876f63722cbf44ffc8373e4373133b42a27e
+
+AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+Plaintext =
+Ciphertext =
+Tag = 855fa34e92736cdb
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = 3644a1b460f07486e115784539dfed6a
+
+AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+Plaintext =
+Ciphertext =
+Tag = 8162e8453cfd700cc92617d959477c5aaa4162b5d80b0877
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+Plaintext =
+Ciphertext =
+Tag = d4560888c2207a63f5839f468f7bbbce7b272e8aee24fd081da4251eec48d469
+
+AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+Ciphertext = 44c0f44d20398ab58618061495d17e66bbc0478fb815166cffb6d7fcb87b3fbdc5cd91881ecdce
+Tag =
+
+AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+Ciphertext = 160ba94c2d680e3538757699dc7e5401b0b0aef8f9d6aa547be3c74191aa30c7500c84f973499c
+Tag = 26946ae9bf70c479
+
+AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+Ciphertext = 355474fbfde16cb928f1024c5ef278c3b0a360a12d091b98d2ea6cffda26ef226de7c114fa8cc7
+Tag = 107fb6ade7b49d1b22535bf71b4fe15e
+
+AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+Ciphertext = 7d63f54dd374fc683f13194a6faf9d03dfbf85cb8d5d762ba8ea5185614e4f3a8f7e0d4fa90c2b
+Tag = 7fc36248b86fb8d9bbb4b780af49816be88baf5313a09969
+
+AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+Ciphertext = 66f79607649fa1cfaf6ff869da99f681f0fb17db88ed82128247a9324f84edff9155d81601d4f5
+Tag = c8868a9690166e27698bf10dfab6ec9c0b590095c5fc9c237bbbdd1186d115a7
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+Plaintext =
+Ciphertext =
+Tag = 4c153578ec9b58e1
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = 668be4256212c7330a4fc463d370d4ed
+
+AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+Plaintext =
+Ciphertext =
+Tag = 9eb125240a29e80df6b7a895d033d27e20c399c44dc48c27
+
+AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+Plaintext =
+Ciphertext =
+Tag = 920e46485cdf4d25c78a3b856e365a88625a352e93d9603e0e6b07cf7e2601ba
+
+# initialize with key of128 bits, nonce of576 bits:
+Key = 7a13ac45de7710a942db740da63fd871
+Nonce = c32485e6a60768c989ea4bac6ccd2e8f4fb011723293f4551576d738f859ba1bdb3c9dfebe1f80e1a10263c484e546a767c8298a4aab0c6d2d8eef501071d233f354b516d63798f9
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = eabdd95ab8aabf57
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e4ca3b2aa260f444e02d936f85b26a9d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 353a2eef059e0e79cb76d7703128c7f01ea3fdb423c20172
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = b62ef1ea8e12dd333cc014f195483f8c1c710150fd5cdb6557d911b693ff1984
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = bf4dc0e75b
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 9f96d26789
+Tag = 794e6ae5188c24a2
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 537dc3f65b
+Tag = 6290defc948901817930f05cf13cdbd7
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 88ea7a3161
+Tag = 0331139257446cfdd5593ced376d020510c54d26cc00e49f
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 25b598f9cd
+Tag = 8a9f3898c9e193b41ca2cccbe2c69f91bddc3429cce4700d5b23e042cd3ae217
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = afb67225c7070207185c089d
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 1abdd4b43d262d959c4fb8db
+Tag = c31c581aa8f9154f
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = c2391f1f2b539a5a9d2b44bd
+Tag = 000f8562708f39c9f2113efec1989712
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = ffaa41ede3447f275bf98193
+Tag = 98a96b9e1a8042767a928a104f5cba446d8af6a2cbc32273
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 1d3c0af385ff2e87c5b3a3ca
+Tag = 7700204dff82183fbcd7449f249fc2e05b63de447cf56932ecd513d08e829e1f
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 34f12a57b7ff2a7f7dd071aaf397fb0cb8e068084d2fde
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 5c244120b171203eedc2bc572c5f82718c58314b5d0432
+Tag = 92d9ab13337f1eaa
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = b6b2a59c2f40c39da68a648f58fc9f4ef95baf6bcaef3f
+Tag = fefc72e3e269247952d2eddcf35a0fa5
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 6a8d73e9dff5eca591931d8552c6d63e39d12a09996ba7
+Tag = 14090c981e90420b9e401578a6e606c278f949af6de85d5f
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 91469b63c7fc62207f9a547ac584abccdbdcad20548cdf
+Tag = f654b3f9224ce47b7933e66da21483598f91ed04cee632b58dd8d58b4852bd77
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 328d090108d9559bac54e21994753a82633b895ce1895b1d394e2981f66821b30757215f60d074
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = fd2afe0812068877185b3bb341942d85e9f5ca8beda1e9356927698e73fbf0296ccffe0779abce
+Tag = 9855ed76ff8a46ce
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 8db930841d0e91d41aa7f6d362fb92efdcfa6200ce2c82d159e4eae3789b8db2a106443d227d92
+Tag = c0bb8b07ec406189ec2365dbc3d241d1
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 19ecc880f46063d95046f4b49dece79fafd0ca4304fbdb93d2a426554940a5b251c8e2933962ad
+Tag = f0bcc321461028ac9c93ea0cbe77d7a8d7c5a7fd0563916c
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = cc37ed41d16fb00d17377ccdf6bf0ce26d6048588dfcf445a5f9ae0f76a52f76bb0cd5c855d826
+Tag = bb27e0cc5a4e19e674081241c7eca7ebfdf5ef3534882ac2ad5395e8f3eb4715
+
+AAD = a233c455e67708
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = aa3bcc5dee7f10
+Plaintext =
+Ciphertext =
+Tag = 70de249718c919c7
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = ad89d991984b0ef082079e9b0dd2c59d
+
+AAD = ba4bdc6dfe8f20
+Plaintext =
+Ciphertext =
+Tag = 40c3e686965bc032ece538dd807ccbbb12c6724b08746253
+
+AAD = c253e475069728
+Plaintext =
+Ciphertext =
+Tag = 40e354fd0ebbf7010f1758c762ad4d434ec9a6631ca1589b31f7182e7a167ada
+
+AAD = b445d667f8891a
+Plaintext = b0d15172f21393b43455d5f676971738b8d9
+Ciphertext = 7711ce39101c1e32837547ce977476ebd7e1
+Tag =
+
+AAD = bc4dde6f009122
+Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+Ciphertext = 5fc0f1aa2482a08161230c88bd0e910ec4d9
+Tag = 6845af6367a82194
+
+AAD = c455e67708992a
+Plaintext = c0e161820223a3c44465e50686a72748c8e9
+Ciphertext = 9a1ffd66f178d95b095c2b646dad9b41b20d
+Tag = fdb88afa1f7eef9bf05beff39f06abd0
+
+AAD = cc5dee7f10a132
+Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+Ciphertext = e6de6bf91944a467fdcfbd11ed505a18c894
+Tag = 678458561fdd9859ec0ce85262669a39449fda7397909321
+
+AAD = d465f68718a93a
+Plaintext = d0f171921233b3d45475f51696b73758d8f9
+Ciphertext = 7a2d73c6167715841eb75728dfc15b725627
+Tag = a449a595fb4021c79646ea50e1130f630ca14b84533a9db8333e3d3e11c7bee3
+
+AAD = cf60f18213a435
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+Ciphertext = 88202eab46e6bf40361806b891adbc79e43f83d4344408ae65cfb9b66db34a3d1d25b354859f9ac5739fd06be1
+Tag =
+
+AAD = d768f98a1bac3d
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+Ciphertext = 2e43b6e6791271957a8a88e5e296a3fd358eebfc1895458aaa9328930bb077f42fc7e287b47c12d87fbde536b1
+Tag = cc2c4bd1772932fa
+
+AAD = df70019223b445
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+Ciphertext = 5b2fecd07740fd30b1e74556d675c99ff443bbda1dcc94c36ab0fa05ff53754c29a6a03ca3dd2a827c0b99ebb0
+Tag = 346b9e135bab6ac0a7bed3f57ad521b6
+
+AAD = e778099a2bbc4d
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+Ciphertext = 1f472f7a695de7de6e0927c0e297938504888652c01ecee05b854b44757a9da201afa16ed188236a969e379a4b
+Tag = b9a49f0fd47a489c1076e82ad0cc598a44011edf2e3a9b63
+
+AAD = ef8011a233c455
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+Ciphertext = 8b0c98cb40623716ab0a5be6a7d952d1a7c9fa8651463e6b3c3237f9b300a762a43cb605176ecc7c4449749e75
+Tag = c53c72d3a0548fe8ee7d07062784d28b7f2ef863c8dff35fd6552482d45eaa22
+
+AAD = 54e576079829ba4bdc6dfe8f20b142d3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 5ced7e0fa031c253e475069728b94adb
+Plaintext =
+Ciphertext =
+Tag = f90a184336dd398f
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 78b30488a1b5db95dbb102163b7a3d13
+
+AAD = 6cfd8e1fb041d263f48516a738c95aeb
+Plaintext =
+Ciphertext =
+Tag = 12c885e09906cbc5f8471023d327d3150d9de849582b6af6
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag = 878f3ce92ccebcb9e024991db4c01410c9f6c5ff6d44ee983e5bab92d138611c
+
+AAD = 6f009122b344d566f78819aa3bcc5dee
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = 23ad1b2cfd4cd6121f99e628b4764f6398527d6171c9ac967e9491
+Tag =
+
+AAD = 7708992abb4cdd6eff9021b243d465f6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+Ciphertext = ea2349d70a482a410c29e21d124e25da212cfc9924462c0b392fde
+Tag = 378dc139587a2fd0
+
+AAD = 7f10a132c354e576079829ba4bdc6dfe
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+Ciphertext = 095153f718548defce7dae0b730c1839227cc17af624eeb93255b9
+Tag = 7f49def455efbd2c1c7d498a687251e1
+
+AAD = 8718a93acb5ced7e0fa031c253e47506
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+Ciphertext = d70a635b264640253937ceda279ce92d0b65720044d57fc86775ff
+Tag = e6070c13a2df516057fde715580fee8d7853c0309ed9d38a
+
+AAD = 8f20b142d364f58617a839ca5bec7d0e
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+Ciphertext = 892dc296e1a4a37ade0003a80f632842911e105af42ba98259a5a0
+Tag = dbe49c11c57872f7323f9cbdea2e32163677b41b940139157ae0fc8b786b7718
+
+AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+Plaintext =
+Ciphertext =
+Tag = 2d3d0b2e7e9f45c8
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = 51330c77c99711e6d2602d631d086b6e
+
+AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+Plaintext =
+Ciphertext =
+Tag = 0bdaad09be39fb2a6ebc16ca22236a31ea14a21992b1a132
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+Plaintext =
+Ciphertext =
+Tag = 4d35ea81340ba227afd07a6ae8d4f60edf21efb125cff451a6076d4fc751d5ec
+
+AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+Ciphertext = a1e73ffa2e3bed7bcb41d05ef5a895829c9db7de542a045dcba190d8811f2cedee70aba067f275
+Tag =
+
+AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+Ciphertext = 310d1257f44eca7af4ce63d6a87dad4b82b598d6b8c35cd645b51615d1e7c4fde72052b32a6b9e
+Tag = dd8d3c4bbd6e8b1d
+
+AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+Ciphertext = 047e8fa37d976ad8aef10ed6dda62edcf69ea6b57e2ff5cb13a9a9e94374135375d72b8c31f408
+Tag = b46fe339ff9fbf6a2582bf0d1135e304
+
+AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+Ciphertext = dc4891d6008f5592ac66b635d2825f5d04b6f938d96ddbd36483bb565a97640a31c81a65ae5fc9
+Tag = 50f68acb0923d313d3f2642abc7598c2412963eddbcb40ae
+
+AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+Ciphertext = 27152e2a39980a6d53a343affae5f03419c6529c5317f94ab70e4a6741380ea139976361ed33a6
+Tag = ed700f5a37907d7d761c4081e7ab8f51a31d2d93160afdeb21bea1112ecc8c2c
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+Plaintext =
+Ciphertext =
+Tag = adf6db141987bd11
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = f1c172e32415c09011323256a21fbcb8
+
+AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+Plaintext =
+Ciphertext =
+Tag = 1198b561de020a03e9635f681c41fb1e292fcef7b59bfd42
+
+AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+Plaintext =
+Ciphertext =
+Tag = 9b7a4532cf442c0c06858d6bec90ebd898016edda67a16f55c14e5a42178afd8
+
+# initialize with key of128 bits, nonce of608 bits:
+Key = 7e17b049e27b14ad46df7811aa43dc75
+Nonce = 4bac0d6e2e8ff0511172d334f455b617d73899faba1b7cdd9dfe5fc080e142a363c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898f95abb7bdc3d9e5ebf208141a20364
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = cea78cd36c974704
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6dc6035911b222a3822787473e45a9e6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e6629928868f08f9274a45866051f1ae95b219a6e22d3f9b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 20a9234a2a8643f2444a99ea7c5a50eb4ccd7a66fec094df291b10ced3c4538e
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = bc731dfbe6
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 862bdcdcdd
+Tag = 22cdc5ca076f0bb5
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 6fb37a90ef
+Tag = e16455e5b7f49f350eb107f00985d8a5
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 05edb70b3b
+Tag = 12b9b8383e63dc35098e1c84b66473b3f7a05022a53b08f8
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = edb7dda77d
+Tag = 4b0cfdd4a8dc302416442a98ea8897588ec8ae3ceb0f713e633e9bebf6554002
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = bd3b2439251c5ff7e57217b1
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = b308c354c4b18e0c0dd0d871
+Tag = 973ebcdfd127fb48
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = f208a72a5d781a97e179f1d5
+Tag = 6a3241fadf2e7ae3fb2a4240a2457521
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 5c813ce8bd5a153334a8165b
+Tag = 4c580e67fa47ec72919286fa7cf2e0acb79449113d83ef34
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = f40239d3e1cb48e123ce698a
+Tag = 24919e312197462f240e82127f6d2816e305017a5bb73710f117719d1d450bb7
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 4dcadbcf5bd031dbdcf3d27971f1c68b313230937dad3d
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = f39a34861e4a3b2379ddbeea7a32830bc8f7c592daae54
+Tag = d57e396ead617233
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = eda97cdb5d9556a80ad0da774e3767d728673a882b6152
+Tag = 17526e9bc3511dcb9308ab40cff0c416
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 21f2d2ae092307fc81cffde31342f8357352746496afef
+Tag = ef0a77240b9e009d3ebcf6a0258cd2878d4bb2f5dee57421
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 563b45553b901039b3c87bb5c08f258d760f1bb5ec9ba5
+Tag = de40b9fa3b1a300fd4a893b957ec6905a8e3192d778f18fac974cd363756e931
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = f306f6cc75e122ad5264745a34e07318d90cc6c94692141af6d42fe91ae2d17bd4dccba2f4d440
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = a66f0df8715e9fc4dfb3ad193e16ecba00c388b55201ce53c4800722a8e119a2b44661979928af
+Tag = dc3452074523562c
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = c1632406062242fb6c79cbf171bc222148316b2cfafc6897771ea2bf19540dd16d9548884ae8dd
+Tag = 526955db0ab370d117d7e53823fc861b
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 575b35f07442d05f7045e938d049bdb01c799efecad803181d9cb43d54db664a7bc43c160a1be3
+Tag = 75e60e30aa1528e6a1f20a04b4c7dd44cf70696bea6a3171
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = ff17ef8f175a8d4ef58619e41cb83a07a9f2751f7c08ae2e65b05afc1ef69f3999724de70cb4c6
+Tag = 33a7c535e3568ba6218a7473bb4e88c9979a5d62dfa6df9806e58a00163ed0ea
+
+AAD = a233c455e67708
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = aa3bcc5dee7f10
+Plaintext =
+Ciphertext =
+Tag = 943488a97872672c
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 01067303508d87a79cf5b80c83653165
+
+AAD = ba4bdc6dfe8f20
+Plaintext =
+Ciphertext =
+Tag = 6b4f405fb36e576192505b094c6b2d6439e8bbfcd62e4df9
+
+AAD = c253e475069728
+Plaintext =
+Ciphertext =
+Tag = d01249cc9eec87d6569a96c7541581ed381e3b3137d8b0fa425439eb0d90b8fe
+
+AAD = b445d667f8891a
+Plaintext = b0d15172f21393b43455d5f676971738b8d9
+Ciphertext = 29dc22ff89ca294d368cb91913e257ab4a81
+Tag =
+
+AAD = bc4dde6f009122
+Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+Ciphertext = 64f81b36d4a837583da82934865ed5c7d4ae
+Tag = 4daf9ae4fe35b638
+
+AAD = c455e67708992a
+Plaintext = c0e161820223a3c44465e50686a72748c8e9
+Ciphertext = 916bde14c846bc0fae0deb7e8c3dd6f205dd
+Tag = 2fdb39f6467850ea0f1bdbe0b1bcc1b6
+
+AAD = cc5dee7f10a132
+Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+Ciphertext = b5908af3ec1e5a4c18a68ebf41ef116895ad
+Tag = 6883377b0b36d408181aa1689219c24f025a5158f9591a1e
+
+AAD = d465f68718a93a
+Plaintext = d0f171921233b3d45475f51696b73758d8f9
+Ciphertext = ab803d61519b98860c1c008c36c50b70d085
+Tag = dcb50783c5312394d6b1535fa6c119b20aaad130ff67a212702f7617c3d78833
+
+AAD = cf60f18213a435
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+Ciphertext = 10396a625ac7226d26c032a26105e7ca368bf68718e575cd49c262eaafaca32316fd3c71135c51bff70c289408
+Tag =
+
+AAD = d768f98a1bac3d
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+Ciphertext = 0c16f022cf292ecb143e4171d475077a35362703535f1773a57bd7ca81c494de6193d0832db67ee73e4917dd68
+Tag = f84d81c277d937d8
+
+AAD = df70019223b445
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+Ciphertext = 851f99646a6a577dca97dffd14438e624950a9641d36a54bcc670001a7003f5a060be61264448f8d9bc354b179
+Tag = 4ff4d3992db02fcbfb89e1262f9ec213
+
+AAD = e778099a2bbc4d
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+Ciphertext = 91e5e5dad7f600156a1beb6d395053af2f75379d20f04bbecb4b746402a8560650e6af3127c3ec9cd7a8edbf3b
+Tag = 847a7a75cd0533c3b825c603e95ec97efd3eb875693bef95
+
+AAD = ef8011a233c455
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+Ciphertext = b966a208232c13a5847d61f3218f8414cf432c537c7e70318819dcc7e25953254f9e2eb66e9ced95cc8cccac23
+Tag = 73d7b60570eedfc560599ea15ee68cbceea26773927276dd8cf4a505c5531f77
+
+AAD = 54e576079829ba4bdc6dfe8f20b142d3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 5ced7e0fa031c253e475069728b94adb
+Plaintext =
+Ciphertext =
+Tag = 07a1b252ea24d7a1
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 113de6c91d84e91aee8769b29c44ac0b
+
+AAD = 6cfd8e1fb041d263f48516a738c95aeb
+Plaintext =
+Ciphertext =
+Tag = 278571690cc82c2b14e53fcc95f859ca71720863b2546296
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag = 5e366f2fd83a2eb6771c330692600821b8cccf7242b8d3a239b766f4843efb11
+
+AAD = 6f009122b344d566f78819aa3bcc5dee
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = d35f6733661ab02349c64c015c8f80a1c64912f71967c1165c68bd
+Tag =
+
+AAD = 7708992abb4cdd6eff9021b243d465f6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+Ciphertext = 12a5f084dafcd048f0ca30606663525f594bc60dbfe8f882e42a81
+Tag = bcc97a6048b9a09a
+
+AAD = 7f10a132c354e576079829ba4bdc6dfe
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+Ciphertext = ae7d94f1e7db128ab6a1708a955d8e0855a4a0fa5e30d4c5e9dfd8
+Tag = 8c76aaa51ea0bca48c9e3a241c822c0d
+
+AAD = 8718a93acb5ced7e0fa031c253e47506
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+Ciphertext = a7ae21d6ca35cf99e0c5c766b62a85b4fdeba40c9237168523c9a3
+Tag = 381034a7b8990bbebcf602d27dc0c753739dfb2828806047
+
+AAD = 8f20b142d364f58617a839ca5bec7d0e
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+Ciphertext = f813d3712a4b3af6965b9b6a63858e472883b275d483f17d7632d7
+Tag = 2f0999cb395b016d3d3fc204d4bfc140272e3ce84fedb2e318df7e80a19e3596
+
+AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+Plaintext =
+Ciphertext =
+Tag = 0fc702384169b7a2
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = 8d5fba53a6aac98362a194192218356f
+
+AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+Plaintext =
+Ciphertext =
+Tag = 00ac7f527b29be3ab6d36ececae5af1e0dcb49f9f0a057df
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+Plaintext =
+Ciphertext =
+Tag = 65fefb5e017fe8314a648bbd33a64d021cae322ea513c6c1111a573ac21212f6
+
+AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+Ciphertext = adbd0016308634e6c112bda36b0533307c3dca2d56ac9a266499d25da6cdd183bdc171798915aa
+Tag =
+
+AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+Ciphertext = 72f89bc73c95a4fe6a68946e7cd9485666c78c149f20a261644b14eb1371f13072413a4cfb2008
+Tag = a955266e5ad8eadd
+
+AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+Ciphertext = 28c36d0ca2e5364c1891dcf23858d0edf99750a12c34ede7dc46c67db257d722707ceba586ddb4
+Tag = ca0d15ced6e360a1978a3fa367114a0f
+
+AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+Ciphertext = 82a2f0aa1cc7d4f3b93c563f4264c7e1198a2564bc0ffcccc1b786755bda21bd740a2efb5dce40
+Tag = 6b1bdbea157fd653084850fd4ec2543f845c7bef0ab9829e
+
+AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+Ciphertext = 8f3278aac75a87260a083376319052ff71f88b729519cdfc132ef9a6b7d45cd0890df67fa33231
+Tag = a8701e84f348dcd5acd8b4e2299432b0c7db610dded8562fc6e9cb8b5dcd14d4
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+Plaintext =
+Ciphertext =
+Tag = ebd0d1083b92e7b9
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = 2b4677ffb902af4e123f6f13b87d8c69
+
+AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+Plaintext =
+Ciphertext =
+Tag = b863f43338a23678a9813f245de2df513ef3bbb5ad32cd3c
+
+AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+Plaintext =
+Ciphertext =
+Tag = b2ddad34698aa635c7f1da005032276c4891a48aac7f1eb1fc1f10b49c51a111
+
+# initialize with key of128 bits, nonce of640 bits:
+Key = 821bb44de67f18b14ae37c15ae47e079
+Nonce = d33495f6b61778d999fa5bbc7cdd3e9f5fc0218242a304652586e7480869ca2beb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d9eff602081e2430364c526e647a809c92a8becac0d6ecf
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 825fce5c9c8b1baa
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9a15dbc5e98dc72f079efd85aba69533
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9409154bb5e088f1291ae1625bde4b5d82cf2c5496e67c1c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 34ebdf11a73c0335776233529bde0d4ca6b14315e9c9b5104e293417c905d249
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = b4b90f50a5
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 959d0ac49f
+Tag = 90dcbf719b4692e2
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = bd97edc78d
+Tag = 628b2c614b96c2d0c8b2ab7be4aa9652
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 9bf9db317b
+Tag = 9117d95109a2fa2633fde19466b15cd1b6567f1bc11e1285
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = f5688be900
+Tag = 3ca121f507e2d10c799c65c464e3d1b5eefd0b8805699db2f5cfeb01ad706718
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 15e8c984771b0fd313c45ddc
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 44d11c8da686dc147509dff6
+Tag = 011f11cb1629c552
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 089c90816950a75d760ffb2e
+Tag = c0abe4c4d950d0732c4b3fbfe0e65cde
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 2aeaa6f367a4568a6a676d99
+Tag = bce8a16a78b22ed321dc38fae5c02d4ee1e8fc22389b34a1
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 78e0ebe27a0238624396dba8
+Tag = 8869290af78acf0edc5fca91d4b9fbbeb6aba90e9f57d999e5d59d8fe349fbab
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 931879ce101e5029bafcc75c35d9dd75b054c9dbc81229
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 3c32305680143b5f0635aba01c8046aef3fee9b891249b
+Tag = 845c68c61902bfb7
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = dde5cde25ad50ec4a894166bcb9d5c6e352de39ff8b3d6
+Tag = 0313d23a0dfc3409c35535de679f5487
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = bdb6bb761c9650e2c44f10ac91a078b4bd05e07c961581
+Tag = a494100873c6df6ad554a23d9f7aed84ef4d268eae29d927
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = b188f4f5f9a14a9cb6572ed583119b0ad7d464854c29af
+Tag = 19d63534cecfcd342629c532d3121bdab3df33c3a6dcff9f4d3411ae29841d0a
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 5ca966672241e8e41f19ed66fc8bbab9526e8ea4894dc23a542a009848cc24928c9ba057af9dbf
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 72c2f39b088a8dba6b0bb3a26befe8c8b0477afc553b34ea10658e89fc3cc2ec9fe91404d34445
+Tag = 8fc71f19208c4455
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 6d21d4078b427a0cf11a4fde3c358113a690176e5be5b2b1f56d1aabd9c1434f2e59c5ec7be368
+Tag = afdb5f532c297a57f5c35e37fad89708
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = c533361278ab62b27fd5f44ceb1901382158c43ef8bd9f57bf7a81cfe3d0daf5a4bb5f1de021d5
+Tag = c7d601fd9fa5c8a7f52716aba993caff033728ec5193a45c
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = e551267182ec91cff4995b24eea06dfd713e7a7ed49e35596e4454f1839b60ef052484d8f683cf
+Tag = de95125d5ff96dd93694432591820dfb4863830be28fe5dddc817786ba33f52b
+
+AAD = a233c455e67708
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = aa3bcc5dee7f10
+Plaintext =
+Ciphertext =
+Tag = 9b41d310b07f7415
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 8bc4b38a6ead152b5f0c3019b558bf51
+
+AAD = ba4bdc6dfe8f20
+Plaintext =
+Ciphertext =
+Tag = cfcd4d5ffc02f762ae20f443d4628941408640869afe207a
+
+AAD = c253e475069728
+Plaintext =
+Ciphertext =
+Tag = d88b2dcc4e6599dd01f4ea61269a151e1ee6fb2704617438bc0136669603f89c
+
+AAD = b445d667f8891a
+Plaintext = b0d15172f21393b43455d5f676971738b8d9
+Ciphertext = 4a8de60485ba43d2a54215ba0c940bf08f29
+Tag =
+
+AAD = bc4dde6f009122
+Plaintext = b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1
+Ciphertext = f40bab25d1afbde2596b7177fd9b48f612b3
+Tag = 8e719e86b22db87c
+
+AAD = c455e67708992a
+Plaintext = c0e161820223a3c44465e50686a72748c8e9
+Ciphertext = b89ef812e3053aa3c3085121e1d1a5bacce7
+Tag = 157cfe4e7db49cb4f03b7c54fcddc423
+
+AAD = cc5dee7f10a132
+Plaintext = c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1
+Ciphertext = cf6bbe921e7757d0bd0e248717661ffc979a
+Tag = 510f617bf4548fb2f8786ecd4f76682b6bd920249581b259
+
+AAD = d465f68718a93a
+Plaintext = d0f171921233b3d45475f51696b73758d8f9
+Ciphertext = 4e3bd01e4d8ea8aa436bc04a6a998c03db40
+Tag = 790a2d5c869bffcac979cf1d992a4ca59e5a043c3512bbf3eaf71e1e4c57fdd3
+
+AAD = cf60f18213a435
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9c
+Ciphertext = 68aa9364e5d108eb5d61ab185046b939feadf37d80d199bbbcaa075ce85362ca3398614b122a797b2fd28e4a27
+Tag =
+
+AAD = d768f98a1bac3d
+Plaintext = ceef6f901031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4
+Ciphertext = e0aaceb0d41d07d6d480a75e09de87312dfcf371d7e460e540fb68aaa502b0441fa9f510a4fb5d0d02d25855d9
+Tag = dd5f44a6359418ae
+
+AAD = df70019223b445
+Plaintext = d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2cac
+Ciphertext = 2b6dc2286694e01726169640a9da7bc41127cf93b0007d57e822342d38f49a60407052b4be85627803b7277576
+Tag = a49a9b53ae6db105cf2d668f281c57e3
+
+AAD = e778099a2bbc4d
+Plaintext = deff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4
+Ciphertext = bb0427c4f53f5232eba05d1429d8100025baf1f5730129d0b419d35fc40e4faeaf80d3e085dfeffb4d615a3744
+Tag = a956f782d8639373be7306beb6a21cd95e9f5b36296b9840
+
+AAD = ef8011a233c455
+Plaintext = e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbc
+Ciphertext = bfca906ba6e557c65ec35b725b5288364d4ab048d63a5a3e7ac93ed5be2487cc6733afac383677024570cb0d53
+Tag = bae633b38f116dc77bfc1d708acd543ab179801b8d2ff45ba7ad31a2f2bd1d98
+
+AAD = 54e576079829ba4bdc6dfe8f20b142d3
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 5ced7e0fa031c253e475069728b94adb
+Plaintext =
+Ciphertext =
+Tag = 832bf6f66372979f
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = f94e283ed7d9cbca6545e98044a550ca
+
+AAD = 6cfd8e1fb041d263f48516a738c95aeb
+Plaintext =
+Ciphertext =
+Tag = a9bba7596c981f6a384a0f5c1f3420009b0c9f73d7598ae9
+
+AAD = 74059627b849da6bfc8d1eaf40d162f3
+Plaintext =
+Ciphertext =
+Tag = fc45080184fd52ced52f3aff533b2d41dfbca462323479bd7ea96ce9e1d1af02
+
+AAD = 6f009122b344d566f78819aa3bcc5dee
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = d789a44a1dbcff252798c6c4de182e6c38d6c2caf64576636fa92a
+Tag =
+
+AAD = 7708992abb4cdd6eff9021b243d465f6
+Plaintext = 73941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0
+Ciphertext = 3ca5ea81c90ed9cdc3219f26e21cf7b7a3b2381777578ea0bd8163
+Tag = 6b02bdcd43a120d4
+
+AAD = 7f10a132c354e576079829ba4bdc6dfe
+Plaintext = 7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8
+Ciphertext = f20eb4d46112d9c4fd5db99b33a877c405b19abf17f958c7b6daea
+Tag = 8cba0c7fa91e3d19c9d86292169c26f0
+
+AAD = 8718a93acb5ced7e0fa031c253e47506
+Plaintext = 83a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0
+Ciphertext = ae73f8d9f3afe9bd416d29bd4b66e4f3c945a616bddf0d3a2cde2a
+Tag = e1be90b811e9749b66e3cde604fe1f421e8dbbfb7505242f
+
+AAD = 8f20b142d364f58617a839ca5bec7d0e
+Plaintext = 8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8
+Ciphertext = 91c0e97e86414408257ac6c090a66fc29b6be0dd3c2f5013396eb5
+Tag = 2fa3c0a21bc9ebced18700d793213b1067696de10057a71205efa0f0ff481b95
+
+AAD = ec7d0e9f30c152e374059627b849da6b5bec7d0e9f30c152e3740596
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = f48516a738c95aeb7c0d9e2fc051e27363f48516a738c95aeb7c0d9e
+Plaintext =
+Ciphertext =
+Tag = 0c5d261d659fcd0f
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = 2f6ab2da92d3a631d89701f16365c241
+
+AAD = 049526b748d96afb8c1dae3fd061f28373049526b748d96afb8c1dae
+Plaintext =
+Ciphertext =
+Tag = b85a8317b880acd4479a9901f66120daf72db1506f2ed155
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b6
+Plaintext =
+Ciphertext =
+Tag = 30293a25fc61f5eef9e2ddeb3d8bcb94065468d0d971e8b3e46bad1ee708fd76
+
+AAD = 13a435c657e8790a9b2cbd4edf7001928213a435c657e8790a9b2cbd
+Plaintext = 0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e1618202
+Ciphertext = da5156700c601e07061f873c74a1f7cac289bf3d80b386243ade69ca8ad3e54065f61e96949916
+Tag =
+
+AAD = 1bac3dce5ff08112a334c556e778099a8a1bac3dce5ff08112a334c5
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a
+Ciphertext = d9105dcb2592b004de44791da8bae2241e2e1dd40351c68dbcab890598d25e01383f461df4d42a
+Tag = 5e4eab50f127d5a2
+
+AAD = 23b445d667f8891aab3ccd5eef8011a29223b445d667f8891aab3ccd
+Plaintext = 1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f1719212
+Ciphertext = 7880239768efec3b53c4ad7d6842232a0393d8d5110d6b8e127dc2c524071a10b0d5bc97e40c49
+Tag = e54a27574936d340107b414c8bb261f6
+
+AAD = 2bbc4dde6f009122b344d566f78819aa9a2bbc4dde6f009122b344d5
+Plaintext = 2748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a
+Ciphertext = 5c321fb95c8cd463014f256b870fec4a42d078a8506cf1ef2f3d439aa439786f63528128159cdf
+Tag = 8168fd88a11baa706b846ae5ff1b8c79acf725b7a5be0246
+
+AAD = 33c455e67708992abb4cdd6eff9021b2a233c455e67708992abb4cdd
+Plaintext = 2f50d0f171921233b3d45475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a222
+Ciphertext = 26305a77c2ccfaa5e4ac66e02921495977967d3b1345d27af91be143ed49de2e90f3a3ba38749d
+Tag = 5380b25e3a694da7b95df6e73b7832ee56bda75beda67f097ca38db21224c851
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d2ebf50e172039425
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 14a536c758e97a0b9c2dbe4fe07102938314a536c758e97a0b9c2dbe4fe07102f28314a536c758e97a0b9c2d
+Plaintext =
+Ciphertext =
+Tag = e41cb6318353e01e
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = c88ceea20771afa43473442616c61150
+
+AAD = 24b546d768f98a1bac3dce5ff08112a39324b546d768f98a1bac3dce5ff08112029324b546d768f98a1bac3d
+Plaintext =
+Ciphertext =
+Tag = 132344bb3efe76b99a1979cdd506ad4b4cc34ee43dca66d6
+
+AAD = 2cbd4edf70019223b445d667f8891aab9b2cbd4edf70019223b445d667f8891a0a9b2cbd4edf70019223b445
+Plaintext =
+Ciphertext =
+Tag = 7da3330aa6e8d3186d3384d94ac09fc5c0edac9fdfbe3c697f063eb000851bd7
+
+# initialize with key of112 bits, nonce of664 bits:
+Key = 41da730ca53ed77009a23bd46d06
+Nonce = b71879da9afb5cbd7dde3fa060c1228343a405662687e849096acb2cec4dae0fcf3091f2b21374d595f657b878d93a9b5bbc1d7e3e9f00612182e3440465c627e748a90aca2b8cedad0e6fd090f152b373d435
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4151c378dbbeeaa8c8b2e513673b2b6a
+
+AAD =
+Plaintext = 3b5cdc
+Ciphertext = 0dcd28
+Tag = 14fcf0507b44895b564ecd1c570cd84c
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = 84cb574dda3fdd
+Tag = 080dd0b03d4a9a78247d5129453bd924
+
+AAD =
+Plaintext = 8fb03051d1f272931334b4d555
+Ciphertext = 206564f6c5b1ef08c108293c28
+Tag = 57de4403ee696930c1899297b751ab48
+
+AAD =
+Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
+Ciphertext = 5802417c9b51b6fdfe06360dcbc6cdd8b08f1fc99353
+Tag = b398e0c1f51e7ffe34f409aee6b43774
+
+AAD =
+Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef
+Ciphertext = 73450a3cde8de10597bc8c8a60440994466a42c46c86bdd2342ef433caf0b44d307215d4
+Tag = ae44fded0cedaf41161dc405f64c34cf
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = c2fd640bde60ac5cced260a180a33ced
+
+AAD = 7d0e9f30c1
+Plaintext = d8f9799a1a3bbbdc5c7dfd1e9ebf3f
+Ciphertext = 7558c6742cd973475105757c1fbe73
+Tag = 41a14651a8807ba7e09617f37f716314
+
+AAD = 9324b546d7
+Plaintext = c4e565860627a7c84869e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f5759616
+Ciphertext = c29b66188901207f4fd69070334ce47563fa18ba70704b0ce34da1507232ffaf922b5ee17a
+Tag = 204bff6c1ca2773c46a479c0a2eff611
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = f77be341dc6599212282d0dde3c455fa
+
+AAD = 4fe071029324b546d768f9
+Plaintext = aacb4b6cec0d8dae2e4fcff070911132b2d35374f4
+Ciphertext = 9484c2b50fba103ef31f3ade3b3c04e740537b972b
+Tag = 44348cee603233fa9069a08f44fa9736
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 279eddc47febf4d93fa49490ec17c8f5
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8
+Plaintext = c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090
+Ciphertext = bf296615abb2cc96bc85e20c4cb31555241979af80d249b80c7bec6368
+Tag = b8ba0d68922be0eaac71d8d0e63a4e68
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = a125677fb4d0cf4db5326233082aaa8c
+
+AAD = 68f98a1bac3dce5ff08112a334c556e7d768f98a1bac3dce5ff08112a334
+Plaintext = c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d7
+Ciphertext = f68b456346508df16013eaae0bb2423f579911594e0132919b1902ff64b94a5976903ea1e511e84b
+Tag = 847a2a6130734e3396829bd94466c42f
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 812f7126561e49085aa4234ea684146e
+
+# initialize with key of104 bits, nonce of672 bits:
+Key = a039d26b049d36cf68019a33cc
+Nonce = 58b91a7b3b9cfd5e1e7fe0410162c324e445a607c72889eaaa0b6ccd8dee4fb070d1329353b415763697f859197adb3cfc5dbe1fdf40a102c22384e5a50667c888e94aab6bcc2d8e4eaf10713192f3541475d637
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 26d169f455af0a342d61514ef3cf9e68
+
+AAD =
+Plaintext = 99ba
+Ciphertext = f43b
+Tag = 823235aad89bb739dbf3e9424f06d18f
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 222cc275e6
+Tag = 5d5b6f33b93a5bf5cd6eacbbd92c03f9
+
+AAD =
+Plaintext = 0728a8c9496aea0b8b
+Ciphertext = 3eba408dc887e748df
+Tag = 91eabfbfaa57f648e523f1a580c335dd
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a
+Ciphertext = 4333dce11d235529503cd8b5eaff3f
+Tag = 197ee21a5614a87a0b3b86c2e90fe722
+
+AAD =
+Plaintext = 85a62647c7e86889092aaacb4b6cec0d8dae2e4fcff07091
+Ciphertext = b1fc9ee70e85949f7cfa6073c1bf0a1d353a35e9af83cb54
+Tag = 325b90fbe3cf223490c3b64d8cccd6f6
+
+AAD =
+Plaintext = 61820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d4
+Ciphertext = c1b6779f11f35f0f26f161e06a653dce14b48e9329fd54a2b04b01076eef9eef959d7acda060
+Tag = ae0e709ec012d31dd9d1c1e923bff583
+
+AAD = cc5dee7f
+Plaintext =
+Ciphertext =
+Tag = a5279c94ed493145fb2e5352befc74be
+
+AAD = d96afb8c
+Plaintext = 93b43455d5f676971738b8d959
+Ciphertext = 387383d47a521abe3c733cca33
+Tag = 44695d807d0feff4740d34ce8b5cacbd
+
+AAD = ec7d0e9f
+Plaintext = 99ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829
+Ciphertext = ed8779eaa9008a9049f971d7efcc41ebb6bf53c4dedf3618d9ee575fa08ded24
+Tag = fae0d69ff94e3398bfcb72d048494d6d
+
+AAD = f68718a93acb5ced7e
+Plaintext =
+Ciphertext =
+Tag = 8ab57c1a7da2bb77b1bd9d1a61fe1565
+
+AAD = 08992abb4cdd6eff90
+Plaintext = c2e363840425a5c64667e70888a9294acaeb
+Ciphertext = ba68fd5c1db36addc0cfc7215d4305f09d87
+Tag = 762c0a72abf73cfabba531a3f9ef2e22
+
+AAD = 23b445d667f8891aab
+Plaintext = d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eae
+Ciphertext = df7414ee4743af7132e0643c48420da8438c2cd4e730afc1b0f4c6bb47205c9260016eb752675154d647248dbe
+Tag = 74070f55a1d1b4d5249a2f538f75c4b2
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 6b989f376668eb1f5c214708c2dcd70c
+
+AAD = 7d0e9f30c152e374059627b849da6bfc
+Plaintext = 3758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3
+Ciphertext = f354d5ef9bf45ba200a0a9c0c14380898d9e749cf28e90a82a
+Tag = ccb2839f9c77d509c12557aea80d480e
+
+AAD = 16a738c95aeb7c0d9e2fc051e27304958516a738c95aeb7c0d
+Plaintext =
+Ciphertext =
+Tag = b6bb0ad275440c9a72eeebe72faebb2e
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2f
+Plaintext = f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223
+Ciphertext = 103e0e01be3e9955e45badc4736c7b23c3f72e0cbed5f47c437f265ea7d7bf844eab
+Tag = 0eca614bef2685ce6e50f08d91ab6042
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = b9680e07d6daeff7a144d4a97638ddf5
+
+AAD = dc6dfe8f20b142d364f58617a839ca5b4bdc6dfe8f20b142d364f58617a839caba4bdc6dfe
+Plaintext = 96b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d
+Ciphertext = aac6458a464d397d0ed64d1b6aaef8bb0a9562135a549cdbde7a2bf589f9d3653eef0eedc1723ce7639c5ebd4a57
+Tag = 3b20bd1ace762cb759ca0140cf3b062d
+
+# initialize with key of96 bits, nonce of680 bits:
+Key = ff9831ca63fc952ec760f992
+Nonce = f95abb1cdc3d9effbf2081e2a20364c585e647a868c92a8b4bac0d6e2e8ff0511172d334f455b617d73899faba1b7cdd9dfe5fc080e142a363c4258646a70869298aeb4c0c6dce2fef50b112d23394f5b51677d898
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 656d538fe0b6df2a916e1743fdf874c3
+
+AAD =
+Plaintext = f7
+Ciphertext = 9d
+Tag = b7c5efd0a90f61124322298fba65406e
+
+AAD =
+Plaintext = 99ba
+Ciphertext = ec6b
+Tag = 3df05c5ad6aa3a3184df062d7d961498
+
+AAD =
+Plaintext = ddfe7e9f
+Ciphertext = fcd4d283
+Tag = 0c1a46195f8ef6b4ffa817fe777e8df0
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = 0c90ad603e9308
+Tag = 38de876eab329351d083f21331f24802
+
+AAD =
+Plaintext = 4b6cec0d8dae2e4fcff070
+Ciphertext = 81f0afae2e1a9978b47fc2
+Tag = eaf2c8c898570d1f022105606d2785f5
+
+AAD =
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
+Ciphertext = 4db5ec225ae7bfa8b2cc2f7473e5af35f2
+Tag = 822327bb949c7deb9c3c1e7199b4cd0d
+
+AAD =
+Plaintext = c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = bc3cb1a75f5f39fc089df6903e76c2ecdc8d4234b30b053d6da8
+Tag = f76daf633fb66425106a1322d120e642
+
+AAD =
+Plaintext = a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9
+Ciphertext = 6dadaec86cd98bc18c21c90e1d8ebc9b883608507d69f7cd31b24b9f5d0666ec2971f0664d9f3de0
+Tag = 1c6162d4f5e6838bf4f5dc6cfe55e284
+
+AAD = 2abb4c
+Plaintext =
+Ciphertext =
+Tag = cf96b4f09b202eb2d77e91c1c1226a7b
+
+AAD = 36c758
+Plaintext = f01191b23253d3f474951536
+Ciphertext = 14a5863dc6d48ce1e53fde93
+Tag = 54b02ac246e88946f7cb2f5b35e65331
+
+AAD = 48d96a
+Plaintext = 5475f51696b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243
+Ciphertext = b882490767ce6b5004830fe7951774532eab6625ceab240840e2c4581718
+Tag = 7b1b36e05368be040227b5f48a21bc88
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 873fae786f2f092dca57f259ea6e3db4
+
+AAD = c253e475069728
+Plaintext = 7c9d1d3ebedf5f800021a1c24263e304
+Ciphertext = 301d30ca5ea59910044fc37cb0286b7a
+Tag = 3f3471774680bcb25a0b70b9b9fee8e8
+
+AAD = da6bfc8d1eaf40
+Plaintext = accd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc0
+Ciphertext = 84340e3d51e89f8f49c73a5f91ed978a3b1551f78ba8b87cdc9df19bf1f6c9a72f9c2520ad282b8f
+Tag = 81dfef5e2556e089b605d24ecba2f0f8
+
+AAD = dc6dfe8f20b142d364f58617
+Plaintext =
+Ciphertext =
+Tag = 3e138bf800e3b212c12f45a0d947197e
+
+AAD = f18213a435c657e8790a9b2c
+Plaintext = abcc4c6ded0e8eaf2f50d0f171921233b3d45475f5
+Ciphertext = e196482893acd5e78b8606c0e1f5826731952e4dd1
+Tag = 93bdbdc5383b7691ddea8c4f3299502d
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 7072bca4dec59dd66bbe3eba736f452d
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = bf3956d81085b68818f17f3141b36c207107ccc9fc1ff064ca6206e7
+Tag = 05ead72f421b19322b9092a39dbb3e33
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = 6a997726cadcb3caed47e97955394988
+
+AAD = 21b243d465f68718a93acb5ced7e0fa09021b243d465f68718a93acb
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d
+Ciphertext = 312d8361e47f11c6f6345824a5798a7580faf5020885aeb039959f82403a3a8e577f93487a
+Tag = d3a0bb915e07ea0f409558dc372d67cd
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
+Plaintext =
+Ciphertext =
+Tag = f1c92376d9de2b55e9b2553145aa8853
+
+AAD = c556e778099a2bbc4dde6f009122b34434c556e778099a2bbc4dde6f009122b3a334c556e778099a
+Plaintext = 7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797
+Ciphertext = 2e0345cf349aa7e79a663b1240c2590d3dc6f337898e881ee020bf899000e49577af6bf3e5658439361020f63fbaba47bc
+Tag = 948aeeb10cf84d2121b22b20cba0fd06

--- a/tests/kat/testvectors/Ketje_Sr.txt
+++ b/tests/kat/testvectors/Ketje_Sr.txt
@@ -1,0 +1,13582 @@
+# Ketje_Sr.txt
+# Algorithm name: Ketje Sr
+# Test vectors obtained from https://www.github.com/XKCP/XKCP
+# The test vector file format hasbeenadapted to fit the format supported
+# by libkeccak's test vector parser.
+
+# initialize with key of376 bits, nonce of 0 bits:
+Key = d069029b34cd66ff9831ca63fc952ec760f9922bc45df68f28c15af38c25be574fe8811ab34ce57e17b049e27b14ad
+Nonce =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = b44900aacf1362198e2761d51cfee188
+
+AAD =
+Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef
+Ciphertext = 20a3caf6b4bbf81ac3e5e9149ee7f5292bf97d7a15d0aeb87a4fb66ada52206229532e31
+Tag = d16b1355a9c7cf3fbb65c4fcd9c14eaf
+
+AAD = 0c9d2ebf50e172039425b647d869fa8b7b0c9d2ebf50e172039425b647d869faea7b0c9d
+Plaintext =
+Ciphertext =
+Tag = 176a01bea1a398e82d0eed740c86f7d1
+
+# initialize with key of336 bits, nonce of40 bits:
+Key = ab44dd760fa841da730ca53ed77009a23bd46d069f38d16a039c35ce670099322ac35cf58e27c059f28b
+Nonce = 77d8399a5a
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 97897ad2c46d7c0958c9787b112d70b4
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262
+Ciphertext = 3a7dbab118f563cc9a52eab786d50eb19c29daf89c9830b1b46641303e860a
+Tag = c92af8faaf573457af830339012cbfdc
+
+AAD = e273049526b748d96afb8c1dae3fd06151e273049526b748d96afb8c1dae3f
+Plaintext =
+Ciphertext =
+Tag = 0734c1b2636537beb8b7de6c249a91f9
+
+# initialize with key of296 bits, nonce of80 bits:
+Key = 861fb851ea831cb54ee78019b24be47d16af48e17a13ac45de7710a942db740d059e37d069
+Nonce = 9cfd5ebf7fe041a262c3
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7f8e706cde08e85941dada8a5a701995
+
+AAD =
+Plaintext = c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = acd1dd6d37e623aaff534fe7bfab8858d1a6218f1812d7ca8a1c
+Tag = c3a843a36dcf96ec932ffd8c981a64e1
+
+AAD = b849da6bfc8d1eaf40d162f38415a63727b849da6bfc8d1eaf40
+Plaintext =
+Ciphertext =
+Tag = b4912d5973bbddda5a307a09ed405c49
+
+AAD = e576079829ba4bdc6dfe8f20b142d36454e576079829ba4bdc6d
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e1e3fbf
+Ciphertext = 7a89b8e9ee0cb227679327c244b23bb6fa8551db4b2e35c1c10e5fe40ecf1edd3a82967d88a9d23ff6e93b579e
+Tag = 5f12e843e03011b8195de2dafb062bd0
+
+# initialize with key of256 bits, nonce of120 bits:
+Key = 61fa932cc55ef79029c25bf48d26bf58f18a23bc55ee8720b952eb841db64fe8
+Nonce = c12283e4a40566c787e849aa6acb2c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9d27819556c492d502a547212db27093
+
+AAD =
+Plaintext = 9fc04061e10282a32344c4e565860627a7c84869e9
+Ciphertext = 9fff18b30e1cd763b593d6b7e50239418dd63eb8a2
+Tag = 2706f1ea8acb9a28250d642a0c0f6756
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+Plaintext =
+Ciphertext =
+Tag = 2dee13f9b54222393b93d6885d636965
+
+AAD = b445d667f8891aab3ccd5eef8011a23323b445d667
+Plaintext = 76971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9
+Ciphertext = 1efe8d4fb0bff4253d97f26962a3f6b846b4c3eef082637fbdef57bf25480abb0e22df45a1fc
+Tag = 707e252758b90f5f42fa5b5e8c2387cc
+
+AAD = 46d768f98a1bac3dce5ff08112a334c5b546d768f98a1bac3dce5ff08112a33424b546d768f98a1bac3dce5ff08112a393
+Plaintext =
+Ciphertext =
+Tag = 4df2fba6ffe842a5eed3efcdf459f2fc
+
+# initialize with key of216 bits, nonce of160 bits:
+Key = 3cd56e07a039d26b049d36cf68019a33cc65fe9730c962fb942dc6
+Nonce = e647a809c92a8becac0d6ecf8ff051b272d33495
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 0b951b81fcb31ba440fffb5ff3729e8b
+
+AAD =
+Plaintext = 75961637b7d85879f91a9abb3b5cdcfd
+Ciphertext = 67c1528d2662e58a2aefbcd1c1c807fd
+Tag = f87d8b58f1ef27885bb2622a00dd6599
+
+AAD =
+Plaintext = a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9
+Ciphertext = 568f5a04bceb60068a364533ccbd30543508424171b4cc5d2189be4c815309a96545f537585f6bdf
+Tag = 30fca3bfa7d1dabbcc90df6347016d08
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = aed174608ca3148683a8c943d4198b0f
+
+AAD = 8213a435c657e8790a9b2cbd4edf7001
+Plaintext = 61820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50
+Ciphertext = d1193e3dbafedf37ec00936e8a348faf56d398010596aaf676d0ca04f7e7
+Tag = 5c7aeb2aa54afd639535bb143c3df6be
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = 5736f3ed7822e495ffe9eec15d6f7aa4
+
+# initialize with key of176 bits, nonce of200 bits:
+Key = 17b049e27b14ad46df7811aa43dc750ea740d9720ba4
+Nonce = 0b6ccd2eee4fb011d13293f4b41576d797f859ba7adb3c9d5d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 23cfc6a4f02199ec0986632161a7abf7
+
+AAD =
+Plaintext = 4b6cec0d8dae2e4fcff070
+Ciphertext = 7498019648e5956406775f
+Tag = e50e5798075da3a552e21fbb20ce08b0
+
+AAD =
+Plaintext = 6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898
+Ciphertext = 038bac816119a44e91615426a50eb9c9a5db161ff473e5ecac0686
+Tag = 61a36f7e84df26970dfba88d7179e4bb
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = da97cc192a9ab322c6af1a12f1b00a2c
+
+AAD = 51e273049526b748d96afb
+Plaintext = ee0f8fb03051d1f272931334b4d55576f61797b83859d9
+Ciphertext = 5b3e0d15f7637adc30b5133756e8b2a0e4787a25a01001
+Tag = 3d17b93335c74145ae7acd7551ab302d
+
+AAD = 16a738c95aeb7c0d9e2fc051e27304958516a738c95aeb7c0d
+Plaintext =
+Ciphertext =
+Tag = 3a22aab5ee5b5a387e144cdd5623070f
+
+AAD = 3bcc5dee7f10a132c354e576079829baaa3bcc5dee7f10a132
+Plaintext = d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a
+Ciphertext = 2e561f2fe9cf39f759be5a764cb4a8af551710b45debfc86c1135ae3a2d9c9f72eb9a4761a
+Tag = 1fbfc4230515eac65f9ec4ee4b9e8a61
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = 35c1ef0e664f653ef733c8b9d66b601b
+
+# initialize with key of160 bits, nonce of216 bits:
+Key = d56e07a039d26b049d36cf68019a33cc65fe9730
+Nonce = 4dae0f703091f2531374d536f657b819d93a9bfcbc1d7edf9f0061
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 274607d971b3db683838a54dc367abbe
+
+AAD =
+Plaintext = 0728a8c9496aea0b8b
+Ciphertext = 0d6fd84c2a7286975e
+Tag = fe6937da5c0fb33fe98a34417941e1fb
+
+AAD =
+Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
+Ciphertext = a31807b897bfd46b5124b11974cc4aaa3d0ca2a671e9
+Tag = 3e187275cfc8d632c1727ef7f928176f
+
+AAD =
+Plaintext = e90a8aab2b4ccced6d8e0e2fafd05071f11292b33354d4f575961637b7d85879f91a9abb3b5cdcfd7d9e
+Ciphertext = 79f4bd4f098c6dd8211fc47014633e409f7cf4f970e3e1e60753d396c5339e4d48ecedca9616b88929d1
+Tag = 0895a2d8cfaa5931395ca0490f81c5a9
+
+AAD = f68718a93acb5ced7e
+Plaintext =
+Ciphertext =
+Tag = 04ecd5ac6c15433768c716d36d3a0309
+
+AAD = 0a9b2cbd4edf700192
+Plaintext = 0627a7c84869e90a8aab2b4ccced6d8e0e2fafd0
+Ciphertext = 9a824fc98208464f7c5fdabb704836aab6f956d9
+Tag = 27dc2deebf71515ead7bf6361049f114
+
+AAD = 28b94adb6cfd8e1fb0
+Plaintext = 0223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f9799a1a3b
+Ciphertext = 72707038c47a53511eb6a2a6ea7d71a8da1171296c15c60a5383afdb3b16b6f3c76e2772d8235504ed6868a044c9f7673e5a
+Tag = 8e4513ba062f051a1f8aaf1ae7783983
+
+AAD = 8e1fb041d263f48516a738c95aeb7c0dfd8e1fb041
+Plaintext =
+Ciphertext =
+Tag = 854ff443edcdbafe225a2e12cd84c560
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061
+Plaintext = aacb4b6cec0d8dae2e4fcff070911132b2d35374f41595b63657d7f87899193a
+Ciphertext = 3edbba99606a4e76f488b96a26e8a8d4a31a0f48585c2911ccdda112dbcac156
+Tag = 7c0920deb31116be43484949454410cf
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = 46d3a69aedd44f909efd80d2bc627a6f
+
+AAD = de6f009122b344d566f78819aa3bcc5d4dde6f009122b344d566f78819aa3bccbc4dde6f00
+Plaintext = dafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0d15172
+Ciphertext = f5484221b1ed3f3c1804206b5e69c329fdd0c77fe77efe023881779bbc8dce620679f296648056238399402f2f6f50b2
+Tag = c8523eaa003e8aa92d9713f908acbc6d
+
+# initialize with key of144 bits, nonce of232 bits:
+Key = 932cc55ef79029c25bf48d26bf58f18a23bc
+Nonce = 8ff051b272d3349555b617783899fa5b1b7cdd3efe5fc021e142a304c4
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1d0597d060e3617e76e753a3a6d52712
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = a74a9e96619068
+Tag = afa57ac2aead8d1f5ac9f57a026cd723
+
+AAD =
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
+Ciphertext = 2df0fb1560fce6ec7bf4d3ce91ac416a7e
+Tag = 91e720b57f895343ea3d574ae8aba2b8
+
+AAD =
+Plaintext = 95b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425
+Ciphertext = 4ea13bebfa1d9263ce0c09bb03894f1d9e6b348095acd8e8e50ce6c31bbe78c9
+Tag = bf3f59660283aceed15e83afe71b82a2
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 7905f5e0798a504d645269a7dd80596e
+
+AAD = c354e576079829
+Plaintext = 1e3fbfe060810122a2c34364e40585a626
+Ciphertext = 4eeb74505eb5ebaed507bc3ab11d125bdb
+Tag = 61ed06beb898719ca0b4054ffb2816c0
+
+AAD = dc6dfe8f20b142
+Plaintext = f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a5
+Ciphertext = f6138f6b46fc1c28db750a8f7ce4697c0ddb39f6406738c1a432185847b104f2ba99acc8c3e4132534be
+Tag = ae724589948002bcfc11cc4966d8d480
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 2589864b72be70fac1d8f244c6879bb2
+
+AAD = 7e0fa031c253e475069728b94adb6cfd
+Plaintext = d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e56586
+Ciphertext = df44174341b3076b3ee452bcb3850f46384e0ad876c6cbac16bb
+Tag = 2b226e8477ea78c8d0e8dc17adcfde48
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = a209039b8f22f93506f3f36b16db5343
+
+AAD = 22b344d566f78819aa3bcc5dee7f10a19122b344d566f78819aa3bcc
+Plaintext = 7d9e1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff0
+Ciphertext = 2ca234c3ad4b6763e0454e6c3495a87be7ce07e293255a8103b7bc0e5fe1604e1f93ee19449d
+Tag = 3838d3bd8c16fb894fa49c6f6a55f921
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = c7fc4b943e7d7c7be61b62b1a4e54c4b
+
+# initialize with key of128 bits, nonce of 0 bits:
+Key = 32cb64fd962fc861fa932cc55ef79029
+Nonce =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 974ebfd674494aa5
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 5c5bfecd391d4cdca1ccd434f86098d2
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d2e14d85c9518d58d447f461d924a5c7afb0727b264471f7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e591172c31b0e14073c4928335365a79401b2f358ab6827fc4918e401774aec1
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = f09fa9d707
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 6c9418b361
+Tag = 91415b6a068acca4
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 55021732ea
+Tag = 3913cb5bf34831ee73fcca37768ef040
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = f5c92bdbdb
+Tag = cc2adf478fa75ee496808eaf04689342893fc29315b0b19a
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 1070780e28
+Tag = 54993ad07bed7b0d18cc64c8908f12972a2c0365a12ba432414a92d263ef756c
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 16242f0be0ef19b736846fbf
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = e00fa0302901e7e95f8fa53b
+Tag = 1b2a1f50d46808fe
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = c5a099d77cbbe42c732dc867
+Tag = 730afaad85945315b05e6d0ed814d0fa
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = b80a269110be7fbafb4d5ce9
+Tag = 4d834794c1a4631bc0245b9f48cf4112d95daec7cfcb6f4d
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = d7ec99494691741512d25578
+Tag = 8da6d935362d3a8660b4d206d0c160fdfa4431c0cb25bc48a32361db568dd23d
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = f465edb4de0be2e17c86153d58f10cf397bf423d36db4c
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = fcf2b7889d920a535749c8443fd03b8b59363865e9933a
+Tag = 8b094cbd1dd8386e
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 7d6d00c8bc6a25f40b3e18d32f2927fe89b93dcf760319
+Tag = df0334a6e8b3df25409d87c2c422f840
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 0824cea7d74e8e98b3a16fe6a587b52136b6e3e4716ff4
+Tag = f113243371799e40924efe52ab0db7779828a7371e24ac0e
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = e3b2d1eb36b84434e7ad63b7494af5c36885a1849894e3
+Tag = 84a412c7def66d24d006ac5169844a365162b3dd2317d9caa4a0b0a14adf74ae
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = baa9ddb85b0245ecbc9c2a9833ff7c5051566ea3ac37baf42fa4334d7826cb1329213c6c58de02
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 136c7c9d6f6cb2cfd61f16ac8d3a1ec8cd350999cb52e7496208d6ddae4c9f91abd76dc01fca1a
+Tag = f576e2037c5f6f87
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = b53d0f5cb79905d8fdbad60da778f95771658e7861bfbddcfca6f191abb2f7672e6bf4b85d9906
+Tag = 389f88fbb75a33468e216e414be1623a
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = c5221042f9f649d2e36d6b884a52008fa552c1a4c8238cfb9902b714d584f454e6f17d6d75cff6
+Tag = fda95914f631b84a3cd5c232394308dcda29fb3b9f4f28be
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 0dfc82be476b69907227718cde616a3781de62571213855f28882876449fe5a89fcb0577fb36ba
+Tag = df9d26f34a68008f2f0d69ef40e3c874f0fd1a4e5db010d78793bc95893b9c5f
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 7560f5558806ee89
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 68557f166913288da1ab04cf043d478a
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 3f6d7d94426e29e89c7904a4b3aed558cbf0e7d64e5d3bb0
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 76d82a94cfd8e90a8a7b1245a3a07220857be123050629339d66fcaa5b26f7be
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 4d972aa712c278485ffcda9f2720
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 2a4a28736eb9a667f2cd7b2c068c
+Tag = 58ddd1ebb4ebc6ad
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 1f2a6aad81c2a969fa37b0494174
+Tag = 1fffd08a591608305e5f5859042f158b
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 9f91ca83e48a562e53b1e5a00cbf
+Tag = 3cddf54f7850df2438a387986b69bf2610be7cfa5fabd7de
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = cd9b9c0587080233082c77465183
+Tag = 5cd3658d526f3c148a34002801d3417323d2e4de755ac86cd118c4f905f75679
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = c3b095bd1bdf14122be80e80612592e180ef53b1c1297bca5daef3b7b3574e1162a104
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 58a0cdea0ce3d6b239a0cc31be4e04cbf95ffde6d78d414509311d6771f692f9a620a3
+Tag = 0284f566c42e621d
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = a9f1e440a29fce98666c01b5e1ab2c0d564abb6b0698904c511f2a6d4c62319e8c7742
+Tag = c6dd0f7be2c38edfa6dbe17566316b7c
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = d1963bdbd43b6452b3a85a1bf8223f65bff64dabc773220ffde27f439fd10fce12cb17
+Tag = c5210af5f2e9afc84d966cd295c0ae718871af3823e47a3b
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 74775cd126465bdcd2423f9da4321e147f5e565572fb87fc8c6241d5e25c170b127caf
+Tag = 1d39b0f53fe3456173b162878bea9cbe1768288049d157603de0182becb1c819
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = f60f23ed2a0ebd1f
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 602943d1789ef06123195310aa62deda
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 2e4ca2e550c7fd0b56c42550764bd618c7078ea5d0063a6c
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 64f4d335f136c78061152cbee193eb73879362773c828466696a648edd7f7f87
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 94253c57fe4589b17de3d287f20e0a0f2d8b27b4
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 257b6ed78962cf54a8f04803e70818fc3613e6a8
+Tag = 0609608586b17b02
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = c9b88ac9f22f16433d2b95f368e53592c2bfbb7f
+Tag = e0d8b30238c0b8d02d738983bc3e0f42
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 7a6dc1dca6449e0e674261164fdbb03b26ed830c
+Tag = 132089560dc96f5d96acc8ab9ebada03cb7138a2a81a0c02
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = dce34000400e71863ef9b75aab3d4c005ca5f2ea
+Tag = 3684e59a31908fcec3bd6f161d63d363ecd180d09043bcd1a974750fe28cabf6
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 96cd85e288198351bbee0ed3bafca03cf5ec87efe9fc94e2909476a4bb952ab920a00477a4d4501decec4ded0a0d3b9025ca
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 7be79e80429191ca506224e63e5c52876ebd52a144acab4f0fdb1f68ae22cd1b610fb65550d909c46a28188641a0f656b89f
+Tag = 355bc2d665bef512
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 7a69ad65b2a350e8a1feb692a1dcdcd5c7fe9d0498dc82bf138a5a537b908efb1ba8218d9aa12c038bb0401c4177b67c3210
+Tag = 4e9d0dd8b6f473941cda8fd56a08bd6e
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 03e7c7d95d512cd0e272bad38a2344531f6a4793b35c909aeff4c736112bd45a7f3b874b89cb212cc72717f28c8af4900ccc
+Tag = 41282cf4cdd17cb2dff3c3b53ca6d64b08682c7eb9b3d2c6
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = bc3e132ae26ff3e178774ad7c74340c271a5b818772379662869dcf54d3a5df5cb6ed8c39c061d74d19064267775184f0b4e
+Tag = 9e93353188fc6352e729c02ddc2903f38c44339f568436d35d2eab4c07196b7d
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 629c382bdd892d82
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 899f2c720a47d8100629f12b7c540eb1
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = b1ff034ab1a1951fee1030bac8f5c89b5e327cfefa099010
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = fcb0b1e608f36fedea90fa26fc6f27d02bfdd59b12744603137ef577ca9191cd
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = f0f33d8dfd584211185ff9139b3f37903f18302e536fa03c1ad5489a
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 905787d5f9675382ec402ec2bf55e0e4e70137c3ddfafcddf2bf8221
+Tag = 0c9982229f4807e1
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = d5e986213d9bc397ab551a5ca356697a20768c5108ba9d983ef5f470
+Tag = 94832067b223fc25ed4473e2746bd62b
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 1e2bc062df12b81b9150149a64aef2b3c35aa0fd1ecf93352aedbd8f
+Tag = b82aaf69dab98f5bb5a6a5b39a5256ff68d58654e36bf1e9
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 6acfd0b48f531796145e4fb97e196dddd5444f3841d6b866b740509e
+Tag = 77ba7cda4a9daebf0ffb6e2f9b735e76cfe8cbbace7f6603e6b5e96d230d0e5a
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = c5c24bd4379784ca
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = f80afe19d2f9c56b85ba8d9edc0d01fc
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 478ba556414026ec1c83850e7a718a8c25cc97964b739770
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 5ce833306d05c5d38e9255ef9f6b7e83f177af31c1afb9f9f76db75efd54e9a0
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 895a7f8f2da3bbe6759e3eabc1068d0bf913570ccaad17538c1344c286d1891800998ae90a3e0c
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = df6d96ddbcb62f668135f9e20449bbdef334c55f28d93664347ea3af76fc4419f9fc32e817d8f8
+Tag = c8850f11d5f368fa
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = e7adb44cb754c53dec2d43bbaa730d2ed4772ad3d07d827c24787b022bd31853f596529b056c36
+Tag = e13c534ddd5b7e1f49cd914e3c92f049
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 5ee3a0d9f2f01e5b6f5b422d47b2d918f880ed4bdf275b75c3e5a6632709b64c845d0d3d1456ac
+Tag = d0d20797d8ef91bda2e868fd360e4c13151dca30df7ca7b5
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 5d1032b6bcb3a207edb4101a1d5e901911a61fc3b1bd308ac0a4b83c4f618309047c1ef891db57
+Tag = 5ddb56b90d5f991be29872b6d1386beab33fda3f20640c5ac21ce8dbbf748c85
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 64680fce1033acf5
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 1fbcc1ac1cd2e19313fea7f490eaff08
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 699f59dab68ac4005b782693d7c596384d5ea13fd54d4dbf
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = ce26491c280480e41f4985dc9a180c5879f44ab47b0a511301dad51221ff8aa2
+
+# initialize with key of128 bits, nonce of 8 bits:
+Key = 33cc65fe9730c962fb942dc65ff8912a
+Nonce = d5
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e942002c3573f423
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 00e6c9bf0f4966cb9e7fca02a1c3d5cc
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7d11242dd298799d8a33b5d7d45f1ab42ac755087eb5596a
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6e174571aca2af983d8610b73a60b7fe7c39aa36039263b6a3fc483cdac3d04e
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = ee1b9b0851
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 486a75a7c9
+Tag = 5a81e5831673b1d5
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 3d924422df
+Tag = 3c22e0849bae782122c885b1305ab608
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = cb254e2007
+Tag = 8e7fffe0a77fae306e2a2e920d38c1ff81220c2822f4baff
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = e80909f25b
+Tag = ee1579753beff201b5f53924199439b10ccec06a73ff7344325e9f8670a6ea80
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 3c96b8c6c43abc0860fae54f
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 4ba72cfc6f55b37482b909fb
+Tag = 3b0368c3a640fb7f
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 79877d7b80e6248ee3566ee1
+Tag = 7abb1c0fb5672decfce82271907e8b5c
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 2147d28d23ee64a810ea083c
+Tag = 94b331c20aacd6d937d32144a58b4e605a5086eab6f0289e
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 4b042cd29aeb5bef64423fdb
+Tag = a70f68a8415530c0aa8a6f0e0ca8deda2f12ed5b096d24b28a55cef485962fa8
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 6c387abf6ee296b1ba3e6fa8c42a98e758fead91d49b04
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 0c32c3db01f205df2df9e356b08e4f68ec6e4218df60ec
+Tag = a83aaecbbdb77f7b
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = cf00215a53907050bb609361db4b55766c59bf040a2c81
+Tag = 254b62b0cde51806e6edfa3dd2546839
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = c588502556c242dfa476b5f118d23b1deae8167aead4a2
+Tag = 5734cfaad5394abc62bed48633c1fb0c50fba8035a5d0bd1
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 857ab9a6fa1bd9539d5b3e7949d705aebd7f2dc3f8d782
+Tag = cbb1b4e9b00e89e44f16d81730d5a7e89f8ee16c52b3d1eb92e49bfe0536df8c
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 763f3972a17d3f076125ff0b09615dd64adf0b5371caa7efc098f2d6d1c797257af886dc36517b
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = ed669b0799d44012e2f116a37d1a6e060b2d393b11b535106022a86299e6eb19132a48bdee08e4
+Tag = 9b742cb31976cf9a
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = cc93ebb4b5ca87ee0b45c6c347df115c87711ff63d88097fef441ef456bc46a2385cfcbbfc27b2
+Tag = 039ed740e24412a819bb27cf49b79aef
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 2582f371efe1bc9d028d739ea5b3ea45fe8aeb909435c536c86ab26320dc2dcdb9d0a694aee9f3
+Tag = 2f318eabf58b77f04f909208748f66fd8460fce416bb87f1
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 46fa3d4499e79b90509a54be6c3714179b5d62a5ce103982d77e92d3688d8afc95f93226f8b395
+Tag = 19c94ff2766efdd46c125216077f82f137b6bb806cc2a137d55a98f2b6e3f512
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = b9f8f6c2702ebc41
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 2a28da0b8c197acc0faca826a068b9e3
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = bbc10e89a5adfa9a1bc033db9e56da235d9a551ddfdc8f42
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = e25da6addfbc4f971e923475c44e3f50c308091ce395f205290731a0c9979a4d
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = e3dafd186693742e9a31df2264d8
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 7643ce2a057b057223813580a922
+Tag = 242050b8a854a094
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 7e79a38e8f7ea85d74d522ba5b6e
+Tag = 7d35026697164b116cb2080cf89828ec
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = e6168d0428e140431fff970b0de7
+Tag = a1a50e5cd2e01669e160238465d36590a00090d1188e3395
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = abfab1b09f4a8c0ee2da8349914d
+Tag = 939b0ac0defc31189b0f4bbcf27652d6ecd2a39e5b2ba0669465f34b7cfe0458
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = dce193f802a626d902b3d274dc1c683758fd1adf8a85a27259c3b7dceee36ac4c3ba64
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 5f1f757f6670d84b2a44d47e049e5500b1ed0987dddf1c73d9fd2e4cbc53cf09733093
+Tag = 62630db5311f15f4
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = d786b460f76e9397916ba6dc96ca15a31bfab934914a2a212f76ec67f10d2086c1dd92
+Tag = 1d4c269e8049180f070bf99ffa90574d
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = b396c41c144ace345852eb0e1d0390cbb715b44f171e04cb2056cfdcceb011fc58e330
+Tag = d6a88d2bd3acd9e80a0ac86f100dbd79c8280cc67313eca9
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 8842643eef41afbf5ea551f1209af3beb709bcb3cd5d13a2a4e8e1ca8ce12f12e2c6be
+Tag = 2950e37df791b660ae8efeb075bba7d0c3bcb816a770dcbae983f5d8e2c8f2ed
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = b415978d54ce2701
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = c8d6637e48439c3d6df9139e3a9df099
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 281cc87a44011d78578a1c0136f11e09f2ff63e1943758f7
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 7e9d2812793d1918fb021bb44332ab672c3d4a2317320fce3c3ac07484a9e8fa
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = f493e098878ff5fe8fe7231600407c45c9aea903
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 4f420bf35e473b719e0789e5633cee88a99f2829
+Tag = f7d7d6bda0d9247a
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 2b45d0b1872f8e85e42fe128427638f7423a5265
+Tag = 1590d4be1a6d0942de7c41deeb1b331f
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 098ff920c4f49f211cb96cffe2c4f57504101e46
+Tag = 4637d1468ce22441bea90811eabdaaced109d4dcf7741d7d
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 6a100ea53ec7c444ef7c5395b356cdcc3b0bc998
+Tag = c4e7bca1bd5019bfac0ee1c7d01191d5c49309dd32a10c5f4d240e6e8ae6d687
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 114f923206620e78c9d19fe0a2a21d14b67d32b766fc5cd9cba66c126aad314de664581eb9c870b63014fb18f647a13513ab
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 0e9baa3181b7a10ab887332982d5fb4cb754b109296eea1bead19fcaf0eea93a4c74a4e2c580bab3047a3cc2efcf458ad0d7
+Tag = 127026bc120f80de
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 4aa37b6140b16ed2028097192abeb2a1692c7f3bd9f9fd8bc48c536f49601f9366868fa3afad4a4a551aa67c89d525795b38
+Tag = 070a66f4bef7d2eb1cf70b8694486b8a
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 42ee06541600023653c5146b1237388564d70e6026146aa28f0a0d69e53d40e4028c71b53604246577c25c5837633724bb6e
+Tag = c57405a6ac001625444b1ddc1361fb8160fb1b44b311acfa
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = a6b5bd8793b7edfd1c3418bc9b03006a1514238a8e1be48905b0f765966033a26dd985feae0af0704458250c2e1b4116629e
+Tag = e5cb3e12a552f09983bc439d88886dffc81b7d6bd00cd2a9c1b99bd2f96ed900
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = f8afa011b4940813
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 47581993da52823178dbaeac8ec30079
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = f466a1763ffaca45b93d44e65bcf6cd7e711eb2165cf5a4d
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 07dbfaf865bf00503ed3c68ba6027baa1dfbc99098ee2acdf8b8a6adec2c72ca
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = cf1cda9e67bb055304040dc4a16a503f6dd1bc89ba893fef7cadd6cf
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 8738d42c148ce3bc676dcc3332dc836a001560f54da67dba3ee75e52
+Tag = 15d09b67dc3e4834
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 84307b819a31d1cea7feafc817c84b0da7abf9bcbfec5bea21310b02
+Tag = 2e4627cfc7bfd3093d365315cc297fc5
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 3a333b4b921d23e2739ced82d528394e5520cc66b8a91a743c1f879b
+Tag = 5347ecd9c594fd06353474f71992500f4b7d3252aece18af
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 1301f6be3f06095c29e8de2f5a73d23992fb9f0a1228b009578163a1
+Tag = 49312bb63f4a802e1a49a7a8daf8cd6b330c2d6cdf38cceb0a0de975cffc842a
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 1e433c4f805a7625
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 2cde7e3a2383d48944040c4e1bb8d5bc
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 1666b5e226b68b9286040f59d0f90033441b22723e219e69
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 54efd08495e39b72948c0bcd3d0994dc294e8df36dd403bde07c75ab0f0976fd
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 5ba3d1197b5d19515ef8cea08a0292be7f625bb204c760efbbe835eb31bb2e62ee40d7a5eca6d4
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = bfad55e94dab96fa390122ec34d80d40abd7d1a97880c13232d5aacb14a1ac0a8234982ee623a5
+Tag = e8a246a5e36e4228
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 22377b67664ea84d4050bbd5e42f4f9cb9b42fc065a2b13a0cc3db1ed675a5d07cbd84c339d295
+Tag = c463ff7c802bddee80d8766e2afde347
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 385ba75d6c2ea46862ce88a16a77bb11eca9bd415c0fdcb2ce14858ebdd787f02fd8c2b7d669dc
+Tag = 967ae69b6a1efd963a88138cef6277bc8d5628b94ceda039
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 7264e5d5569df1c47007d77dc3a74db580539a2be2de5b9e357f7593fc5bcb3730209f82f31be0
+Tag = 4ecac36532c7de96a23ab0ea0aa84c4df6f520efb8d6274dcff524a0d91fc25c
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = a40274ac52eed240
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 61eb0b439ea8f8565bee2f08012cf8c6
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 2421d4423e7063e48eae9469a7f4c6b078d80bfc476f07d5
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = fdb10e6d21ecb03540716c4a8bae8a7b80e7ad52bc9427e85410121aa8871c5d
+
+# initialize with key of128 bits, nonce of16 bits:
+Key = 34cd66ff9831ca63fc952ec760f9922b
+Nonce = 77d8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4f600e52724ed001
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d3b1c584c75d526e725f1da59c6fc850
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 63f2b1cf25d07bbd19c01617a8de940656c2bff1180280a4
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 645e2457d382e16efe281b3b82e934d49454bbd112272a1ee95be17e5c490045
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 4afc3617d3
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = c2e023cfd3
+Tag = 138f4e43c0baf4f9
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = c39a58520e
+Tag = 88702e2f6cda27b0b6d8f56362024553
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = f6e3bc091a
+Tag = 7bc40fcd21a48bf6c41a4e1bf38aeedaeb1e289ddf1946a2
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 35ba30464b
+Tag = 9759713f120cf7eef33d22ae49b6964abb11eeaac499ff15ace9a610410ebdcd
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 7519a5c6553752a34a9adaff
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = f34dba697652bf09c601eb80
+Tag = 18693ff42feeb711
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 2680ac8b7f3a7da315cc4707
+Tag = 4666565c39a84a037b64b1ed5204d65d
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 4075f5cad801bc1f4bbc9c56
+Tag = 1296d6d2cbed3370e6144b022892b456d43f1650edca0803
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 62c483186d5e769d3e006bff
+Tag = 3eed86f4078fd620df3778ce922f8bf0cadab80111ae3de65cb7b6cee0bc2cb6
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 82f080fc3a93022ae25480f293da280c071a457d79072f
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = bcf798c1a7355629136409c49233a07ab29345a2e94542
+Tag = 78b8668afa6a2ca4
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = dcc8dc06a73f38b19f4fa15f8db8c5225360ebb87d882e
+Tag = 990c3e4c814be6f3c8e874311bc92a0d
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 8a05a45f5998fafe7a8daeb5abd2f6daf7f9ee73f74f59
+Tag = 3d11b77f3fc2080ba692617c8612a681dc85f46df2d5e483
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 38762dc798fd562c1aa001dc6ae61ed880b42aa7c57840
+Tag = ade8ae5c874f9fb06114b64002234e38f1841308d1cf60851f98253a4642c234
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 3232887d3b7e4acb5128a1eb2b94a0e01356c059a11625d62ce9eeed3efb07af738280e5cd4eea
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 6934470208f798367cfef99054c01074ad5f00dc34b523d69989b385e23994ac9fdb865bc2d0e6
+Tag = c94bb351b74fbe2f
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = e09550de05a5f26a0691a119f52f659c6a2b89123c340c18d44b1e7a15778f763c2d1381940da2
+Tag = 46b7ac80e4f75b83ece6e54b190fb0f3
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 0f7300c305e4446482ff91f7a8ee102cfe2fce8c58c76c8b08eb92aab0413304dfaf39a04c669f
+Tag = de52027a4b128dfcb3d883f02e15eef15d5afa7333590fb8
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = f066ddcae3bd8efde1f68e72184bdbc8189bbe6d4df1edb717d7949a79b566721a11dc4de91fc0
+Tag = c899ec60dca55e13dc830a122cd7644ec7f025ee6b3910003da2bedb762f1d19
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = b190869ef90aff75
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = eafc934605e9155c38df833787e7a3d0
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = b1d0899d82ef2ea68babae7dd174fa7c9dbf02074cc3c775
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = e4037feb40dfd40e13eedcbecb79cc10a868514608c0f67071ef460d65e84850
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = cbd5cc277742631845985da95822
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = c651804948a8ae63c26bf70c1ce2
+Tag = 68cfa5933d68ecba
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 868109ea783895ca9dc7627cf241
+Tag = c69df9fbf1d8811132284a3ad65f2ff5
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 1a722f33453a567fdf2fc75046b3
+Tag = efc764ea11a1ee19b1c9e8ba7ec2af98343229c559d36e5b
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = a2ca439b0f4c859d7cfc5ee56960
+Tag = f620c0d5670f4c1a4646d2fcf9aae83490978e45ea74d499e79338eb0455e6b3
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 2a3a903b69459e4838781c972effba583feb42195af7a869dca4093c56189d3766c2b3
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 5432a42c84d6f18bfe0081ef28f4096d9fc8a9028a47facc0a1c31384516be5db86947
+Tag = 40da589a2f7a7df5
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = aa38869b897cba0a1c7b5b85665a293d101bd44b41ddb786357aaa5de4911c1f7d1af7
+Tag = 1eb75292c2624b53026d49e18246b3bb
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = b2677b9e87eeae7f60e95ecbb4b25c51f8a71f655bab054341dc05d93d4911421369ef
+Tag = 3883b5c1822847d220bd4068a2e76e7f239d83a230d3d69e
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = a05518ef57d9b7281b49e4e4f8b4dd4af7780088ee9cc87feff9b96035c86a86e2d62c
+Tag = 0c689975ac7d18b10c2982e917f9a8911ff1766e5015f2156b35abd40f64c8a2
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = cf314a0d3ee6e46b
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 6635bffd2df6fcc1b5572ea7a636585b
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 8158dd40ba391b0f73cfc4dc1b32126a5c970599777fd8b9
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 8ed9053edcd9c62cb8439ecd0187bfef58e839f01adf9f576f0447fa7b3715be
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = ddd4ec664a2e9552c05c316447afff3de1d9b650
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 4e41830f027899f13b13a6762e4bb4c07c369a3f
+Tag = bb0750d70eace419
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 8d4905533e00b012315acd3fcfb9a89864ea4dee
+Tag = 8ed941d7422cc8872c8cc840e274d6e5
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 5ec18043e6e57c5435d280fe9878042492577e39
+Tag = 8dd2d829cf5f929eb923c9e1d9824c9ca093afbe245a35f1
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 737b76c1dac93c8d0df08d6ca1a853f012c4a88c
+Tag = 317866c36bd8b49a4b4d02c5f52202036ddf12444224048183f728698faa5d11
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 11c55ff8d57038662149a23231b8842f5e34a6f836ba07a4f119b9e7ee8aed3bacf2d8ad59b0820c9677c09957eafd9ddee0
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = fa178bbe1cd9568509495b2dc0c645075895b45c4d607fb6f431a6796078393daab2c670d83cb8c958987fbbe48546a5d169
+Tag = 1af2f04d3e4e09a3
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = a0c790403856bda3fe6862590d3e6bc7cf83dd2f3bad2d29938772525511931a25ca458b291acf0ce5e93e1d9dfefd3e3f11
+Tag = 509b3966ea4c65c47449e79a3ccd209b
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = da097dcd214d4422b1424fbd2c5ee073be0f708b00fea7a0bb624b84e2b179e39378cce8c9dc2194246f2dcf8c3af578cdaf
+Tag = bdaf424e5ba4e0cad025e675dcdfca3f730136fc90782e02
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = a6bd1f55555ca0973514e7b6506ce1c5551575cba85345c5bb6bb69fdc62eb700dd7dccfc6f24aff8530f237a2e4569c71d1
+Tag = 5bce4be376dd6e8c655364a3d59ecc0569af8b82947eb8e667ddc257934df27a
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 8b1b3f569a8be915
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = c5a7ab8543e1e27c2f5b7722ade14512
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 2092797a1a8f1bebc6fb2f8e7fe901b38d8a33c420b67e81
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 02d35c86614570d1b884623f2a69c44e2cbc644b0839414d800a6f2a531fdd75
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 5c0f03e1ee6ce51403c3734675478931a96e90dcac2071db0f70c7da
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = ea0e6570a2f75853c7e081804a6d25d32ee63ab13a49986c223cf76b
+Tag = 56d997b39234fec0
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 4130e32cfef194293e58821c1face54f463e7deca25e5d2c64cc96e7
+Tag = 1b81a5cee05cba1874f7f24f07ca65d0
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 047ae17f7ab2c0d53fc3330c992a06b9b3b70e96b2886473927840df
+Tag = dbd5ec8a9077d4465a4e2aa69ad48c05b9236e4b3ea9ceb7
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 35686896ecd52477b6a2d15deb52a4bb185d22ec03dc9beb79192591
+Tag = 3e54c5fa4d2658a7903b38089863d657d72275de018c97f8af4eb6ef79309c56
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = cd192fc4e576dc47
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = b3fab8943575d65285491faa70367766
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = e566369bde35b1548ea773ecf4abfda1125d2209f96cb57d
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 4d7711ae5b32d26b4e3e5a244e34f56d462762dbccb1bf21bd784ac085dd869c
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = f837e08bad969287c67ead5893c304a6cdcbc5661df2e370a97d72c88e7c03a133e0fc1044e9bc
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 7091fed1a8028fe28aebd7508f294672cfb2a843eab63fc00fe5f5f7296db0d6d211751fc384ed
+Tag = c24afeebda630a84
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 0bd013ff3aa77c10fc570f3f45d6c0dcccec939903a40382e160164faaf42395df2f9c868851f9
+Tag = 730f087bb15996994043350c010181a5
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = b8d7d8daa130296b28506da36935f39d9a7f129a752bf956143d97459e5dc8f6b7b8d207db4f3d
+Tag = 0dce59c81aab50b0e27a3365f942485a4bb73df4242c4afa
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = d75747121621e7d6da4ba70c98bfe50edb9616f58838bf48231a63f916acc6c1f31816bb566ee6
+Tag = 149e48eb4ca270fed7b5188f92e84b63c39f6443193a82cb0c444431a7a1d5e4
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = d8b011be8a39902e
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 85367aefa757efe85e7abf69782a87cd
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = db36aa18ad719cedc81d554f72c842f322ecbfb9dc3a8fdb
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 74acf528766e60a4cb6c874805a846be7857584fa6e8f24b0e50494c0b007d69
+
+# initialize with key of128 bits, nonce of24 bits:
+Key = 35ce67009932cb64fd962fc861fa932c
+Nonce = 197adb
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 0ec7ec95cdfe1c8d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 88e5151f258f03247ca22317db422cff
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 08afa8d6bfec4122de8550e1abcc87027044dd55b29c3ea8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 70457c5f9f2cf740e1c74fa053755947b5572c21b1fd9866055ec09feb37628a
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 773e46b304
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = cdeedcadaa
+Tag = cf2202383c0d2a91
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 9c3858c5fd
+Tag = 1fd2ff556f0a145b18e925c8f419ec6b
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = bb7d99d700
+Tag = ef9fcd27a3a57c0578237e20d2b58fb8336477fc8c520a92
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 65c21637da
+Tag = 2fbb5fed25388dea9d914b7866f4aaaf0329089d7a8b27bb2b450137a43dd1f7
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = cccca8ace40e22c693cec083
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 78e6f60bc89a621393691e35
+Tag = 06cc52c53d830bf3
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 9ae0edca2e8a7c705c50ba2c
+Tag = 7eaabcbc0d684481acfeddca4d0c5184
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 754f3141e1c37de907c97dd4
+Tag = 8a5d117478b4ca95609412b70d6158d221c73d0cc2dc0143
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 27a9ae8c71b5781c4a776415
+Tag = d78aad7feccf63de84c9de0e9fe1648c8f25ef21e8ee8d0867836a96681bb6ef
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = b4fe97499a531809d66b2e30ec4160c63e3340b661ea29
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 93e481322fd30121e1961bc4eefb29c813288ec87ef9e5
+Tag = 4f6de8bcd39fda10
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 3ad4b6d95b4b4e7db35336c51951ea4c0c017802574649
+Tag = af830d6433278fbdb73e24919054d9a4
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = d229fa91589c37abbc7aec0347e41587058ade69ca9d35
+Tag = 7c62ffc9ffb096b5c54f062c41e8201607b69d2b737cb7cb
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 912376396f186e23c7d685689b2c42254567aa6866e96b
+Tag = e351b364846651f499876a274472152996309c173dbb521e6e25fe0503a5ffa9
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = d2463f457b7ac74e5ddfae276019642cbc551a6b49b460cc76d42b4c451a1659b63bff565b297d
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 08bde8a2230ac28b966490c50f7ddffed878a464c2442aaa73c263be0e756863bfbb77ac49948d
+Tag = 8d9f16775f617c06
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 49afa8eb2e895de07eab353491be6f3afb8df00addb168240bb3d6da4fd61bfac13309e90c6350
+Tag = 3a51f99b4db1cbb1823e03f1d2922f79
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = c60aace5d402a8785386a2ed3b70d96358103b71eb78c04a12f8a6e7fb95a49d86555e51d65577
+Tag = 0bde944d0ba331ae2104fe64c3a68e6f05b02201c234d3fb
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 423c90c44945cc799f2c5c5b9c146a52a4b970946c21a4024235b25d48ae56b05da483573f5ac6
+Tag = 2c578f1a3cca5c57a34b3c869dcbb0cb0783b2b0cdf84cc3d9966abac785d8bb
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 09eddccefae07952
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 449e6bb154d0ffb50909fd9e82a38d42
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = b2b975bea88966c372ec5ace29d5e91b29bba08dc9d40f3a
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 8d246664cc88122e61aee8bcd5185ed7c25577ecf894864d3ab839a34eb00a98
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = aaa3fe9842f6bc051854240ccbbf
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = d6a00ca36e55497aae68cc80216a
+Tag = 755ccb1609490bbf
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 6a2d1ed8db6ebbee76edb25de219
+Tag = 1c1b385d3f05766622191387fd595a1b
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 14046d02eb7a3536b4bf4d072336
+Tag = d3c16b1f1924699a47e4a95fd45c5027d3126527ca4134a1
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 643d81de437a7e3d7ead1f25c7d5
+Tag = f7f9485a490083005e4dd59ae823222bf19752c3a8877f5aa36883940aade4ab
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 551d7ac19d14e27d57f5aab8aa77db640719e264f695e6a71a45a1d4766e025649c931
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 36a9e007846708d708bc10f723f6a7aef44d8d40d3c23ed76d1ea99d6e4445134dfdc0
+Tag = a8e5b4217069898e
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 5a79d2f2d505f0021468306e3c9e2e170b6b2b0cbbd2c17530a7c65f7adcc9543aaa1b
+Tag = 96ee5ca2dd173a25f09a0ffbdf217bdb
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 140b6520da66dbd252e6f83056967dbdb2e4d78fd963eaab33b03bcc35cad4d5d683f5
+Tag = 3e29878402be7cef9058828adcbd5a2f1b3aa3af8a2680b2
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 6818a2564e066c55123e7ab9edec4862be3b4a46fb4a548bacce62c76d90787424b936
+Tag = a43c3784598d732b2c7214dfb4ecb167f968fa9cf745e4900e8ba540e4cff360
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 3f8f564b3eaf535a
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 2b6d268a2953c8d5499e9f1dbf8abc62
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = e66e6462246566dd157a36f1406198be16ff60c4e0e3506a
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = f7fc6f813ba250641d438cc9c26c39c2ba94229d62ae88998782a372a75b1f3b
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 395e3d61ca1f26749629f1612f19343bb51fefe5
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = c7c0f439b383466ead69826a6c02dd39a37ed117
+Tag = c5aa42f335c18758
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 8788303ffe88ddad4243e96822375dbddd5690d3
+Tag = 029b1ecc11e89ce5eb761dc6979a8c74
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 64c9b001dcc73f5afe18f27ca075729234907891
+Tag = 22f9a8f01a5a53a097879016b492ccc58a84fe043808e082
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = fff53913da6e2a12a209634cb09990f7c02f235d
+Tag = 47828e90ecc3395fcb7cd43ed0d41fcaf6370cd8e549badf37066ae8bb26b9de
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = d51725cbff901a318b31b088ac7009a1863b26327ba27f9e680f6cf959fb0435bc39cbba855d6402632f05e85027a0e24776
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 45e3f3109c62a3f4b4d0c2ad96295c8de2c8e7e41113fb0bd050802115cb1c6ba013c4cedf4b3efb4f2542ea564d963cc338
+Tag = 9011599421f7d05e
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = c58150e3371325547b3f233b9b516a93398a2bd0447ae558d572a6a18d1d99d501d76ecddd8be748d535f0ae5bc6325bddb4
+Tag = b8b56920d23516d79dab46197f81a69b
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 2ca174bf638952dc0e666328dbc184527e7ce98a12f8ec240ba80efe449fba79309f151c71e2ef7f1e8c2cd44778ae243a50
+Tag = 9e6583a2267ae668611780ff92b45a1c06cd53ec9f7d33cd
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 632fec8c735672d88a9151fda8003ac9dd816532adffa7581dc56e2e1b851ebfee738d185e0b60291b4ae2256fbbbfc55ca7
+Tag = 7a6bf1b9f8e795b836443fbc03e1b8664728527917edbc439a07c3cf5fe19f49
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 8b757808a0a9b23b
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = d8ec4300de39f9a18d8544dde12a6c82
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 41a012a5e0334891c3ef99b9e4db374fa1b442783af0c0e1
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = a64659a0cbe6a9e57eef5c139227054370f69f19a8a0894ed6f98ab2ad31eab4
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 56adc204928b6e9a8bc702bfe62477f2dfa6b7e7f84883f4a1a077d0
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 3ff306893789a8a6dcd1dab08d48d717999396f6556b768b57405772
+Tag = afe21b871895777e
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 9374966e580a0af10e1ca41446fff31e5a1eeeff83a560cc5709f831
+Tag = d28dd65cfcb7e246302fe377078bd058
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 7aeaaa70af68c69dd232f34dccc5da34cbfa4ca2719a9bea28025233
+Tag = dc889f33fe248a6bf2df62a7175c1f0bd821e8bf3a7fa3ae
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 3ad7d53c435e6aeddadb955e57826802b4b6969e70930b919986aaf9
+Tag = 730a5c55e7994d3b21145b8364db75ed43631282fc3a24b09e54a62d7d33b76f
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 1df5823b5db31201
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 538438d006fab5c4dbe6174f5ac9c581
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 5bd56d7d5249fe096585065cf7cfc3e3a6e3d51690ca3090
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = bc41f82843538e94cd9f497c29e0249bfad26d43f2e597bc66326c1444755f26
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 521c799b385d3542dd9ca2e9a4a1072ae95ed26daf793d944d9a067f693a911b6fd3e7f0d007e6
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 9b5d2460ed26b510705477b065361f34cd6d7712ebe5a63f2b1448c7b06192c89426e85ab29174
+Tag = 6f6f15894c1e69e1
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 30831deeb332cdb3ef86f87147e6e87537ca61967d26a50967bba706ce8fddf47f99697e8fd78f
+Tag = b2015b696362d793d615f795dd68e3a3
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 798eb66bd6e118fde5b5f1eb37bb10277d72bb88e799e6d5bf11ec0bddc1cb27d68772baa168b9
+Tag = acac17953e9a68bdd72c28785d32c7b11c47d0215f543995
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = cbc96d202bf8d170a0cc6763b104782ccffe5023ce08695b22b872d5316f29ce74fe5555068184
+Tag = 47e734e6f5ec5c66b9e8123285bd2a0cc47004ac72cff955fd1e74c8b19c67a8
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 456bd99091ded393
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 77bf3d8b5e89a258076232cab8ccd208
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 6ccff453c982b1cd2ef2aa0a73eaf804b4274a9f529b4a04
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = b7a351ef06d77635f7fb1f8dd11e021ab11e347a843d11e86d7ab761a01164b8
+
+# initialize with key of128 bits, nonce of32 bits:
+Key = 36cf68019a33cc65fe9730c962fb942d
+Nonce = bb1c7dde
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6ecf2c9906a1029c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = cfc29a0b1a06b6aab4dd05464d0cfbed
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 590a9d963a7a867efff7baee652b4bde3078201ff91532e7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 60e59f26324a944834056130c3707400f357a4e7326d46afe82099215ac81a5c
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = e5268d5633
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = db56b5fbad
+Tag = 1b2705a29eff5e9f
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 9347c29d9a
+Tag = ccafdbad8541f29776fcf5eb08a8641a
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = ebf007018f
+Tag = 15c018a98ac449794c28f6e1b03debe605e6623b09ebccd9
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 94c8687194
+Tag = 084bc2061a906ae7d07c0af2a9515ca7e2ea3c5158e5361225fd5acd921c6c47
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = d7bdfb080ab09baf0490be7d
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 2a0716af7390a86b938e8c8c
+Tag = e5a574268d32725f
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = c111ab3d96ee4088e2b5425d
+Tag = 81ddd9bfe05614c1fff5c319657a6e26
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = b06a0bd65bb4094f4e6f5c8d
+Tag = 15cda3df455fcb43f121fdcfad09d0f15c186f416244c19b
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = ccedffad1efcbda95f7376e5
+Tag = e62a080e1c61de6b77aa847d7db1dcb33c1f234af9492c7c130eb76502bda7f1
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = c58ff9a60206c12d8e14ee8b47e2213076b0d516a6af5b
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 00ed919aa3098ecfee87a0f528f81af6560b6b4c649fde
+Tag = f8bb67aa193ef846
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 2c8f0b038ef820287895a8d15ed7666e92bf153b68b982
+Tag = 43e1e6ba752335c78328e0d905f5312d
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 9f9c1e8f2e1b14fd6ff0ba1814bab7cf5596485bbc531d
+Tag = c1251bedffa1f7f7b4c84753cf25a5b9501c52132578a6eb
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 2b53d6ac3f7a6483f131f699a474d1152c3e3c24ebabe5
+Tag = ad12b7ab0e2407482784f3863c882ede56d00383b78a9ba09bc50cc231fd3c07
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 31127d9ec24459065fb469d8213b2ae3ab5b8414668c6f9db98a9deb5a69c8989918e01178384a
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 3e8405160d017f7b574e1723361d7da7e29f9b7c9ab22c34d3a84c099a150780308c165b3ba4fe
+Tag = d12fb24ffe61ad66
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 00e3ff00752d0e9b72b38a226beee2f562d9028eb8b4c159abfdf47e50f236632947633eeeb9a1
+Tag = e1cbc4a33071978df1bd25b62ac933a7
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = d4a0e335e757f9d762fb607f940c4b9e89599e39194a49a7527188952b6313c7671c71f39968e9
+Tag = 011f1990e2948046b3fbf8551f8a7753a324f29a432b3cbc
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 93991597abc583578a28685365ee00b1085790d126bc0fcf5223b3a6bf2f022e1bb65794723a3f
+Tag = b98b5952eebfc9ad3e6b3ee0ecaf29ab3896c2dee44de90f0f5390a6366b5801
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = fc14d1f411db6b43
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = da3c4f830ccc3b4c602cf1e52e523d75
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 17085bd2a9dc1c9c315832fd012c629df196fcb7317b7e04
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = b54fdd08a8d7dbdbc904858ab2a602828f2a58e93e674b37f88e26f6bf084f1b
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = f5b29f8dcf24a5c8b3eb6f043494
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = b112d1c3eef69f0457b00dc3d8d2
+Tag = 644401261e20b931
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 42ef7b923f84e9bbc52fc88a9af1
+Tag = d947947bf3aa8f99178185044367bd81
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = f6a7abdcbd970f1ced6f06004a22
+Tag = 20cf462fba53d00e4eac254ba3db5c48060487d318c32c42
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 437ec94b2e48bb5120981a283097
+Tag = 9e1688140a1485183b75332fa8220a12ba86e62cfbd11ec2b75f050315df00c4
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 63b54d284d53ab7a040e3b6af426299b12b028c9b94d1c429fcb822419340f3e8e7ead
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = f01441c09f0a29dc431a2c1a146b223ba1f48725c15c699e15d6b1f73000ef416fc17d
+Tag = 28416f17154db460
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 7a0f34502a7a6bcfcc5c9d3740e786bc194ae2ae11f9b3f4d8f10f68c0feb91e318fad
+Tag = a3bdf3b2a6986046d52e3b8b4df86f5a
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = e8ad6a0a41c511ec5ea9090a17f21ec451ea8ee21c05a87336742b74ca41d2961824a7
+Tag = d74a1ce8362a51d9665a908197a43a62350afb4e3353ba61
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = f297f5c1b95550e696d1a856645b4ccfc19b809fcc274e8066386ce175266832e30687
+Tag = c3ecabbe4b8e46dac3d85942a8321c44df6df1b674ae6cf423262b9bf0c30d2d
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = f72ac51f78b0fd86
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = d19c6f251ae91bd14472470de1d06fb0
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = cc9e1e1040b303acb6d822d0fd5038170812a5906f387963
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 0112562c866e5d8a4d5b024c8a487fdc834bf3c5c278a911798b406431630f54
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 510149b9b8ca96b0a678938b16546af2242256c3
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 094d6ed03fa79ea8dd0caae5f0c4c3d37ac32892
+Tag = 7ee5ee1c867216c6
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 5c3e73f081b115178dd9ed1e0ac0e3bd33d29d29
+Tag = b3be09344f40a53844482501ec9d1905
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 055b5bd4a26c65dccd8af43087e23466c5f1889e
+Tag = 18be8dbdd079426b9f04a2c4301066f4b60172a1467c7165
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = daf7bdf574e74fff71b4a7efa76ef1a21643102d
+Tag = 81bb265addf272e65cc4501c05e33948cdeddcdfc2b1d9e462b08b553f3fb592
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 8548d78b983293beb411e0fef0879fef329f758febc0d666c8601c2fcaa630cb093389860cf85aa020869d370181bc318a43
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 914a481533b48e92843cafefafd4aeab282eb8d4b57258714489cfd56df51f6029b6c8563e7075d7388cfddb196923ffe4eb
+Tag = 0935a31c9f806011
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 5e36ca396bf781a544cfc253d82449cd4b695ca02f6d31a732166f5dac23d4c976d66189f56cfde81c9d52b305ebfe558c48
+Tag = 96fa2a27defd490fa05e47f02e7ae5f5
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 6241a1a60786630dc1024cf348e7ca8df105732e118f656b26ce66400487eb5afedf2791be672b360e4af269fed7834de73c
+Tag = a94df6aca4c3041cc705f0238d5e6607bf57f892c3c32646
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 3bc97b7fcafaa684ccd0c624a783cba2477f73ea498c60f6cfc356724c2c5653e698af1eeefb2cf9b8095a8d99e1d9039c23
+Tag = c4d4b6ace01f572409fb85efefa8429ac6ce56dfa90ae4db9f05422090f889d1
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = b17e246a4e496c1e
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = aeda9ec107a133b793b705297bc3013d
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = c09c82192ca16b6c39ae9abdd84fa769752c11f3ef1be664
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 69e3d7676e77c5ea72c602c65833cbb6fbce199ef1d0b40fb97f572e39bfb6e0
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 848a4037c149580405624741b567d7e07ebeca2e9887a3198c6f2f6e
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 40a9e8f09f1cac645a338615a5041bec4774aca6d0c2f2fb3309a72d
+Tag = e028492c2c5755f8
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = d44dcecd093005ada5dd9a36d8a6ccd603b47a178d997410376a3270
+Tag = 4ea44136b4d3975a03dda585c1762e1f
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 3059a78a598413fbb14ec5ad1140b8109ae84eca7ac2d06ed28f10d0
+Tag = 817f99f6e46600ddaee73f3e8511b907cd5f3c981190f7a5
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = bfdddc07d66c9e4d061bbeee8b877204e043d1465c688131f06b9f56
+Tag = 381d4e34ff993f6edef962cbad18c03eecbaf7e9103864950fd5291e2893bf8b
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = b6c709cfb4b9fd0d
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 637432547d386afd15fb5992b0b8167e
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 6749d36df218a437eb8b98320a7639ad39c8d3523188dc2b
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = ae668efbbf9d62a2e864f96c77b7a668db9b90359b506e1463ce7948b3f1f13b
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 8974cf23bc39f4904a32d7c07f76a534150e30242ccd2a62a53adb42c0bfdba2f964c2d0f77201
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = b413fd6fd55e15bd7f80e23d2b907a21f05b9aea7300453733902133c39bb95f908f68534c4e5a
+Tag = 99e85aa19362c1e8
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 88d2d082e3788a984134818d6206fbecc4878f72fe94d56e75b344a88d7082a7650b937be53966
+Tag = 113ee9ee6246a123fd2e41bbbfc828c5
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 780ec557956b47147547be3ecc7faf76aad7b19b0822122d63df65ded2cc0b6344a1b19552786e
+Tag = fa77fcc8c1cd19d859e5cafab9e9dae55a67c6d8642f6bb3
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 691f966e6ce5a3cbb474822f86ccc3a4c6facb4dc61599b30e28ce9dd532323b4ef59e2cebe910
+Tag = b6236806fe94f3121c284c8e3cd5c570e461dcf243c137e5df87495fc8411065
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 4e0275c3737e372c
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 87eadb97cb28c64f614bb7001d0fac72
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = d0c03354496171049d1593e22af6320d318b8a65f5cf8ac5
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 9ef7a4d6469cf01a13b60cb3fcdf6a3d79db9b6feb3d98de27db08d5f8e4d8fe
+
+# initialize with key of128 bits, nonce of40 bits:
+Key = 37d069029b34cd66ff9831ca63fc952e
+Nonce = 5dbe1f8040
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7edfdc62614045b6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = bf325b7a49b242a78379a756718758d2
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 174719d370b76e90d61e287f3c7593653d2bd6d99395dbcf
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1074d954735e04ce66921ba91199c9480f51e8a0d6c1f1386e5dcc14d2ff514e
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 741ea9ffbd
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 47a82473ac
+Tag = d448c99364876024
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = e533a04490
+Tag = 07e9d7804c15a392f1423cbd58c254e3
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 6fe28feb4f
+Tag = b12af32d6b9b4e9442e9ef9447a9c9de9f6d16a494a3f000
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 1bdb758646
+Tag = fd0e9bda3609883adfdd73e5c06d0dce853020d93416b2093f1809d3d26967c7
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = a75176a9ce21e4f682ed80ac
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 52a070c38d95b8e990635d45
+Tag = 324a2b94a7091b4a
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = d8ffa196f932cab3925532cc
+Tag = 80511abddd2797dc75685b221710d1c8
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 7a529f2204d6a22e96f03ca7
+Tag = b39f004a63bea6af015951e193620e880441ba862086f150
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 2c4061870a76dd3f6b754ba8
+Tag = 82bf27a1c4e6c0a41fa855634eb53ac875c1b15b2bb9ef8de72c0bf98706a619
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 75bb816c1cc8e32fc2df8695b5a591c959f3890cfea60c
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 615b09ce953e66d60460fdd65b54e88c5b53ca29727c0c
+Tag = 4e26810fd86fe1fc
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 975af7b178c6cb48d7012b1666f3f968b183a38a7cbd5a
+Tag = 784b428ae6823d1fb3e630c3df40aaf7
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = dc00d0851f7dac08983d56f72d71aed3e1866fbbee41e7
+Tag = 8b807616d9feb8f934b46cd89e6c21ebdd6103bc1f692e3f
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 16c70ee505748566e3a894312aba044033361202b4f723
+Tag = 78534a93fae643970f9861ccb159ade5c7bc411406fff20d34ccaf7817147f02
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 7a52415977df6e80221e1e7f5ebdafd81cd3ee88cb8c89eb90ff0d68c67c2b95d5c4b8e2696f5c
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = ca26dd0e9ddbe1870532502591ec0a867604fba724843d33ac46636b721138a5f26016d61db32b
+Tag = a31130a08e2da23c
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = ebde6499d4ab608a76decaa087752da15dab50c3231adca9916848fb764fc83da32b1641e563ea
+Tag = 5d9d8e6e3f8f7e36ad4689587ee3ed7c
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = c72c5d97380799ecdfb7b0f1d9f7ef83390094e65792d804c8d01bdaa4951078a0a407f3c4734f
+Tag = e721ba210ccd6ee7ef0551333229909e178087073083c8c6
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 9e3e5b6d52d8a514e2c76205801dd3f5e7a83b9cf780e21d4d67f6eeaae43613cc5c7d6e9f8c06
+Tag = 391086046dc942a31c01bc647026fe2b72d828460358eeb62fd6a12a23d6ca5b
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 438783d8479bf6a8
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 90f7e3beb94a4578f1dc39a09f2b24e1
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = ceb48101344f1b2aa37d14f6d1ee3e21713af5eeb28e8c8f
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 89ee9867495fd8491b7a81a07da276d2c90ef1524c51472d839291465bdc7d4b
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 2117b23a4e004d4c5ff21d7ffb7b
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 355cece5fd35340bfe933b314d1d
+Tag = bd52cf5772168e3e
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 91f70cac9bf03efcb7f7cc645394
+Tag = 559f6df04f43bc0c599f3214aa1b1fda
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 33e454490ab893feb5fac358b016
+Tag = 7177b190667268f790c5920776493dc1909f1786b8a8a53b
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 928450c41092a560f8b174bedae1
+Tag = 173339d0f330e2f7761f3de14b31047530cbc7b3b20906ff3ec3cfb79cb28133
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 9a917db5b906ce7d29e6cbfeaeff5ab5aaf004b942f23a84ef5990f7199895be503409
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = e7d1e24db934927b548cc70678f47d8e6431eb9e5038a72be8490dd8d0e7314c8bc2c8
+Tag = 12edc49a94bc9150
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 1df8baaad1c092964fd669c78a197ba8e26bb70c48ef2412556873384d6f125e7cbb43
+Tag = bf20128ed5f7ef26c90f473d0dc614f9
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 59a7487d5d3025bb69b633f71c87c5f6e130cb5da9e3313230ab2d46219c1b8cb741fd
+Tag = 86591c7c9089ed038bbc539231578a9e7b2f599cdb171f26
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 72e4241647b47b0a0a269e35379933e994eb753c9084e7d4a1647748f86d1dcdf5ac8e
+Tag = 4821e045197e28d4d1dd20591d2acf0e164f2b53de0bc7ead577f88915d450bf
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 5368123958dabfdd
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = a1707c33ce0319f3e5bfea7eb919fae4
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = a561f4f86b750afd3c86104b6a504c50a0a215d5f849042b
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 2bfd6f3bf7818c38affa6192a1ea23f9f9d0a8e6395cecaa51c18cac2797d2b5
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = d051d86ae81153366339fb4e0a465bd3141e71e5
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = dc15b5a562cc1f3dc4e2d8475cc356e65763af9e
+Tag = 0cb3735b89c4e1b2
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = a14745812b93489b1bc020a2e98d05815703ce83
+Tag = e76ced3b3b80199b627cefbafcd14f72
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 514541dcc09c5fa39a512b07d60ce28f25de21f6
+Tag = 8a29c340be8f1cb5299c9cd9099fd5036e0aae147211d7e5
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 2b229a894c3e83d36e84ba98202ab07833ef44cd
+Tag = 40eac4de3f3b57b45b07e2a61ebc4bf5108d8cd679fa9c09bfb3dd059895ee07
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 62d6856e1175f9c6e174b9dc8fc0673b1448f083050cb62cfeaee4930ef7e7f4597059290c8f37ace1894da9566311ebab28
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = a3080113ff95da001344a555d6a05893ec1a8891bee210bef29eb5ed59470be0e95ff3553d13b4483d77a8c29d6d5eacf028
+Tag = 192f66e6f2cc5a6a
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 23bc7fb461dcc16381eff52c59267fcb815778ad29d732674a6f50de9ea9227f35a91a0e04bd2e364d5103f684ccdd6cc953
+Tag = 2818b4e62760b59acf0c72a5dfaa204f
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = b8eabc1685efe013d4277a686556947b7469ad4303b66ad45fbb39cf1dd43a3d1ab07b142e24ea1d91c8793852182466a31a
+Tag = cf7c7bd9066f68e34389dcf175bd25c9c6583cdb6cde497d
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 5c172245019ebc33e1a81afaecb5d149b84edcfc02d175db003f4889b3f99acc06ebb9d96e0636b9c186fe89fbfa4a819d0d
+Tag = e130b61a34978d5edc908ee8adec9b6372f425dc26b60320e158e48a06ae40b8
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 00af24ef50c4e9cf
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 0aae6adeb62b7b3136b4a226b5bd564e
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 4e661dcff38aecd5e7b33eac307bf3b1ac92d806805dbcaa
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = cb29ec3ef268b478ee8c867dd2bc820ffa0b07593553adbbd8de0a013ed5360e
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = bbe7b65bd7dc6fc68285a8556b2e8d24df1a0986f8919c9ee0ae0a72
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 8caebb7579a7ae91d8f3e7b6f7491d996028148b680c19fc95597e8b
+Tag = 782a9d35177be43b
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 787fbc131d39f63c50933eb7e00bdc621fd5c77cb662e1026fc8a728
+Tag = fe8ba0da758fb46688cfb66221a71986
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = dad42c81b027c5e2de39447c7b6ec278c1760cb693baaa7a9f5c1e29
+Tag = db48024253f3ca5d421360ecae926efdfbd4db7b634389f3
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = c0c43844d4385cb2fd83228d98165f62c96856c3772cd027a8ce87c7
+Tag = aad996ec347e0e664842fdbfe5ba43f2859684c80bc37941eb55457262ab894e
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 21c5255333a43cc6
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 24b40705eb4f74e1d9489f01101b1511
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = f6950f072b3d74ba087cce53587425ab80cc19e509193b86
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 16544b099cf3b91279287df503c24f1f349c38de8f88848f41093728e12fa179
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 430454e29753425100532dea60eb024aeedddbc8241b6a5208b09c31218fc3265a230b234f0275
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 7c03f02e1c484a002ceedc6075208c3c700ffbc2545116dcc1037cfafbb3d314a038ff48d6dbe9
+Tag = fa53e6b05d2f0fdd
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 9630dbf9b6a50f0a3fbe6518d882ea7360cbc31929c7a650ad05e114113b1eaa718a6a0f8f79c1
+Tag = bfd5c75bddcf269819da760d0d6097f0
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = aff606a6ffb9e6e8771376614c1eec40fae7b30b8c014fe765252e2785364db1dc93bcf7896bb4
+Tag = 35ce57c104d12c1cb0bb08f7f00120a76e045ac0985b5d73
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = f985493b62eab9bbffc5b8623b0bda00d53d1509cda8b4a5a22834c7c1d19f132e956f85ca4b92
+Tag = 5a8742ca16733daf240826bf5b2505b376fd9553b3564b6f0ea222dcbd873e98
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = a11ad45df4a47edf
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = a63cbd3417a1f2d74bdaaac154b866f0
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = da7f2f90188ef8d67fd5e8e51878ec5059d513ae2f2e902d
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 2b6c492f1a0444436af26194b48c0e92fe2a0451437844a3b07d822ba6323033
+
+# initialize with key of128 bits, nonce of48 bits:
+Key = 38d16a039c35ce67009932cb64fd962f
+Nonce = ff60c122e243
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 60424bf8f3212ce7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = eaad6dd08381e531604cd8eec8706d7e
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7fecb4d303d8aafaeffaf2b424e3db7885f26d5e668ecfa4
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4e08674c1cf85be520d025af0c23825b6d70b5ae2ef1688bcb62f5202b7dee32
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = a9ff81c171
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = ff3b3014f1
+Tag = 53b22a00ed93f11e
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 89d38c014f
+Tag = fd74728dcbb92590b29ce558c925c21d
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 8357c154a5
+Tag = 0f58ca78ba20345e3db3f56591a2334d882221b4ade45f07
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = e2e0c082d4
+Tag = a8f33be4a9b7de699259ad63e15a3daa44926b5268ed1c818f812ecc59105d3d
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 0405399d955809d7ff8535cf
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 58e04b7405f5dc639658a9f8
+Tag = 5a17d6a602eeffab
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = c3112489c7e71761c59502e0
+Tag = 7c2c57e5d0a320706cf0bc05cce19a11
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = e3a5c1c739de13f41b2f24db
+Tag = 9e5230a69ec2dd29097de6a09b4ed71476644d560f9a4bc5
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = ad568b1156b1b9cdd2b99220
+Tag = fe263694eddb3f0a628b558ebc46a4258d881a793dbea2a587b368b8ee8941dd
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 4bbb797a7161ab265911276e953213c9ead62d8cab67c9
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 1bf17b96c2ad0bbd1955970db69ce9a6dbd18ddccd3a0e
+Tag = 9a1cd9257f134fb6
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 6aa277b0f3903c928b7cec7f75786579447933ce595681
+Tag = 99e278739235a13439cb3c2bac33144b
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = f1b57fc7afb041f2c4d7e00df8114a8347e2c5fc273642
+Tag = a27d4d9dae63ea81ec72eb1bd4d63e0c5454bdce4ec72089
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = c4cec25191e41d41aa526e655e16b136a9ff9f53a189aa
+Tag = d36a8a1ec65cfb73e100c012a5ecb38cba36058d071271b37e4aba0f54766808
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 7f6b7f0285c3975b9d95a312f739b1bdd7ac4d7cd5f37a03fff149ee7e57a3eaa7b04544eead5c
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 74240dc5b0029d48b52f6fb028f03938811e1d1ce73275badaefbd5869bd3d8ef7628521173993
+Tag = 4a97283567d7f624
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 7b4c3e753b96a1bc2bce8d52c804c0ab7804102ee707a939f23fd1ada35362e94899b631e073a2
+Tag = 8cbe2c43bcbe62e3fbf3db07e70e8a81
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 7212ac5160c94cd228887a6761e1de621178b6aa347b9181d66fa52359ef21d006df115ee7b171
+Tag = 2dccf0146fa5b1d1e2a307ff12f8c2c18110fd20df6933be
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 53ec3e275cf0edf508459d41a94189134c2fc2ebe99c34cc0abf9bb448032a9eff3d6c32531691
+Tag = 4a17095ca3e4641ee65ad13f8f1284334c01b878e9ebad64758b4738afca703d
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = cfc7cbe6fe53438f
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 509946b43d955ba362596c953d8fd6b9
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 4e322a7516ef707168e088c1d4fc27deb200368ffbb03efc
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = d6a2c0f9f67c82811f37b61a08f2459da98d5f5707500640151bfdc14d66acf9
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = f6f40cf37dc537380fb98d99ae3e
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = beda092e757b5f6cdcecd57cbeb3
+Tag = 22272238fcde6476
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 2db33cbdfd2341d666895f6e991f
+Tag = aa14c9df352ef99935cb5bb4f4fd0e84
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = ab6c07b6744076ee5ea9b9905605
+Tag = 05407745e8ca70f8d8055e0db77728772b86570aefae745f
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 4fa7a2ae7aa6b1c2c06a2883728a
+Tag = b9b9f84eab04d4a42f3ae9fde233cf6591dfa59caf849210a63d1539b1ba72a2
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = d3ac9c0a2e1f083b65533969077306cd860feebfd52494a8fb8d814a1921809882bc2e
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = bfbd2eb7b36c71339e0952dbe018fce17551f08f3486931c373bf34285ba5ac7f11552
+Tag = c60bb723bed3b345
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = c469f977c396dfa4903b61204f36cedef1dbfcff8bcd210db048792fc902877e1e37ed
+Tag = 54ecfa22d5089532c80d3c3f003a5ba8
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 2f1b23dda19ca7c26808f3458173af932727965a790f53da21c2a8adb0a37cb8ea36ed
+Tag = 5745947f08a2f661bd2e6afb711372eb4b9f8cd66d87f78c
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = e8adb9d5402efcaa94feb9f39a07820e805d2ca829834a92a8433e733f571ef64d6b29
+Tag = fd05e292d221f71fed2b1f0342ee1e99be8edff102be32ef2f4c56f0b1e8c046
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 880e4765f2c27f1e
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = a07a57bbf0b14e2612aa7d6edc474159
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 0f0a5ae04a87d79fed2656a8d1cba0a003da6bc18d76845b
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 65652c72f8c3a2981b8501c8acfa49f0121cf12de3feef946cf9bd6954cd64d1
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = d595055810ef0b664c55f9e179ceaf3be3b48f88
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 88804941eedf2ebf2bf34d5019bd91e27506d3b7
+Tag = 6ce0cf82190f252b
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 10624bdd27422f44164697a975b38358756b3bd9
+Tag = 63f67293f07c38fd35bedfe583c8fc73
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 08050dee10ee00579566e1fc01ae0bfd1f2163af
+Tag = 94678514b813d1e3ea2240c3ad8fbae2211156a7b712023c
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 5b8d508f715a720857b137c1da2e979cf458b949
+Tag = e380dcce12bb92004147895d73ca96c5ee8c5cd1c6f89fa0ebf2bca4ef488335
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 9bb0dde9ebc5a4f7de589a9f9dca27a938e412b4af91f299790e6d52bfaadda203e8eda057ef698eba3e64735cf9d132c7ff
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 3bc902a63c27d7f54eed29ed1ee5763af13069f0f367afea888365ec7eae8b279989b8d399f1a29bc9250aabe66ed67985f2
+Tag = ccfe9532bb5c4619
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 4ba4a9e475afd2386f36b34524394246ed4f243fdcf109db12bdd7d5838252085f3a9f63ad4417fce22a562b6aa3c30337a0
+Tag = 10ea3714c1d5143a6fc0ad984c54a2e4
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 9d61cbc6d04437ef879eee94795aca76758e1fb566c116443612a1d6821f67f6c01a043b4adc6d15d9f75b76a56a8f1c1dc1
+Tag = e45ae30374fd58f95cf82cc0ac5f459a4af1fa50ae532415
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 1273e5e649638e7bd86226671e4d81084f251ef00228a4155ed8b60de585b3525c23abf5ca0a092dceece6cd1f257319dbc5
+Tag = 9077965d7a50ffe924d131039588c1f1ad52e4b6641ae9495d4c0ba17bd78501
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 4a46c56f20f36c28
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 9a32711e3f9dd6ce51a0d4bd62bbfba4
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 4d654bafac98c1cbd2306d52d9c8c7dc53ea53c3685301d8
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 015ab87ff55152c8256106c645dc03955ccd0b738691dd0ef6b3f24444f4f502
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 2fa29f2ee35655a62131c399e7de5edd4b4753ea5bc1a908110452a6
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 7a0cb137503d0b8e2280a85414bf197261a80892372748f1d709f368
+Tag = a2c9e62926015ce7
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = cc1e859d7c960a7f896fc32c6567b434013a772850e56aaa96993471
+Tag = 979fbe49585b4b97171628474c1e18bd
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 4bbc66f11b04107b1e70d90a154a5e7f42f147a922c72360f4e569a5
+Tag = 293e599229815535b7edf4295d28867cfc889c87636e1b95
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 479e77105d90c357f33998b24c7c69e8116243ff8e9b2f8edc6c246a
+Tag = 067ecc35fc304b2cad6a68d75511de81a2e58f4ec2508d22b83f5b50930baa21
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = e27b7be9cac00aef
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = b0123e3282969417348bc13f6c54ec02
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 10872d4ce54b56b2b33197fcda9c1008463657325279519b
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = f5dbbfac64330e9b05743adbdc482a7f277b2ebee96896d776990d230bc9d61d
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 104155e14fa112a5aa7c523407d7ede1b151dba6e3f023e75c54ad0b801aee5ca4b3a6aa66435c
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 887decd36fd6d9199e5db5de46fe06220f24dea615057bde165b5a962f098ea0fae34938139d17
+Tag = 8b4f46bde82e954b
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 8ebdaf4f7183f2015a02a302316d5de58f659bb92b20f72b1cf109ca89b818deb6326d8ca20f8b
+Tag = 07579828ea415ed1113e4883dff748ed
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 4428798c9b2d85d80df311032b7c433cc189d582ae6a5db394fba02e1c1822132dd60acfa09f07
+Tag = c6119e1c5a1797fd3327e20d13c9d49caceda00f74495c73
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 1103bb49d86bf1f21da6d838f8a68a13f1a3953de32a94c78450dcd2a49e8971bde8025ef8323b
+Tag = b33bf9d3229881acc3ae65bdfc844cca02f58c1a11d273a6fa3983a616702fe4
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 1dc4f37f2c0f0064
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = fc9c1e0b3226770c0fc05846f61d91a6
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 965cc5083fcddd0cf47b17778584e45d4f60b45da1546af5
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = f6431bba1fa336983fd326f1b463809f5b1c9346f061132c3b0ace4534211f38
+
+# initialize with key of128 bits, nonce of56 bits:
+Key = 39d26b049d36cf68019a33cc65fe9730
+Nonce = a10263c484e546
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 0e28a9eb75b2b2ce
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2248aeba1d8af9e7975ff607e7a85907
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 47b2711ec1ba034b52285aac414873eb5f9a2d099c9fa405
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7ccc82a20449cb231490dc6e9a290b7b493a4239853f7dc80cca69f37e64c992
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = d977ee3482
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 031e5ec359
+Tag = 132a34b8c88009c3
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = c9c4bea513
+Tag = 4e6c3839bba4e6e71e95242422d2c5da
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 6df3b9ce58
+Tag = f0182920e8aea7bb0cd223ae521c74ddbcce3d850c6a8458
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = eaf2054291
+Tag = 87f836d5d1f3e09328ea1713cf503827f9519a36017ef19e59245c0df444d5cc
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = f259e2ca5fa6fb2a09850a1b
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 1f5f87e316b25ec502ee0752
+Tag = aaf35b0d7eaf49f7
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = cd6f636a9ecce01461c11c3e
+Tag = 64a5a5a03fa4d5d7291b1a5fc08f78fc
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 8ba6426c5bd917ebce5a51f0
+Tag = 1c5b9bbb8dab0341c48e5d40add57ac4f3fc6074b5ebd77b
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 191a5ce5a8187998004f2911
+Tag = 5b8f6f85b8dce13383110dcedfecbb2f9d6a79379f3261101e7f4a122ef10f56
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = b3ccfacf10f7560fc223bc4937d46bb336feb364a2a3ad
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 4508c8a28ec2a2407efd9e84bb927e942b923a89101366
+Tag = d466cb4145fd9f65
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 9e39e8b0f397a7c0160dfde6057033a369a9501ea6f772
+Tag = ccccd7e85298496ae6695f04e8546f5d
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 5b91ef1bb71ec1cef75d5f2268680a3cd4b1b0838e4b5b
+Tag = 7030168217a2638c9b411abc833849d40627078baea84531
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 9d8c1d71f486c0fb2769485da10a0038bbe81501d08286
+Tag = 59023c2bf21c67e1738b67febfd6d56bbe458a7d4628af31c33e6c2ef400e54d
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 2a94abb19218d5be1bb7ab117e07fd9c95c9770c1d41b81d6602f2d82d22e0a249adfdfbcf6b46
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 95e5113a708c4c7dcffd0e6468166e96984dde3cfd352bcf002030aa42d752268bc2102e6c4ff6
+Tag = 7cb4e55e2f975175
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 5aa836b4d7d6885ab1d03760d3024c944eaf48c07da83887eaa4c84c6e4e79eff28e4e25066a22
+Tag = 80fb066a003a7cb69c206f6a92d3e49f
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = d1da1bd840f79ee07d66e711b7f1751ca19fc1b41414f67f4963561a89cfbd24d24dfee7cbf56c
+Tag = 911b55e7db6058e2007a866ead088a0848f9c5603383e006
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = ae9b8725525c79fb945940fff2536298b1f8bf5c7c76906311cb53d7c2b860333bc0698c98e5c8
+Tag = 0a1968fb78960b1991e4884ab57c50e5e3c92b817a7f476fb10f0222671bda5e
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = c4d5a3bcb03e9378
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 55e4db6dac2a524e51e68d7bf37ca868
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 15d8fdf6129dc84909096fdaf8fbfa232c6256a3b9117633
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 3abd63b998e2800ac8b413edc86d16c81aa8611dbe475999f58ffe8d8cce1083
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = cdd1ccfdc8d6cb6c035270c895c8
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 889e2fe219babb6efb5233a7c3a9
+Tag = 8566bddc5ee4fbe1
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = e421b4c4f5cc9da4180f5f91ed47
+Tag = b6dff4a13b4c8e6bae0ef088aa43f2b1
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 078359b7a8ff18af794218146339
+Tag = 6d69e0c4e21822e85cb1f5950326af840e623341b60b585e
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 2e6e51e9e667344144b559d87964
+Tag = 5095e3a04209a6fd744618130884225faa2186814c722a75810f7c2278e5dc2c
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 8a3f5f47496e5f0d977bc40d23c36cc46710c6a04103663113b2bfb320ac6921e3540a
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 4ad1c967ec1188a30a7eedd85273071faddace3f2d2a2110d18ad537f35756c1393812
+Tag = 4cd74326e35273cb
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 57bab78acadfe33caf61e0e821fb3f1774b97dd5b85cd06c97aa29bea199bd386d9d90
+Tag = 36b31ca14fca254f3e16b5e7396cb2a0
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 556349db9fe6b40dca830095a598aac3d2af489fcbb1d2bc1dff72e59848e300bacd95
+Tag = 5255da3fc15e277638cb5e645b805a2c9674ce097ec811ba
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = afe9df32474962b45c564287caf940cdff47702d43c6227a4ce5070af3738d325ac671
+Tag = 89821f5b0e633913b4d909789d8309e8da680aa25bb7d01713b9ca574fa0d75a
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 23c169e812687292
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = c4fe9861ed0b883d8e822ae909990b08
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 8721a43960d1921fba0b79cdeb95799ffd99915cd6e76aba
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 3d53d92f4f4d8c61a9f040e7c0c13cf3d45f0b14f7834faf55af4fb719841b0e
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = cfc096c3e6b0680a1706ae829726954edbf2d98e
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 4609e7e8cf7a771e51ad3aea8f11a710ce019d15
+Tag = 9cb2817ff1b0b524
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = b5ee13ea53a7d90c1631d0667891d3061221ebe9
+Tag = bd09d5f87d53d975ee73ac838811305f
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 066db66a7061a1542f4fc2d3464d07a5d8030fcc
+Tag = cf501888e218ceca10571c033fb7fd4e64cccce3ec8f6ead
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 9a57ed9a50f5446a038e6c47df189922aecab421
+Tag = 565833b883033987223253f806aa9f7667357cc81459604a3b0473eae4485ce1
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 17d94d7c838c6e916f74f288c4bdebeb727dfa8725c1491b40fb2ad482c68d5deb32b88bb2b589e7ce0f2d0b780ab617dbf0
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 8bcb02cbe15b43c66d7186bbd7d58768055e7dc11b71cba837749f910087f611b5bc9b50a060f97f21fdad685db9cc4644cc
+Tag = e03436b819817f5b
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = cf52f967a909f41e5fb2cc2d3144e7e0ebbc0298e5fc14b9d71c87800a80ce5b27bc8e59938f206a6d046781807f78bd64f4
+Tag = 47bc0206c472e87ae9b96cdafd21e8b0
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = c2afc5f553ca4a0b982c8f37f56ba90a3e7b587366e9d0861e59c04d74fbf62da0381955850ee7f7db8831e470871d4afb72
+Tag = f19f40611cd82857b9e7c1a5e1332b2a9950d5ac6476a256
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = a78fd99cbb82d1ebf868aec9e8ebb1f3165b293cc48473a0278d8cf05361c46a75b8782d7d594cde24c202c9bd962f42c927
+Tag = 0ee278bc2545cf7266a9e4d84f625d752c36f8842f49e9d6b946729252976545
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 7c21d3661ddeca4d
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 579780a703ee2015d6fdf196d51379c5
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 865c0cb5d99d241931f272b6d3bcc40a0aff9ab423887a38
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = d0e041502ae92e67e6d2e11ec972455f8b0e770a8a7f70a5c68e697e1c834823
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = b78d39d83dd20e6f4e3b1a4af2c20b4e917dd9d2acdde9d5d2a886d7
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 96f6a8a089f11ae633540144635566541ad75d0abbb2958629abba38
+Tag = b4e43f4f4c253813
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = de1957d7418c92cda81b064376ce683384c02bab2e6303a1994c61dd
+Tag = f797cf2dc98994acc4d38bb40dfe62af
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = cfe835bc0ad774f7926e2d3f758665761302de79da2cd367cde07a7a
+Tag = fabcee39c013dc840a3c019a6a45519bc67181d27fe1fd7d
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 9c704803e0cbdfc28417f939db33cdbfb029ee9e9187f418011c5a6e
+Tag = 5c588d02a8695f6059cb0f74f8c241746c4bbd308c043d855490a2492938e1c0
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 931921c46bc8b5e3
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = cb9525c83474bd11bf4db307d92d54eb
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = b4e4ac3b56a51da0607db7212887ee28bfd172c9a52d0edf
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 7e957fdab3b179d65d5ea43cef6c4a2fd8cf205179f72beb97363d6d36d48167
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 931acc968ae060fdbc622d0e211ea77fa3774a20e15215e94166ff647eacdc4594a02d1dc797e8
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 283efa5b343e74b12150b3d5c23f15ce49bc46287f457d3bf0d18f2e2da305d7c6bcc336d4f72e
+Tag = d34b97845ac437c2
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 5c87607aabeba3b85ec6e34fe30ec0919314241fdbcb7d1827f938c1a9c75565814561b617fd46
+Tag = 1f8829e2136f030871307fff181d1975
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 20d23835513012b0dde53056a6f83dfd44eebeb8c138f23dcbdbc72eceb8742e560d51b5feb4ce
+Tag = 4687dcdad0beea6db42b02a831dc711a4ccbd27880965076
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 10ad967e9c23bf32b04483d23d80147b96d60e4d47b83be196c6d4a628557780e8b6f567b41479
+Tag = dfa7f193bb1af7a793d4cd67f6fd0c033420c0de41704025beb4c9038eb8973c
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 20173cefd8f23c57
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = a6edad3d8b34d47e69a3746c25eeeffe
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 655eb80df5d2a205a283e56e7c5181bc41d29fa2cc88ec5f
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = ec685fd1fe70e03e6d4015898c6d540ca1a4db1e2eb68f1863cfe48e95cfe945
+
+# initialize with key of128 bits, nonce of64 bits:
+Key = 3ad36c059e37d069029b34cd66ff9831
+Nonce = 43a405662687e849
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f05838d74045f541
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 436dbf641a95c655036fe03df7e696a6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d3c825f9fbc1609e3429c4c1eb6e91e2a690b816a7ad7951
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c7ce2e20a3a00605097ec8ea68d727a64f52c468349c5715d3de97f735520def
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = b5f62eb18b
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 8bea63ea0d
+Tag = 494d48f98808cf10
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = b337300ab1
+Tag = 9f8db991100c0458b12dacf8bcb25dc9
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 00d8e3728b
+Tag = dd25f740d29055bb8dfb34a08123299c3041d4cd9a0be75d
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = f48916f2e4
+Tag = f3c34b46a1c9cf3b8e5b505148d4d7882b5856769adc2bece82e0defb148834e
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 7466a7c3d5f2a186d183dc1e
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = a1455b3566d1be94ec1e5db6
+Tag = bf6b609a8b4c3485
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = ab818641ca9dcade91bf6bd7
+Tag = 0fe45316707c30d6cf354b1a188516fe
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = b3b6ddbb514d01707ff5ba8e
+Tag = 0f087f9e15d416425bed7639edf81acfed5d75eb34024b55
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 7a45490a75b620e4a6c786fb
+Tag = 05385d9d8498c86e00f9b69fbe4adf8c277b230017118a45742cd596dfa7823f
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = e733719e889d539b24d2c607229e47f59239ceb6714b9c
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 5eb9138388ff53cdcd9219ebc32b3ad0d57a69f3942919
+Tag = d9737a92c612da53
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 9043ec78a21dca1e06f4297a50142d858c7671d1cae40d
+Tag = f4eafb8695a375eaccffeb0624fbdbba
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 8b5f31fb96e1382cf1bebb450be11e717bb1da887d49b7
+Tag = 66369d469f8ded91754f9c085a724f92cce2290721572e3d
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 5d0747b5838ab556473c6eca933b3f10306f3424722a23
+Tag = 6207e26ef6374f1ad48134630f63cfec013dd8f707e291754007cf8a276a18c5
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 7b91786b2b8c65c6292e1961ba9a1c5f99b0e1043464e43749bc01656a4017050b5ef709c2391a
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = f7652ab124fb60a7c587f083aeeada3ee312a0960ee7fd0906ab70e7deb7be875eff338c5fe267
+Tag = af7c526d08505d4c
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 23e0014482d273b7017cdf5c280b72412b397277f96754b685e001c63f9338f179827e8692dabd
+Tag = 7be397f703653b77738d191b1ffd8de7
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = ab49496729949128bb63613210db430456414969746ccfd54428d9fd65f5e7056a01015c9eca0e
+Tag = de869610e114372b2cb8672e49d5f1bd0bb417cd47a31d55
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = bda1460e8a4efb031896a89b0207a0b2dcc839aa5476709be43f1b9e11e93ea2c045a643a74353
+Tag = 751390cd2282e7b7ce3c6143d17d1080ca94bcad60e1d2c186a0bc34cb25cdc2
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 34d13e2bae296f7b
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 5be2d9708ec50aacc0baff52b9014075
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = b63f01ec8357547940f37bda14605eb71791c15b0aff89a7
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 84f180e512d2294bd253e5075481eedff2be0bad377d88393919e2e97a145fd7
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = efdf7b99a78ac9bfb500ccfa6d78
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 0a1d15722c2de96411f8088bcb3f
+Tag = 8491f6c0e5840be8
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 69be3eaf38ae93206eae15a8bc33
+Tag = 2ea2bdc88af5c8e3411df8d7bdb38e41
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 5a5030214e93408c41e3c5b8a78b
+Tag = 0ebcb6af3e691f2d7397a5f7a8852e84e598ef5d3d1b44bd
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 492d8c783e841abdbc7d07504628
+Tag = f93f54a9e15d09f611f97facf7d74c7afe92c28c23195009c8e347cdbe21279f
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 7202f19e3b433abd66127ee7c4541c17fa198a3e830dc6fa23ed54ff258956c366c802
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 802be6c0c32415ae90c21164dc4398c3155ccec1d9ee20da394202b3a8b46d4d0a2604
+Tag = df5b6466bbfc3193
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = e775949af6c58eb06c48670aed2f0a75009057e667915034ba56894c98c68c9fca9eec
+Tag = 27320c05b16e110af9d24c750d227fd0
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = ed9f99ba0d331fdf2cb96c17f6c37c20fe45a69c70de540e5bb4e574bc17aa2c4c7a9f
+Tag = ab738ce94d29158d4edb0b390f5774c8e903368a483bb30d
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = f390d79483fd2b601afeaf14c060df58bd700bee3186c67cd1bef279655dbf164bb6d8
+Tag = 4d0c425b8f0d7c9c505b125f6eb330efc81cf3425ed449e140ab732028cf463b
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 7d63a5024b1fe669
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 58ebb6f7c3140f2a58a69a3a4b5452a1
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 2fb9c807762f22d2247f228c4ba6e7a659c7fb74434088a1
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = b92625b4269e28ae62b3031ae55d604488c1c8c430ab0a04694135848270d926
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = a2e719410ad569e930ecb05c009ca7676aeddf96
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = bb09f0e0c3d2c0bc26ed1066e121f5d729a501de
+Tag = 4e55ff87225df407
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = f1fe06ea43d7c823ea275875a777cc6ce8d5dd0a
+Tag = 550e11f8f41f4d132477b4711a7dbe0f
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = f6817d7639c8d7088f5d3cacdfa3cd52c554c400
+Tag = 2f7e7b2eefe6999a4f71bb407d4219adb7d9b064ebe6fdb8
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 4d23f5cd4c5afc1fc45c66a4b227ea01a8f6240a
+Tag = dbc1d771e3367d90a24805ea891f799851a84bf4f071bf08a48f737181981c3f
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = dbb5bd8ef6d66dfc3cfd79aea3a83e182a3c3fba414f876ee49092b78a4c53a9fddb201500fb193d41374a03b853bc666a32
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 143dbfe1443bc4b36af4550cbf548b0bd1367d380fd23f2ea070bde91882345218f7abe0cf996a867b2787f91f7b16a84a0a
+Tag = 7fc961f4b9e4afbf
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = d379420bc348807e582be92bd40e2bc660a7b0d43df97ec3f1deb51df903c85da7c7ea04814080670ffb31c4be1a2f3ba6c4
+Tag = 63bbb82496f2979712b5c0fec6af31db
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = f2b1793b1330fc8bfadb12f8e7d753405cef4ecf058c3b360b79bdf4ec41b54dbd810b8160b0bae9e9080d93cd8dc7b1d7b8
+Tag = 687518614b2e0003c22b5852c1cb622fae3564b4b720c689
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 182024bd72a39cf23dc046d6f88b4d0cf2d679f891ccdb034e9ece663f8e79887c959d5377b2a48d13769630290ba9fd3293
+Tag = e504e22c0a52a66f8025d44da56749a44a832313f491c1cfdab80d054766ee11
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = e46948578711e0cd
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = c018d0f131f373028de9ec2246dec96c
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 5a982f716ec4a553996aefc4859bfa4a0a751e3d64e14a63
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 41c70c7dd4954f2c5631602cf5f24f5ecbea096e460237ab59cca3ccb3340083
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = a0d2c055d9217d4f144f6debe25ddff3f4953abf86d60843ff8537a9
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = b894e52ba63854c4248260b81b11a67d88f99b3ee2ec5e9ca1ec22e1
+Tag = 6854a7140665c119
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 1b908ba183e0bb6e4874daf6a2f5a83abb57a92afd075484de159500
+Tag = 3d6b74867ce096b29891e3d583f4b55b
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 14a0d938b60aea9e15caeb319d49d970f08e25559d9ebc0ee63ae9f0
+Tag = 86c250b93d988001c1c2b418e83276bbaf5d9d577b72252b
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 4f80e954ee4f41c832e919bc0a831d93c7c2b8dc52079232bf2b1b30
+Tag = df7af4f60a7ff95aa1029170c936678376ee6f153b8edf8fb3fd1ba9c7812474
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 328856a60d08daf9
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 298f350571f0a0854abe52afaa8ed746
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 40a433d6e5070adbe281491f967ae3b80753cea3a59a118d
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = e525d5e2c0b6b5e7f8fd428d9f699915c016f5401e0068805061d66f5bb7d4ba
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 6e9eae367e8848627a775b9dcad70f5a25757e528bde694d2e6429d23fa8f306ee30e9af5c82f4
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = d7baae906d1c328f43716d2d27a5a85fd24464df6a6d351160f11f460da70c2df5855e54b226eb
+Tag = 59a043f17a7be3aa
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 9c2fec42c51144032e0ed4f610de6e10374b27ad4d2062fe4efcb742570701ee3e2843f9206e23
+Tag = a560ff81738c961c31d3a727f60cf57c
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 50dc7873596d8a648e9a4e3141941b91df26973cd74c4546997bfb89958e558c7f2c781db83353
+Tag = 3c277488b592339c2b0aeee8b831f1ab10512595800f1eb8
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = aab4fd234ce99fb9897d03130bce3973329ddb35e556644748ad5c59a6d6cb89d295fd8da520f8
+Tag = 76eeaeb1413db9f691300035439c655d172e4b5c170a6180d791ea39a4f85622
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 7716511d3a3738fe
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 97c054602af1d8ef90e21705293a6c62
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 61af015fe3a791b1bb6616c7d84039a2beb27b47ae0c2ca7
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = d63e2233e840053d6c4a4d0b4f2baa811bd6c7d4c4a1e2900c300a1352ca086f
+
+# initialize with key of128 bits, nonce of72 bits:
+Key = 3bd46d069f38d16a039c35ce67009932
+Nonce = e546a708c8298aebab
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 18859a81e2deecbe
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ab27ee10421e071270657233ca25ede4
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 19168707ca1ac4adb284bb17e7ecdd4a2f3bcbde0696a981
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 20a0a4a9f786d66648bd404e47cedbedceb8dd9d2d812b0780ec8f805153e705
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 027083765b
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = bfbbf30d15
+Tag = db50986a5a6c97e1
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 660d6a6af7
+Tag = 08ddb3d6339f6ea25982c0dcf4bf460c
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = f8847900d2
+Tag = 7055ecd393cb077973468cf49e27f56c12886005a28c1377
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 9930b1ca3f
+Tag = c568723b1ca5321a2e6a08feced2b8b9c15236a80db2f831cb2db0bcfc74fec3
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 81a163791a6f2a590027ac59
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 482ed522eefa335656d2f897
+Tag = 1298910005125b48
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = e1fe53a6769cd6abcff066b2
+Tag = e39da6f0519753ad5976f1c3c863b247
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = fb44b2f25b2a0320f8406e60
+Tag = a4bb5cb9dcbf66c22620707604c9c3227d23d8dd7c58591e
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 577fd3ea672c172383917d35
+Tag = 7384ecadbf59c1522bcfd6d959182995bd785bd23bdc54bfcf88c1afe5b89382
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 6e3171e89f3217a96afd1c60caedb4c569bed1e4eb222a
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 95e1076319082dd8362dc78a5a226a7b37d19f9b1d0023
+Tag = f5b0567048d2329e
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = b33a2eea0bce5c10810ba8c245ec3fa14d567ac80d0639
+Tag = 9a5c679fa008909412b286757d241281
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 1248ced43274977c54903fff467bd423a71b3e0cb12614
+Tag = 5d42926d57ef6f80cc9ecb185f2014e7885be64d61aa2ac6
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 5e1683e003f8427feafca23762bf096c451a5fd33c6b26
+Tag = 510d7acdca0ac423db56ddf14a5229683ed08c94cef239f493701fdc34f125d1
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 8d636ad3a8ac21085d23e47001fc2b97964ce037d4d1d8bd9134dc7f764318a8a103df38618da4
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = fc311770d62831cdba58543d428b0dc70323a68313e344ead6a74e50294da1f2a9867732cfcc4b
+Tag = f71ef9f06a2d10b7
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 910d7ce4a5db5ebe1dfca34f073f9e5729c98c470e6067721439daaf7dbd029bd526d040d394bb
+Tag = 27585b4e0605f6ec7bf9cf99239057ce
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 55090dd28c84a919137087d6d34aa4eee6ee917455a7032cda66ea9d4856224f4cfb4fce13ac97
+Tag = a23f679415aa66bb0211c50b638b60078d15ca39988b1722
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = db70ed87fc9d957431bf5e1c87663c909b7ffe2be8e21c50e3664a9509fd8818e9223323ef6dbe
+Tag = c822190c7f8be3f556f7071017d31c220c4df9295e362920ef2eecd4674fde53
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 7e91991fa2e188a3
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = ff88b1964e53cd5d38261855101bf841
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 9abfe055193ccd255e660a89164181c55fac4acdaae12237
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = f16bfd0c3f922478760d48c126a053b263dcfc791d9c9519858914667af1b69b
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 2d296c9ecdbf083999c7a2c2b064
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = cf9caeabf234114c6e7027a86ddb
+Tag = c8ebff71f6f5d7d8
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 2c124c01045a317d199a2fe03703
+Tag = 2d3b58fd1725533fbedb10bdb8903f30
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 667d942c6f388f8e0c2e39b99570
+Tag = 2c5b829ff54fe7104f5bb8800b21c69197576d909575f9d6
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = d34a6fafee3f2987974cebad41b2
+Tag = 11dc1cf7c5007fb620ce1bd28a1664ab4a6ea8de29808dd59f69143c4285d978
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = d3f1c506deefbad1ab20c44062a7539ced8f58874ccfe7550b1f895ac6aa9f421160d2
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = df95407f310ca21fd933a614d5ce1586f11b8415c3b62f8ca7a86fc74898bea093d690
+Tag = 508d5c97dd55dacc
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 643c610a01933a4e8bb4b2e165a78c2396af4a201e454f513457ddb0a19939bd2782ee
+Tag = 7fa7fa0484c2abc06ad22c549e8d4894
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = f6606694eeef98304303ce4953c5584ef3d8f327873ddf24f54793fc8076da5e58cfd0
+Tag = 514cef85d46d0e05f38019c85608a4fdd15178ff6e0b27a2
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 7b8aa6ba66728bf0f3953e6e8a9972979001c959eb49d5cd1fecc85d6abc132a34bd60
+Tag = 45d571c55890b2049cb2034b4663efd6ab3927d10b17322467c09d6ef31ba975
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 0ba47fc22d67ebf7
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 5e9e94bd7f17bfa470904a41cedd16c4
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 4b43c17a77fd0c99d54a80a5e8fb0b4b2eda9934447baba6
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 7e3e7d8a4e337c30a0f233ccc0a6019829a5b9c81c5669260bb5d7dad1c486d9
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 1ead6e32a0ef5a3d15f26a370f8ea697a9d18123
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 92aca34a51162452fb3aedaee21bae732fdca190
+Tag = 311a21745d16bf91
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 29b10c6276e1813a8dafd5b2f579117c4e4fac44
+Tag = 8e6f4da7e0e81489ba058247de323eb6
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 9fd2d15dc207b8a6b9709df6517c4db0e1d6bba6
+Tag = 90cd33da8c73723d450741a0a87fdb19745c163e8138a93b
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 90348e35375a9caefda9c6eb2f02810bc3261998
+Tag = 90ba41691499064a575293b9ed46f44db26e0d580665ce6e78555fe038df73bc
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = abf42ab2549d3cf7baf5beae66da0784359f401001c206c3120d9c734f04c48542ebc022e8d338ab944b6a08fcfe3d60357e
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = c50d01f2df90f4325996a3693b6594719114752b5832d1b0129521a8cbe0cf79177f29a63b851445ad4c3214b086559af11d
+Tag = 20c5624a5dc2a193
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = cb1b6b04d62764346e7a04fbfcbe520e60ca4ebf9dc44ccba22242af62d8538d4063dc4f4ba4d4a1f076ebe03ca61a428167
+Tag = b630a08c721af846daf069ec345d5039
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 349016c6a6657ae4d431cbd9a725bf3cf94e5669b1e01d67ef7225def92f43308256e38e7167fd311e085a5bd6e165dc8fee
+Tag = 6427794d0609f8e34aaea749d26fd21f1fd6b1e8aec20521
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 221a08373ba6d6d210da09a2bdcb12096357bacbc2821fafc4fb20cf345b13f606b28e78f8ff46c449253ed0391ea761adbe
+Tag = f0d45101388bda091ffc63596c295d3c80e86e3b1e59f0765df18d269339ce50
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = cc77f2c06a762e38
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 1035f4acbacc606a6ef4102895bb776d
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 82241972fe9068339ccb9b1304fe9f534af74d1c25e05ea2
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 5ce5a226090a0888b11c4504af400ea73741113bf2d57ee21dfcb4b2d0541e91
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = f61c568d2758c7181102cca6ecad751366243394b4a07cd7f4af2a56
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 15a77ed597e5a56d4686557370b4ced8f9bc98b2ef3d70bccf01635c
+Tag = 18e4117710958a19
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 07ceef297a782b0b37407076190d42957056a04d6bf514a22a9e8d7d
+Tag = d98c24c4845660340ca2cbffa0d1e1ee
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = e84d207f9584b004e23169da847d397736331131a1cb109159a8b1d7
+Tag = d5798a8164f1396a57011fbb802cbf8b2bb3556d5ec233e0
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 23e73c8586ac9ca2c3fc59b134f058323f6f2c00b2bac4ac4a42a154
+Tag = 9d5913793f553aa98ce68a973b760bbacc32a725f7c85a781efe05da1eca79e3
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 7abb4241998ae283
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = f03a602f89cd78057356e2cee8262b9a
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 5ff539f18a2741921506a9ed36e8990eeed3f18be5aa5ef0
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 52b36b4d7fe5feed660b8b16e59095484e33a7a294813f07b3380db58c8a3baa
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 1bc69e7f26fa2ece9cbd88a1b33eae847427f6ba645bb87f7a4a19488947e1a68f329474ccd7a3
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 04629932ef9d603d2b9f6e7b5f3ea0f02681acb55576ed966a532b8d6e51753716077f3fb7feec
+Tag = b4277dab48f9ae93
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 19c073e74d9c075737bed0e4eb61bb3b57275db25451e0489b57af33d3b0c9a2dff29933e7bd3b
+Tag = ecbc0a04b36f2ff9402f35fd114779a3
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 1dbb5bdd8e85948ad6a431b6917654255c7cbe85e573790f5dc6a56c6480dd2f9f69b1a1f47fb4
+Tag = c24c2b153aa7e7fc20e0cc1644363fc97a1a59b18610d8fa
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 5214461e1daf476653067416e7d6a8252d4ef08daea219f041c30505bf98d29d74a146db9058f3
+Tag = c110ab769fcde0e7963e9613f811e28ee19c45c222b190679b173bed78936903
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = c7c33eac084e5aa1
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 72451c4f13ea04b91692c575ec948faf
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = df7d5640ba03a71b0e914af8dcc2d92de1b63a85250faf37
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 329356d900b4c5e68e81465c350249d9bf48a976ee4ef71c0b4a8228448aec8c
+
+# initialize with key of128 bits, nonce of80 bits:
+Key = 3cd56e07a039d26b049d36cf68019a33
+Nonce = 87e849aa6acb2c8d4dae
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = dc6dbbaee3ea34ef
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2ba515686af91a512ae94cbb6c12acfb
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2fa2febbad47123d41056026026bda381ec865b3ffb706b9
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 318b18c36a6d6317b328c2d2f73cae7a57b5e451a421ee7f1ad68f65d77a4b60
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = fbbfcc1ad8
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = af761390bd
+Tag = ffc6fdbb0edc7413
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = e29c90aa7f
+Tag = 673a7be1aa8bad951b64be3849eb4f0f
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 33de5ee715
+Tag = f9e2d01df588f9d89b8f9db30cd941c98481c4be63876133
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 26c1ed82fb
+Tag = 522bb6b3697a7cb46a2cb680b540c9a3b42dbdea30d28d541d83a60bcc723f08
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = be570122137ec72c04da2048
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = c1c6914208df637559053dce
+Tag = 0d59cddcdfb2a099
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = e4eebf014023faffd6ff3d47
+Tag = 7022bd76f566900ae561e3100ef11d4e
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = a9fb5d070cf79951bad9ce6a
+Tag = 4512b679eb65359a50553731cf063e9882a87abb48700c1f
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 208ed42e73f4e5cb852e28e9
+Tag = 52f26752346358999cdb43615211995c6a0af71c0e52c48710860f4c3a811538
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 46995f9f8950472ceae584163009ef3bff97bcc044f7cc
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = a94d1bb5861feb900025a83bd547e02415bb6aa7ea2694
+Tag = 31a2403ca8834b0a
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 223235ecbc82e7a0a09c4363517bdbae3cd75691881c45
+Tag = 6f971dc204ff76afa0ea4cd2196af260
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 5e0f2c1cc5ae2a447b30696bc18b71b62c4bfba27068b6
+Tag = b44e1ebfdbf2b1a67e05710b36092737e0e0a58747e833e9
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 81cc3fa5e468ffa5f5ee381c3707c1c2f49b2421ddbc0f
+Tag = 2419fe1c4888c07f39c73ab25fcfcea825a066504b473be669dfe6ea51286ca3
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = ce3cd94806e2d94a952039cdbebe5c95ab0f86164f85780b71280611363ae43369f97fbbb917b5
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 14d78e62d127fb1afcba9073688804d2a7c2c3655bae5d700cbb2f283b04320a43ea7ed35fb6e9
+Tag = f3da552e37651554
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = f2f5042a1c24ba3bf304bdb5a8a95b65aa93c76b282b490159fdc2b808bff79a2a545fa6ab32a9
+Tag = 08f290fdce97e2a4ea3a0fa51542ce2d
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 785067f1fef25d4009297bac591adac0b46fcfebfbacb1c2a9abfdb818c1d67da152a0e148692e
+Tag = 4fa3c6cfc8e24f071662cec8433dd518bf100b83283e9c05
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 0f957294791097909bfc6ffc42c20e06887e68c8b926850ea4cd742403863fe1e71a6db09e3a96
+Tag = 2cbcaae5a1942bebe4899635ba70f5720e60cc9e1fe06517d57190fcdf218006
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 8b55a0427fcb0743
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = c1d41380403234845063ab10de5251c1
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = d7276366aa56fc7009b95a7310849dfc2390020883812317
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 7679855eee67eed3a4b3569ece6117be0ff0d9196238c4314cedd89009261352
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 2b42ec76c01e1c84f633b5194d92
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 4880879519184eca0742abdb477d
+Tag = 81465b11e7b22d9f
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 0ad828a893331d4efe8169d6696e
+Tag = 524c7d4589e86281e09bed83bc3ca7cb
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 5355b17318609ba9f084da458a10
+Tag = 6a9f6dfaaf435f3153ee4ba8829204cc83b852e4220aa1bb
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 238189e5f65c283ccd44a7693fe0
+Tag = 80ba3afa4bc84621c0307c4246fb8f605b0c71022d237931f04e3e6932c9a8fc
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 04c5ce4fb051d39bfa7fbd8e650cb36a5216db392727cc98841d836a5016aa2a33e3b9
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 323cde0f8776c6732dd637b90a1cb426538a13ba01ec74cd68c97e747d3cca35c77a81
+Tag = 20c82851e4f7285c
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 21d9504a29d33f67c6246ff65d94c868df2cf8f8590802a267377d3bf98e03ffc1586a
+Tag = 18a4d9edaffe4a69f3fe30f7ab6de7ab
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = d7a44fb7db7a3377680d8fb2c460f26261d9a64db4f508510c281c507fcdcac1c198e6
+Tag = 71e819c1295d4325ba4da281600f3a04aa36efde072ad43b
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 45d583fc73d701b5c42aa1eb54eaf375c552c3390f3e06c123f90186418690bd7b3a4d
+Tag = c304c284c5c577a8120ef30b447b5dbf4a20aac2ed12ec06a77c8675059480ce
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 32287f202e942069
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 19e7ae494bb6c140251808d8f440852a
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 68588b3bae9f8f73645655f033fe38c85846efeeabe34004
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 7b43ac78a24cb690caee3fef0ddadbb8c321c48a132dbaa1c332437ff2c5f79d
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 3635a8ba95560b45c7ebb25eb49099d8444e7b62
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = a00e82d18eb43cc137de6460fe84431621e36914
+Tag = 0cdba1b619c1c452
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 726b31677bb2ff8378658aa30140ab5f2a03fe44
+Tag = 76f03b8f73a1e8c4318b993e7f3fefad
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = c0bda1d24f5d6d3ba60d1f59a0051244a3ca6a28
+Tag = 074964e767bcdb35bad5ddc4aaaf1e72d307c6e4bd6f0c17
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 527541cbb3441475b84738a83d6c0fde9d8d64dc
+Tag = 5acd72b38c11b33ed94eac9f64810ad05bdcf51607272d59f30f97b641d87279
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = a66df0ee4f46dc3ef8b330f9a54ae4a7825115d276aae29d822767d6dbfd81e74730a5ea1124056e861009edb48ff6566406
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 8892c76e313ffe628051c17292e454dd85565bf758b2364c5cf31ecad5ecb587b049168d40a9ca578acaebd08dc475f3f6b9
+Tag = 0a0a76712fcb0ae9
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 3d246d1dbb5929fa2d8ed789a06d688959c70fabe6df1d1ff03d9b98cc1834c158421a62621f18003d999411f937c2cce836
+Tag = cce607dba1eb27c5c138d01740f21c8b
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 3508ffa7283832eb6108a63f9daedb92c7b9cd404099585104ac89f367338dc9dd330c3446744942119c1fe3b540b235aa74
+Tag = bdc535fec268c1c390c284486afda660c5afce266ae1bb66
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 177e18c79dff848a2a671d0d36a4f4125c93447867c1125a2d49165c3968f287fcae3269ef4470a320c1887316d2801a5e9f
+Tag = 9a877e9323a92c11b5db73c24db1fbc6601fc25525b697dfd47f26583525b4c9
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 57765e9a364cfd01
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = cb6fa50e0bee39c48df7256c34d1421a
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 7aab5f8b85ab14d3f8831a9a4558650518d3c1d544e1bb91
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = cb4a346eee5ec9a9148a9153a3844302984047c707ed6c6e72263614eaa891a1
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 551c667143815dba37c1416df9bd5a8715db172bbd8235d239a7fc21
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = c04dcd0a8f666f92346cc12dc534867737935277f186eded73521ea4
+Tag = 82a18ffe8d4e3d69
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 26fd5d39474effdffce10ae4dcd4332517fbf8953e6fdedf7e0718ce
+Tag = 6832d99c3fa4f4ae9fd093f3257f1f40
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 51d63deb0bc1b634a86ee305ac896d89861511f1c491f7d5c725fb74
+Tag = 624df00e4e448acf5937f267c103edf5dd6055a7a9350315
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 059eac05713080a2fa462e470da07e04d13e59009576861d89ee48b5
+Tag = 01ab8ca0372e567b6f29026e856562d29708111665cbe7e7b0073ace153ad021
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = c8fda99fb4d2564e
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = aaaf35dcc1b30f06b6b8f3aa47cc7879
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = e84f7fa80c2591dd46a1a95f3d311b941dcdfebdf6755e21
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 3cd392684f840222aeb7337f15b4bc8e20ffeb622d670098bb681b52981a77aa
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 91a65140e8c2d53a366fe64affa541fb69b826ee9641ca4fb8e8f4f7cafee4a73b97b0591f5fdd
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = aa777e62a55ba367e7f4e3ba0d55d8df1df323e9e5691aa28493a5f8c778f531a8c938d63f129d
+Tag = a5950ff237a09404
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 7b605df70364e4649660b4aed5b6489855dd6569f6184a5707492c044630e9c33ec029fcb23fa1
+Tag = ddf20d551df1e78f8dc4193a7294821f
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 7790918860843e634258b9e1675e17efc15ba369bafbe2aa377531e6fe07f2b297c004f14646da
+Tag = c011276316006194d18ca9c816510f9f31f6c9187a8dc191
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 001510464f577af499bfb4093509724130a1b102a772032fe327d62be3d01161278d409c23f1d7
+Tag = 878dc7daa5eba1eb703a443bb2ecfa7fe7c2b9ddec89b1cfc7f2ea792e2d4ba9
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 9c5d2bb092247c5f
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 952d661d4d615bffba43683a7560a38a
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 9682b6242b071b547eeb696f9484132aae724aeb06f69fa6
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = fef791c4f7766b357fd5f1ecebac084d514c5bbb324065bfb5cac80a7317009f
+
+# initialize with key of128 bits, nonce of88 bits:
+Key = 3dd66f08a13ad36c059e37d069029b34
+Nonce = 298aeb4c0c6dce2fef50b1
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 839abacba39d2392
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f7759ead5799494839df7b96648ddfc0
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1c9af38274d346fae8d056368b4ca075fda351647fb39937
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = db6538a13d66f5c7fea7aeda053db619dffdcc081441f6c0878595804497d9fb
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 4dc247ee7f
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 7b0a228de6
+Tag = d775cf993c64a017
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 46718e2d1d
+Tag = ff424ecaa212c49817ead789402ac22c
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 8e60c2f459
+Tag = 445f1ccd742ee6aa4120a335393ae21c5c3766a8989566d0
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 5cfdb997e1
+Tag = 133eb3473bf04d5a471c5eb117b4efd00a1a26bb05ee36a27f8938d7cd27d668
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 2fc8027ebb9726952131234e
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = aded2e114ba22bd97834c88f
+Tag = 60019164d760f912
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 4950d9c4a8c48a57072299e9
+Tag = c4ff2effe83600829bad8be26b8916ae
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 82e9247962ef0ebcb7e5e732
+Tag = 244644e7ca04f7f76e5267bd6b0b08af2791aafd5ae166f5
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = dfb482eaab98b22eadaea265
+Tag = deffd5e7c7024b7d4ae4e4f7932a02caf7c51c856f5ca043f3b9f2460748abda
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = d05c5a3135d5fe5ba639a3aee467260b8a7d228e611aab
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 94407aae5ad8b5ac51ac4c5af25ff5591d747b88fdda60
+Tag = 42ea6fd0a6ddc9e7
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 430078891740d356be7da8e2483c205d36efee50799bfe
+Tag = 58693663ad99b982eda35cd9d8e891bd
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = f171d3048f7a0e8c507a8b7d48c6d603f261b7dde4767d
+Tag = 5f9073e6fb3224f309c252ff74db1adc95e9de91f7d10741
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 732568e461ef495fe25cb976b728261fa1942d07658778
+Tag = 2a8a19b3ac8a6bb38bfd948967933cb536c6eeeec125dd81017a6693d6c96cfd
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 4f627e9a850b4044af50921676ff774ce2909393a541b33f419b492bb25c2f63faf12e50ae73d2
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 37ee52c073d945c8760e919818f5a71116f920641578570eb022ba38d73794f0bdff37cb9c2705
+Tag = 76654af04728842f
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 7febe5d7a0e69c0a8e6b3c411cc7bcab030cb24a5e15a658c7f2b2cc3cbf9e7339166df9607bc8
+Tag = c405633e169c857170bd2eaa1497c541
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = df8c8e091972f9135f3c31088937dad7ee925441f7680a72c7dfdfb15c4a6bc48ca30e6aa37e7b
+Tag = 3e277fa213b9b1d5de0f5c3813ea52ea1c2524151aaf1e4e
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 326f1531fc859bb4986903166c02c0f0afcce8230bda3c61bffd7a2b766b02ba2ddc936ba8fdcf
+Tag = 850ba60a9fefa4234dbecc9a0cc401a79b33c88127a0252ef18e64330d018aad
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = b6f700bfb86f1636
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = c5d4f169acdd7073d38fa9c83b92b21e
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = be9d8eb3775c5a7e84a994d994e4ee31e46e20034490d36e
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 04768e090e5381a6b6855c42bd3f92dfd1a06ec777b4a3a3616217bf53aedd57
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 02a0441c8f0da56b47f245c9bdea
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 74876ec5f9ec508bc996eba4b1ce
+Tag = ffabbcef7d552e55
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = fa8fadd9ae83527f9ae8c8a18a77
+Tag = 60cb3d461754a2dd31c3933669cc248b
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 1a3713f4f5baa3a6dab39e71acf1
+Tag = 408bca03e5fea4ebf67d1a3c723b9c94b832e33e006c7868
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 3b89e2b0172c68c9c3d92ec85f4a
+Tag = 7321e7dc9af7aa74e7ac2e898377add6d07e9f7cdd2cd2cfe734fc49855053fa
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = bdc8bbeddfb1595f1e742c754118bd14fd957ab6002c5b4a3e862e29e0cb795cb3a2f3
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = bd25b41596a581683fac3b2de0b13aae1f9cfa6e04b820713d733396e8a766191642c1
+Tag = a3444251f98c556b
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = e14743bdb97b2781a2ac66b29aa86fbdda0074eb38828119a59bd382b92a3d7de19241
+Tag = 8fed7ad4db939b3c8c70bd086c5ebdab
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 3641bc3f91779a05625dacf86443ee2dd27b28fe964bb0499269d337c61f7cc0481e14
+Tag = 50a49c05d51c2b3d212a996d011ff3d726515414cad124d6
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = c8611a2cbb252fb7dc542678dd72fedd93813242c1ec3d6adc593562f71b69ff6e3ee2
+Tag = 42a46e3f7ad7ccdbcd1f34f0bd88fc745a45cc80cf40aa696d701c0fee9452ad
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = c16621965aaaa4f7
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = b514fc08c9b42f02636ebb2c63ce9c99
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 3937c1a5ce01b7bb55c4189cb81e33567576d56da532fddd
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = d7f0b0ed625df0ecf6a21f9767fa5c244ca220a016322c9be041a0adcee3c476
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 21e5ddaf1fd80f1dadc455810ff157869212d891
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = eb5f28aed7260768dbb696d11ec9c18b64b17f7f
+Tag = adf7531c2493829e
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 290ee847c987ef8b75362038b5e9325e5397b66c
+Tag = c0e21b251cd272632abd5b1e0077de81
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 14cf70f7515752397107570948aa58ccff0957ab
+Tag = 3ab630f976d527420cdde261492f06063f4fc3b8b999bfb8
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 99bc563ca11f13518dfd35c66838ce5cec07dab6
+Tag = 895f1b9e2de4741df97af221e14ac1ba5c70bdb0bd6fe75a6631619c8d65aab4
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = e87d1cd92f471975ca4555aadd66ba0d60fc0a6473efcf3f9a1ff1aec0b84970840310200aec1bb2bb1f75b6c2e749806935
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = d7f1da10558092a69daa806e60e0bed80955c982079a5b7852e0746aaba1340b2281e3fd80f4824e81d5bf8bd75111572f37
+Tag = 1a485849566f05e1
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = ecd529a650c7d2966a034d363cde7d2206b9f02b2061bb672626943b116fe80f2b5a8c484c5ff02b236469dbc2809bce9a2b
+Tag = 5a9d9582f9deb61b7d6b886ba5042f93
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = c5a442bbf8e4b42c93b6d1629e4695ae56f175f92e9f5a99128b3fb1e848e34ec57f68d145f77045cfedef423fb1d834bab7
+Tag = 6ad9b96b2e13268d9d69246e1bd15a48068fe951cf715676
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 4072db65f996993f4ff132d0b0c66592f9946a45641c484a57c58dfc114dbf1b2ab645d0010942b6e6f05121186eb6231f73
+Tag = 19bafd7bfb8c1b7f8efb888f2c95d32f0c3471e4246ff80bac7e483647bb9153
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 27470da69f0175bd
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 23d8b11708400df07cf4319948f43090
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = f57a6a69e5d5cc61ab92b8958f789e63fc2438a183488ec9
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = e1d650eee4ff405cf6a96d389c17df5d760275813f98329f8aa5851877ee0415
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 1f4ceb6ed880aa10dc471e2f707167436b14c5ef799a68514256f4ce
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 944fb29eebfd36d6c1613bc171d72c529384e54b65f21ad100f0d5fa
+Tag = 852de9078958b2db
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = ac29982191134bf44f6545a4f5666dad420d68be645716eb379fe115
+Tag = 2051ccdb2d2092ad28275f9fe5612d3f
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 60844ceee0edbab21bcc27ac0bf24a7710ab59953cbda879a10ea14e
+Tag = cf2bbe6c52304ae662a2e85f4e4a75c7550d55d97bfbe758
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 9f8d578d7f0aea5644a9dcf81c64c26e086e4836dd514b27b069fe0c
+Tag = e182400a26401ae74cb54a5da373064c7ddd5dd279b5b8e583aff16e77c49629
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = e3d02cdb20ba4ee7
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = c14c0d320d3106c3affebc68bd79cd39
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = aaa841e93533a7a709b440580e08e4f5bb8485a2f5370868
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 0b5a0d5a3324c31f6f6a6196f025c61611a579fb8610acdc855dc5df421e323e
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = c1fcc82d9a76308cebcc95f097694ee99951e32d472202a5e3aa60a769402b2eda2f736dc4ed15
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 95a5778d7900fe11b0674296ebf0016006a875776471a6a65c9cb6c5a5db1435a4d9a82a133f2d
+Tag = 2e9849a5b586c196
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = bcafd995308b5c2453d582cbfbeb5675d7e88ed61369578c45d7e36a6eba53ca2a95671b0c67b4
+Tag = 21b82501988e97dad04cb3982105d7a8
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = ed7c6543282b7d382201d44c99d4551c41620a5921e5c10cab8c67d6cb896b066bdf96b340469e
+Tag = b35493d4005261a736548f4bbe30e42bce2712e28f455754
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 0822cb6a69c1ffb15040e77a73a49a259827df5c46411a422f42ef2b14593d0e17033824be54ef
+Tag = fca5da12a60c9ba20cf5da58f55ad48d253f3946c55b90e46811fc0ae4288b7a
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 14d9f1ee91913c2d
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = e8b994fa24f27d3234337156b71febde
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = a62bfe686b54400c90e5e2697620946309c84dac3c7f64ce
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = cf042e0e13a4a7aeef1270e3ad7a8213019ec239e4b93457c9325151e9c83087
+
+# initialize with key of128 bits, nonce of96 bits:
+Key = 3ed77009a23bd46d069f38d16a039c35
+Nonce = cb2c8deeae0f70d191f253b4
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d49eb24951838a7c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = cfc33d6eae0dc4dcd1fbc6882131fc8c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 04b422da1f5ed1d80de795712bba7514eacb827db456f591
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 68ad883a1e771aa5641168e43c670376cdd00f5859861bc060512a8dacf1183e
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 9885d55ff5
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 3279e117f7
+Tag = 0aaca829fd107d2d
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = c6d8450eb6
+Tag = 74768702c0c111bb35c45ed467fe34ee
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = f99b2c16f3
+Tag = 2ab9920c7ae28a4458060e988917b314bea18f0787e860dc
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 6ebd97d88a
+Tag = 8d96620370a196a9f4df333a2967bff774f2565354c6f2dcd1cade1fc9a45e11
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 310f772363bc80b2e87c44bf
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 83925b4ddb398db0beac2b12
+Tag = 14978d399f3fdeff
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 861a2176502958eafa1bad41
+Tag = 72c73873f3e8dd90f226058442ec20ee
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 9f408b9c1dcdf6b0322ec28d
+Tag = 3f5b0ac4708dbe8550a43e94d2a003917cea99639907314c
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = b66b7a1747945bb9b4f29724
+Tag = 858a8aae2bb957fce1c39e58c584d8f29286ce1e1ff952c485671921ef1c1cd5
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 47e39ae9c699ba9f259a00a08af0f895669627f911755b
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = a0ddba34b13c5a29001cbbfe0ffab4f822428bb333ab42
+Tag = caae14da97cdcfdd
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 2822cf5ad19b3d41dc5ed33738c0e866451ed3135f874d
+Tag = 661c4aa10ad81fe7f06de1107839d086
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = de43b5ad348bcb254634a370ccd2a1621fee1da3c75a8b
+Tag = ece3ca5c8bd8b5074dcf2486284b7842cbb20732593569dd
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 45d81fe3b77d966dedb2ca0d50e779eca5e72057599046
+Tag = 2fb0406426df6dc513f9cd851b0108874b29f1666b8013fea7cd753df99ee208
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 617e0e04645a32bb2dd702271e57e1b2d62fffe9a3ba1f56e5b895d60b06e8f3cb84d5b6eb2437
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = f506ebf894843839e37e2a6fcd7dfbe212979386a54f4e0f59385324192df1620177eb442521c4
+Tag = 2469b71c3b35d3f1
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 952360df7524248a29c1f74b152f8ddea15001d89b540832e4d8320760fac4bf0eb615ffdce431
+Tag = ff26e659870f71c64abd118ef7b758b4
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 386a8fce6959f01454a82796ab4e471e046d56659d5804130a4cef2fd5b37ed2f6e1386342f849
+Tag = 8f6fe26c150f7d4b2f72157d524c8abbbee51396a0df04d5
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = d8b6aaf9c340b7ccb93c3c14fe764069557f65929fb66b931b86d7bfd8ba43f60d36bacc3f2b81
+Tag = 244930a1b2f5a4084c9b4a7102010e9f348f6570a0dc7862a86da2ea3c0bae59
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = d3cc0e3d66e7a078
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = d92ed373ca569af4c78c969ec3d68a98
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = e72291e40eb369f380105bac1f08cbba0078064ae929d53f
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = bf3f0f077740daa7acd1cadf37f7d7ff7a284e55d001265005f981117559f73e
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 42aa175091cd5ca584934ce13f33
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 7c615c8109efac250709a6d285e6
+Tag = c732c44a8d29e5f6
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 00f886b04bf01d01eccf4c95b3c6
+Tag = a759724bec605be61d68728dd871082e
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 08de0d316b65df90f1f2fc4f9f4e
+Tag = 0191c60a3638cec5d5e4d44b1ad9cc5eab5e913610a0b562
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 7b3bb654338ae5421c3b57153f21
+Tag = b793b543b8d69c7b9828ec34a1ea58507c8a404d93b4772c512875081317a250
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 165c253d607273e74938019bcbbd7a1004240b9f9ab37e9e30922c66dadf759aaaba77
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = a1fbacd31d4e4284fe0d54d428b9f25f402bd17c72b2ac5dbe67a2ffba36dd1e7d3e98
+Tag = 4163b9bb6cb4d616
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 1180c1a62ade37aa2d8564ca7b354e52faff63568f0b1a1c79d9ab8d03de36970c269f
+Tag = ff2cb1029f3e2219df844f9afe083fc0
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 6c2fd95137f415cdfe46b1c282963d708d47e6e359e065479994b5dfb472731d7ac14b
+Tag = 52c63d22f98a67a7bd4428f5e22a0029df6a43b8db826492
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = fd1039d798b9f5e69800169b94d43a6f7ac51179a424d0a1e0d8dd3ee4267aff285fa0
+Tag = 128765c1844858e0d3551a04305688cc07172daa25e5aa2debe277d9eaebac45
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 89298b2aabaf9979
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = b38ccc44ea080745e4998f613f8f3d9b
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 9e9ff676e86bc4538442eae95f9c0d0ced3051995c66981a
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 864b3b992cc33675c5b7d3e880a013c6edc3cd0927754f22eb8f0a8d01fab18f
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = e89ecbe17726d732382b4824d2b0950cb07909f4
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = e802ccba2bf60eab068d324f16d78a0336534410
+Tag = 6bbc1e8a85e5ecfe
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = d79151e75449db0e54ffbbb8e901d4c59025c185
+Tag = e39d1cd2e741ab888b555ed1f952242f
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 4c0ea9622787ab34311f3afa539000fb8be31c6e
+Tag = 65ea53f35363f67f3a82145e13769f9b333a66967a22692c
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 82128932e7af6a959ad8c6e1b4e20902ddbfe598
+Tag = c599fdc32c3bca0269df82adc444f7992fedd8ee968e664746fc43a774379b10
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = db520777ad5068ea9d2a9997b31033e63893d8701a4d3757ef21d9212cdd4afb089713e0e0abf19ce1a56804e132ddf786bd
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 4d739337d90ba77e87d41a0d7e2a7209c9d4c21bf6c460b11bb76202dd974dc09660bffd01b8e17af6ece892a461d22e4176
+Tag = 343ad66f56ceeb3a
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = b5b6f76b33bc28fd4eebd15ed6f289b4135bd11abde83f1ff6e504900fefe03af195063ca7a5ece01c58df5f662934ac9674
+Tag = 8685af8973feef7b193fb4a8eda8c967
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = ecee49b0de8116c51c5996a4471b9c308e3240f2c1da2c22b11f6971606f383c923175f78491c94a2fef4737d1f034c3d60c
+Tag = 7ee4118eca5abf373b212a3340fc14c6fa3dfea35946a50f
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = b52e50a2cab4a4e7faec57ef1b792139d60606f6f757ce5afd3e91b476cf1b20bc96c23c3d67bae7bd05c7828e90b9ed65c6
+Tag = 7e2fabe6c720bb26a34902225491fef72acbba6ad97fff43245c9c2abbd2f8a0
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 104766006be186ac
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 1b6249be5f1fca9a6abec31e744f4306
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 2104b66a5c9fde69585c368986fd23114f7730606eef7f31
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 841b6e2e706d4a2de224a60b58e7257868badf468c61d135552693fad1165f8d
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 2c5f92269e3bb4bc8d08ed99d8e999bbd0efbd8d67aebe47b7d42bd9
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = bd470384fe8ba36e4dcf01a283498283057a6c1cb4bb635dd9a2b11d
+Tag = 31247fede0a215a3
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 7641f5425eb03da7c2579debf9c13fdb2bfd240fae95f64c8c828dd3
+Tag = b992587a0ae9ac0e773d6b5207c92a38
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 1c151c400599e266db48428b634e949889cc4da19d3eb333d0b4d300
+Tag = dd278d4cddb5bb27bbe68734fcb193927ac46a0fb0e3fce0
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 784c026381cc3f63fe7fa55ba32e1ea2a8ca554cdba6a7ad17505ef8
+Tag = c218c5b2577f3a7f181ed8220c590b49c957104ec5509575e2dce24a61fe617a
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = f5c23e5c3aa568c6
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = a175ee17ff7c809bdf517f1630f7f494
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 07dfc399777cd93ddba5b9e7b92477d9d93859237d116bfc
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 1cc9f1fb34891a94f40ba810fc9978ccdc2537eaa8493f015e34ee6fbe5d8b08
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 99e08046b693d949bd4554f967a0c8ee71440ba31fb0aa714a0744a909e7fe4b72ddea39e42ec4
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 794ced35b2561f96ae3a8e8f5218f027a018ea2e77f1f530bb2142d9f9d6f575474267bfea8b4d
+Tag = 91de0b8590fcab76
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = dac8e04634f9d1ed8602b268fa975c4a66dfe81dbc9a3748b76f62a783a14c82e7a264c6b316d8
+Tag = fe47a2830ea7f7304221ddaf378002a3
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = a8c33ee52fca79c30433b32d9df026b433827e2708b6129abc771574ee92e5d9125fa414fe7569
+Tag = 9536f4114dad1c9f1774d9963ede93fe1e9394607072b545
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 75a2991a73ba38f9b8875c14414c5cc1cb0b3081d9fac50e85f9c80d63ebaf0c361f2031752b15
+Tag = 593b6ca4c9a2acc605f58f1a9eec64488d8aeefd13b493c33773b27053e7133c
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 26c1764cb80fd660
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 1058b8883c4d0312dd534a3fc3ca96e1
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 1e95f8f48012af7c9e1a0ad84a0db8a0bdd8f97831d83c75
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 3e451808608400b0061e3b32402adfbd621825f0ec6111e89303d758d0bdce80
+
+# initialize with key of128 bits, nonce of104 bits:
+Key = 3fd8710aa33cd56e07a039d26b049d36
+Nonce = 6dce2f9050b112733394f55616
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = b9acf2c35817cfe8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f7c8d7889617f6504ec251a0fe1bbda4
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = b997a9424785568f468abb41acced10a89347a82b9fe072f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 31d381578bc8e8ac59f8d60d610c206a20164e8d34fe61929a33a23231725c5a
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = db88d71606
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 7762b75f32
+Tag = 5f4cb41134875009
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 40b5c8e693
+Tag = 8fb0e0208e357b7f0c9104dd49ecd786
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 55f3ee5965
+Tag = bd4efd4de8d641246f7fe4b5198bb1c45ef55ddaff4f1baa
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 24716d6789
+Tag = a0aa801500d5f2664fe5f9a4568b6af044eaebd47154437ddfccfbd54e428f2f
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = d6a57abcd875e7f2c9009d65
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 97eedfd185aea8f52c2d61b4
+Tag = 8b7d0509b0f18e94
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = b0cfd6c7776aa9a0671da506
+Tag = 0452e48b87a22209d1e97d06093d8270
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = a2c3237141baa185103d186b
+Tag = f07ae42e7fcb2a0071f4a5d9b144f3e4a5dd2c01ff08a4c0
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 9d045d99f20cdc00137ea6a6
+Tag = 51a578b20d8d31e3d5d776cc2b25b14dded802103ee4604e6469461eb0ba87bf
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = c5ed559a738a057f556095f9a53e3e1552d18a708a286d
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = e880bb362501e420512ed3990aadcb15aacf00abe3a178
+Tag = 001e9b742d66c083
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = f6a4d8702c56c66e2a71c29d604b96c526923ef014c372
+Tag = 9ecb668cdec2b2047d20c7a4a38948d1
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 26eb1a97f82edf07b58b9171c9df2a470a492c8d4ecddd
+Tag = 6184d782b515fe5fbc6ffd4af48adcd39c7ea0aa6c9c9c96
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 40910d3af5b5392b3d34ba588d85e1a84f69052dcdc22d
+Tag = 57f77c66584de10e442a5c113e5560d102ca5b380e8dac0cc64834e3b81e43a9
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 7cb081ed79b1d70675c73193b2d06df46faa13d754f60fb025f5060c27a7641e958390512899bd
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = c23f12c44ef9f810ee71a2a948cbcba471f780b3fc886a7aa6898620a9455d99a6753159cafc23
+Tag = 57d9acea1b9043c1
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = c6666fd6c1237a3bb53dc9291d00bb15a2c208739f77bf3b1fcc022350bd9b3775aa8dd61957b8
+Tag = 5ae143f568f897b85cd5faef0eb54221
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 079ad0bca36304936e2856e606c7bc2cf6d6610f40c920c367ec2918baa9716f734369b1ad04b3
+Tag = f90fef3167c8245eb8550d47c627f15d23bfe910ef5767c9
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 3bd34e4c42c5bd58f9e1e49210c0e044be2502eedebe68b2dda71f847401c5fcdd84881e7a86f6
+Tag = 71d9855907269b5f70a7edb449f6c0aed541ebaf8588cf9d42da3278bb9007dd
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 040cf86616a9af9e
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 45c71565aec00684959e90f7c3929d36
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = d2e2200e0f01c150deaa63461960ab0f1308873ff55ad9d9
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = b51cf4bfeb0820492bf7eb44e0aea361db1b66fc76c76adaa826d09249625bee
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = cd5f041f2d30ed7c7489a733e33a
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 7c4a11d8786c7c254c62a357debb
+Tag = c244257301a67af1
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = c233c8dd87b94f6f58becb880ded
+Tag = fd84108ae35b7b16f639a267eab684fe
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 56f661e39188158f07bba9e973df
+Tag = 71a6fe6d2904c68207a1af480e297f58f7e115681d30f971
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = ec1ddddc2800b05b0fef03f72155
+Tag = f2719f403a0088258d7900e2dbe77efbebdf764a80f1167e73d41e29a213985a
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 4d4a0bdd9e9201c8ba27f97936901f0a7df2f3e3e2cc2f22fff0d986afec9625ccf622
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 8a32fd91946169f2102477ad2b5ea440d251aff6c479ba9d427cb7044bf36c03a3c814
+Tag = 07df14b9fe6f2738
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 0319e5034a2c5911922942d51ba54f484d0153eafa79639d42a6ed5d027a1782bb962d
+Tag = 90ffb591affaa213d23ee0e4cc2ef043
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = cd94c7f07a7c92d7bd9df60fbcfdf9bade80d186bcbb64812d2ab48289ff010bb58377
+Tag = 7bdd587dca3e40690d1ddbad51862fd6c4192c91ab897596
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 0877e7076a26c5a00c8865a77229dee529218cbd57c3e3596279c0aa8958127d0068ba
+Tag = c02b68c929a3f11dab66e7fc4e63a8e3937887ad8eb0009a4c95df94336c1646
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = c750379adc89aec6
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 59057deeee6f09422cb238f75f568d0e
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 58bf40fa4407668589b25263974dcd0ff0b8a8f2842f8ee2
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 499d055172e00b911f672f22f8eb7c38b98153fb09c3a656c60b5734f1a76eeb
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = b86285ab7523153bfb5c04f773d382f7d3bc248e
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 8d067bf0dd0f3df1f0ae68bbc657a5e011382275
+Tag = 3ec2b8a192b86762
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = ccf3b38da118bcb4358971780f00ef23e7a351c1
+Tag = 689d3d3edf6fcf21f32a06502a932852
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 62bbdb9780682ccdadeef99bfd26825673f61b89
+Tag = cb84e7727e8b20497085161395d853d88fb2615b9078057b
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 1655def19222311fd17f11eeb84510ee3e9c3c1b
+Tag = 1332021b086cb78222482237c965d0cb27c395035478cf695da18eb362c313b9
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 4f492726e3fe48d94c072976678a4e5bae8c385725eeb9fdf18833ac2306e13c6ea100c3d652485b954f232e588225e642d9
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 81457fca1301606dd6da2aa5e1ef10e7d0a95e6ec2f03d8fe1dc02505ef7ee377f9170e0383b0d1aa0ef471b4603b6a7d5be
+Tag = 4cfbfa7ae0c6586d
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 12cf4905cb6321e56fb7d3ab74ade42b42f74f911b12b56971e577f6b8c3a1a7c0d77dfa5c732d6c7e0df0a62d9536ca4abb
+Tag = c89716b5d95415f62c114b1cfd958931
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 6e1d7cbd9ae8b6aea6534a450178a79dc73955afa975e6ce001e64cf3d6e38b26753b5dded976b118370cf518c0742ff92fd
+Tag = c29d84295f507e69459ab252c0b588715671cfb7cbbbd1b6
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = f70ba0a6ede9fd4e867514e3c2c56158ff6b5b27cbda28d32c3949ab23553603a979cc9317ef6122d50722ea4dd645f96ca1
+Tag = 9f44483ce9e8b5cb7a8d07a546dc51b5b4f26fc16f28b1fb66b7a899e7d6a677
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 21e48ab20619b300
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = d04a895e25397ec0b1325fe372dbecbf
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = fda5d0f044a0b090ecb915396d084dc82d1c9157815eb285
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 52d4feff090dfe161adc8a9008386d857d6f1c29f3efcc38fc04c4217efd4ea7
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 4c151bb35bc565b55c028a8a62ae2edcc49d03b8dcc1685b15328d49
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 6058bca546d1cd17ac9259aa2bcf4a800d47eea5e13421130dcc08d4
+Tag = 2de1a2594239c682
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 28c7445460f11b11d952a7a6ca97028ad3d42da8bd5513a4110ad117
+Tag = 03dfb382d114c65e63cf41598c8c24de
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = f23b093acd3a1fee811112568528c3f2f116ba5bd1b7475368499b75
+Tag = c6e2fa9276f4d12f3d4319f18a9664897321e8f8e7c60d1c
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 5c8a4737e4f442f48e2790f5ccb38816e8b67fa56b2d102fb6b6fefe
+Tag = e449461e4e1e3b694a87908b824c264d55e311141d0e114deade7ac30258adf6
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 437e2c893e071e08
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 1aa8ff143aa1ffd6f8ad7036500694a7
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 30e4a13ba2d4b1e91d195741959a9e3fd624a532b74e9b6d
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 323f959e5e5ad3815629881d20b789948443989edae357085952ef3575fe81be
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = d31629fa3e63d3bc84885e6c1c07902f762da9e6ad4c38680405ba3cbde7968103361125878f90
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 0113b6a515681c978a6ba8767da57fe77234ff0b32ad76b07f9044c350e9257884cacecfb19ce3
+Tag = a1249cd8035fecdc
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 5b84d81a7e218305c2771fe87be5caf15f5fb052788bcc2482c08949ab0ba457af953bed50dd4b
+Tag = c8eb27b6f9acc522561f88a03148571a
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 4ce700829deaa573a71cd49c4df3c868c06df2b6cff2caf3ec3d445492ef65059e3fc95e353fab
+Tag = e3baea1aa9ffd84cb1c53df0b1e0ca4c42b651c6e2393dad
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 3a5aeda8892c9076e853b04c845df245b197c7e265c4fc32be2ed0d0bc6b1fa5158f4b1bf3cad2
+Tag = ee8c0f532df891087d9877c7c38e550c509acffa7616e6633c46d2db511762ec
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 877aa8cce26eae87
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = d6bff1fe19c3baf361286d1c04eb84da
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 00accac1e3a6776a2c55f031fc1a627c503a71ec48a052f0
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 2d7471acdbe31b0b06ad05c23cd3b0d87d6ce86319ac5cc1d452310e35ef187a
+
+# initialize with key of128 bits, nonce of112 bits:
+Key = 40d9720ba43dd66f08a13ad36c059e37
+Nonce = 0f70d132f253b415d53697f8b819
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 8de6e9b3b335af9b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f19cd75b51664d4fd0751c54e2978a34
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a3cc432e128cf963bc2ca2922ffb3aa9c56fe1d0558c6ce6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = fc7e8bbd774a6c7d0625f8a430ab8df0d022a20a1aa7bd5d20055c7d3f3b3d28
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 09e82b5590
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = c7d0b8e6cc
+Tag = 414867bdc5190f47
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = ce17823b52
+Tag = afe8a85c166a9e6678599562dbd5984c
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 030c9ac537
+Tag = f65c489a507f37a1398884d963715480b23dac881b7c1e3c
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 5b73c8215a
+Tag = efa8a44bbb0e887bdfefdae40f6b9c25617d043b3e93662892615128779c2f73
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = def3481e80f3b8df57aeb5ab
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 8e6255ddbd9d1019ffa79e19
+Tag = c88d221edae3ed86
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 1dd12ded962908d7edc5a19e
+Tag = 18947e37bae533aaa183f50687f5ea67
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 97aaa4de17ed6ae06ac7baa2
+Tag = 23f30c62bcfd3517a8d11b1f5314c960077051afc5514347
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = a480f64c8b2830184ac5d571
+Tag = a5dec92a3ccc392d74d89f581014dd78e9842f86e9e167fec37e03b0e7744d35
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = b6dacde7a690da761d30069bdb80424b992a558ffc35b5
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = e4107a3b9e2ef6024e3348d5dc6d9c64f94ae1fa8cf3fd
+Tag = 4f4a7088df340b20
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 21dba4019a0bf3a8d4657fe7932139b6e3e2e5329f962c
+Tag = 1554ffc49316f7cf57d3c1474b3532f5
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = d2d4cae262c6578002b601d2829100f9d9c5734fd847ce
+Tag = 0589bd46bc8aef04e5b94dd97da02c24194380a35a8239f7
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = ca8dda016dc81bf031d0d4d5b10a6bc49c3620e484e946
+Tag = 709256b21449bd840b35af44cb124720cdad9130065074ca1120bf93bb06c4ee
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 6cf76d7ef95267c4d9fdf1c70b4490af84dc70fe172182cebd4cfd413b6d01eb17ed9c11498f2c
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 0187b28d7b583269a1832846ac5d96f3652ca16ef1f2801aa2978d130577c37a0ed15368460991
+Tag = 770701b8f0009609
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = e72507e0a9e7017870d5a55bc1cb7edb808b35cc059b735c94b4a006519df4cb8afc4de6cb763b
+Tag = 7515a69905464432ba03bb4b5088b40d
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = d4088fd90d19d9458ba6d70482dd732e15bee0637a9049cd15d8d2e7e9008492ccf552b06d2b13
+Tag = 867a3ee94032507d898f64cd374df325e5d2cf1fad6d966e
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 654f732e0fc1af8d47d99d54fdc587ed7440deb2de87354bda38bbaf34071ab372991570eb7307
+Tag = c42efcd315b4d476e1c6c87eeb12dec3c6cb5d36147b0b3ce466ea31ac51ec94
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = ce41ed21cae35abb
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 049c61b96a7b3d44711bc320bb4ad497
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 5f32c2dc074e771a28778ebb4d26135612ed0e37ef795f4f
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = e78aca75aa0b651502584a81a9f07ddcd8bfb1e1ac3b35284fcb57590890574f
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 9e184a107e47c42f224eb279dd7a
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 4d8c0bf30a7466fa5f19d73ceca0
+Tag = c5c03cfd27779b65
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = fbd0c2631a6d52d0c3daed7acf2c
+Tag = f9e5ffbcb9926f1f44035f7d52cd1299
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = d9d3306fa4e96e513767b1d77b60
+Tag = c0811a0d128d01f5832583ca1021d95c57666cd8805d30f3
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 0eed82dcb3684c50410c1e3f9db9
+Tag = cf340deeb5486c3bdad2afa835f3e2d717f8fa7da5764110071ca09a63db093f
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = bd110ec6b987fcc0baa52991504e254cd94b77740fab9ede7613ed944f8c97b883d15e
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 1c34344693ffb2e18728bf0c4d1c2c3f7cc9852d896afc90a5bb09d84c8ba9c9880906
+Tag = 00fc0f79b7815281
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = d388123a0923973094d3ca0c88274ecbda025575ca91b7c375a0243052ae04c49f9683
+Tag = c01555d1edb1558a73c7f6b56bb4ad41
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 3cb60fa9dffd4ff5136dda522c69e887643db303c990da5a59d7a19bb220f3dd983cfb
+Tag = 00b0253281881ac0dc0271041a10f4d5d4066140b8c457e6
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = c8dd58761af2e8b43ff005aef2ccaa3f84adf10408bf1a58a508141a548ec2bb1ffc1d
+Tag = f9a817b4aa9581c198872e7152d21c17bdcba640dcce5de4a8bbb97d6559c923
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 9460d04b94632234
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 0b8f0cbab9e7e95bd3e9e937bf88f33f
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 0cd76c79d0f185473175ee074c80872bfa15e63cec0114c2
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 3866e0baabadaffe8f036b2aa860921b448b46ee59743fc0ea82d1e2afa116e0
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 7bd03ffba19dc976b0ce20a2487e6f0baef5ff72
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 0571dc53ccb8aae4990bc0f07cd8fb737aee4114
+Tag = 62809f6603cec78a
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 452f2bf7e2860ac19f1b04193f6dd205361087b6
+Tag = 4b8305ea6c6b3ad2bd5a02f9161c1d8e
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 4e75196d4740224be30bd4f109ae87d85fc54850
+Tag = b69b7a8089d54d5dbf104d5f6ba6b36041a2fc03f4d80cf3
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 380fc12a9efac0a784aad51e5ed15bf4b4b2fa2e
+Tag = cf368480a9ca7732f0b6c6867182fabb98dc8fef2075b09fd9d9490784f8363e
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 6d6de97bd5bcdde2f50c45e9d8e1868fd8aadd91a086fb4533ab08c5cd28bf9a0006274186334266d8cbd328d3c06de41827
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = cb9ed6940f84f1e9aa32f2791c9d34802bedc93debd44ff67b4970d9cdbe6de900896ecef9473d535102a9acf26b134520d9
+Tag = b0d4ce93051568ca
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 97967e843748acbe1be8fe0027a32dc11ed1779bc86b55fd8b48f8c2a346caf59a286e829add568a83bc2ce3a52453561c88
+Tag = 1d84bc9120e46cbdfa84b596651ef4a6
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = e45ca7375a454a7cf96bb8d7945112bbe64d744f29fba13f2515e8aafdb0381c97e089d2d1499d5da39bea71ea9b7f9c399c
+Tag = 96cfc97a5619795dae4b634910404413f1fe4d12dceac054
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 76daabeab36ab663ce09183b5a49b27a787d1d718b83a6b670eeb675afb3c6d9e8dd2207c65ceeca0fd6d7cf4ad288f4d0a2
+Tag = 8506d39531f841757b7cff93e2783414588a3eb87b8da7b0d39493a8bb86d07d
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = c3f4f3476716e447
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 8ee5c6b4b8890042b88f6cd789a14d81
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 645192feeea8214a2c1397dc9b81aaadc58422245b7685c2
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = cd5448205341b595782ef239bbf7f74138a4098d0372b922092fbe26ca249a5e
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 211f598760676e328a3f5bbf29bc195d5f8a8c5129866309530ca5c2
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 0b393263c34eeeda64287228a215ba05ca338ce42c44f4f29c928e85
+Tag = 63f8ac42eb7f6b02
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = e1a5e61091ba5f53fda8919ee8dd668efc439c099a4cf9020b2d6038
+Tag = 82dfad77d4e98289410c83a0d05056ed
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 3e3b0d1eb1d1a9fa88e0ff3e0658df93d9bcb0ea85969e331da3c608
+Tag = 976eb9b6213094b399fd8a5583a879acefe3fa4fbcc4beea
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = e00d26a1563d4ebca0389b14231d4aa582cb8ac4b2483aa983bfa61a
+Tag = 35ef1f97ed06e7556e95ad7fb6f310f2a7b9677f1a36c806d256232e4b2b57e2
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 59db5016ab46566a
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = f0b8af1e2aa7f3e8af3ef1904d063d33
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 00cc8cda11fd65f378644f94c84ef5e1821f956fdb2f8aa8
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 902aeb08b0d58b3aef647bf848bfd612ac5bc204df561a6b2ad1744f224a160a
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = e2fa69244d0d006f2939c4e364971e24fb8f4eefcfcc24c209175cf6ade160d57a0864c7a343f1
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = d934d87a5d26e3ba47d1bb40f1fd25e379620941b97a57d5d646a312f2a5fd349493954547e722
+Tag = 7da55321144b9ee6
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = c05bd537b6e33b961a526e50004f92d863eb5c8f89672c68afcc1200d0e3a18f7e7c1f43cdb4a4
+Tag = 8bbb409c48986c50bc5f05d54daab70c
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 6723120207cd63e171f3db9770971fec148ebdfa373592a2d4028e34e3310c83870ca6c0fa881a
+Tag = 61f70e593089861f6a5e1f5cd19b4ca27f4b1e7975be6517
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 4c00ff62f57f351c8c4e2736b986b683b426d16244af4749d04151e381e87444bc60dd0a5a41fd
+Tag = 539cf36cf91cac567fe847d95e77e0563c6c7c954888eac69936178fa81b133d
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 828d9748c7a94735
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 23b49042d21764373b92d06dcc5df06e
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = d5004f929f520a091d8c3825ae0d779931473ff80b6751a4
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 9346f6f3e4774ef3c04136d67de33ce8341982c97e02a9e5b1423e00888c26aa
+
+# initialize with key of128 bits, nonce of120 bits:
+Key = 41da730ca53ed77009a23bd46d069f38
+Nonce = b11273d494f556b777d8399a5abb1c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f88d8f445d34bcc1
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 90e90141cf6e5590aa902aebead62b09
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 92652215108455d3f705fbf1fc2ccd5a70fcf15452a5210b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 347d6d2809975a5dcf40c39bdda86455c30f6e538ab3bb878fcce4f3f7be20e0
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = ff8fa4815d
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = bc48af8bb0
+Tag = 7a6bc78ae14fbeee
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = bfb8983c44
+Tag = dab135b03ade444e6364ef37c3953b9a
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 25ee604cd7
+Tag = f1af3d5674d77fc3837d0b12301f3d897968b0edcf2ccd0c
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = a0cc62100c
+Tag = 7a32506ec83020a65f4d7d1e4b0fe9d53dceec7e9411fb004a89102f06a5965c
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = cb3ceec73f568445c1966b2a
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 0d8588fa86b5dccad188cc53
+Tag = 7535397040a914a3
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 001f56fb860f1ec4f9a619cd
+Tag = 721c2d54c3f805e7670e1af9cb21b76e
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 60e312558ed2361d1722ebdd
+Tag = 237162d1dd3f223e3025058174ba0ac5bd11259cb8ddc61f
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 1eb75d98abd7c27e0d0b9dae
+Tag = c0960c2dcd3f638e1dee0cd96714daa5a0f93f47f3d1c61f690951bec8e0124c
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = e49c75aa204f4f18b51ba6d4ed7ba664a55ed1310e3f84
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 0eb0bcf15f3ee4ae90509f1386eff19f3b5c5e7c1fe634
+Tag = 14380bacf0ac5c31
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 9f7249e095e85733d6e9d0f99ebf4e6ffcb135c03571b3
+Tag = d501b7cb37d357e4a09ab90aa1ece87c
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 7865ac1df3a3d3f72e0a87a50fee4e3c08937079e49c7e
+Tag = 7913fd95fe9c155ade958882550b26abdd8c3afb173bafa3
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = fae269193e75347689d728b6d62acd34c830b474460b39
+Tag = 9192d82793fd8f777084cae76adee753e3cb0b4413e38a83834b7e275e02506d
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = d3ba04fd5bc57f0c597c9880962015e17f974904c9e6d3511ac1f0865a1967e7e48d774cb999ff
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 93969dacf094034708f95a3bc787df6a6302241c7131718ed775dbeaf1684d1aebf6589989565e
+Tag = d8145dfe495e1c86
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 971daa6a15960a566486e38f8dd42c3bd529929cca34fcf4c764d85521f61d18f2be6371a3352d
+Tag = 4e1464ebcb1e2df92b59974422a2388c
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 100fa426410e36fa6e103936923cbfef57bf85b3aa1c42e5916ae49f547c6522d55d0ceff5705e
+Tag = 6c0800c1df4a593172dd23bb9d4dbaf6fc167080d869a24c
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 5388dae93ae5aac357636f79abf98f1dc1cc7a54b9e1d0ae6658b613d207712a68e5f12fc14a70
+Tag = d43d79aa3eda5f098cc02a6c231d625e92bf25eabaa005075df0e7612965d4f0
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 76429f2c2e037a03
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = ac30efb91022020e4965e94dffd57b41
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = df83ffa18d58b5da67953320bc38e2611e1043d51c9700e5
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 4ba7417762defb50a1f1a1639c9af6650e2c438f038f027b25d17696876116a0
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = fe7ffb9f4f4098c766945ad70215
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 0247dd7e231a8ff4bba2aec02e15
+Tag = edc827dfaf6f5e78
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = b34c696d49880461c24a98ca6f43
+Tag = d4c077016805d14c41e15263a74caaf5
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 06a9e6ce5bc2b237a90007d642cf
+Tag = 4e954c6bf780e5fded92db0c3a9c9650c17da3b6605c06d5
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = f4025f8db5c5e11f77aaf96548e0
+Tag = 19d441d4f67f5ea4089c82d451dd57d6e82bfa0d1b6c5f149260a681540c6276
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = bafddf77a4b5e9d1532f7678f4652a51d6f2e7d1eea5ecdc62ba6266bde8f605d0ee01
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 6edbf8bca3737061f93270922f721a009a7c009a5760702e63e6a195c03d541dbe831a
+Tag = ce4126b7707431a1
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 4d2d0f3b3ba88fe2056e1b5575110bfb3663fd465c5093f469bf8109975ad5510aca28
+Tag = 773a12ab3ec882d65920df48759b3360
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = efa05301b3ba276514d45a28a9749553e0dac012d1b6a3cc5a147766cec6a2db526dda
+Tag = 8fc2d2272b160b64c4518d23a1d2b0754cf722e983414830
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = b99446442144d48ccc5aec8e1f94ebf901dc562eb01d845ee91d57b372531b72ae6458
+Tag = 55ae71a4d2be52fda24b86e04c1933b6c29487c92f5e99a764fe0e4ecba45bc4
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 77cd6d32ecb5887d
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 8c9af5adaeee4bee25aa9bf8f708ce86
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 7aa5cf08186f322542fc405ed91173280ec83a8520d63d8a
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 5076203da130158576a34336d888006a60dff0d074bfbca0b99a1015ddbca32f
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = dda02c8ce6ec9644cd9276417cc6ace2e9ab4f37
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = ac637ff4c60307ed8318dc25b4bece3773b53e08
+Tag = 2a815c41535782f2
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = e0f4004179a048cfbfe5429217ca41648f5be4cb
+Tag = c4088422e5df1b4ba0b03c06e37a16e9
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 5ca0b29bf83bcd0ab8f363289d1fcc5238273bb1
+Tag = 51fce7942c8a9c1b3c60440a4f17c97de8612e32c87c6071
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 884a0e32de401b2e85ee59be40b13f66b59f559c
+Tag = b9d80a9bf762cb45d89babafc4af19ffc104c614947e6200c0059d4bb7fa803f
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 8c2840081a0c14d23a3f0935806f8700b67c05f39ce7c256ce8c0a9c29800197bab10c5b74e46331a8f8e48a3846dcd62ca2
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 90f8c0caa262e9085678c5ba2b0797e1787b97dc69f2c63eab23f62cdba6e4a4724501ed5a037a07fd04b2e8d27bb792684c
+Tag = e137179d35f2bd45
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 63e57b9be134973ed2249b3e390f42682d2a8117edf1aa2add4e8ea5b517129c52e513d5ba6dfb5e848ed52ce40808079bd2
+Tag = 35acbc4275cef3a8698e0d91a9ca2388
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = e744a60bf039604fe020dfc0b281900515ff51de3ce40bf3dbe19b29aef3493171f002d01487f8250845597ed0445fd1a4ae
+Tag = 80037f259ab0f7132c667264cad1098b63e5580ac8c703e5
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = c0683ffccb7c05a95854c3e621a103ebd77ec3d5a803cf0f56f5ae22af78dbf2f8ba3a39a5ad9080257b7ec2e09374dee847
+Tag = b918f7a45c7785c88821d7c1f28fe1e03ec4b90487d844c11c0e2d660bbfb41b
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 5ad16b6db1328a1b
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = cc48833e4c72e73a60565aed184856ff
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 80d214d73b4740208ca0058e4f30f33cd87ca0a19df9f63a
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = b1f0508c66d0d4aa41a0b0e606d95ae877df4c151b23b4831cbf746d2144a5ef
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = eb5e7af5909921604f2b07638a1fec42fe8c43042fc84a6741866fa0
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 52d9dd5e45fb46730db7b741b593ce51e46d1052bc5f5ee8484ddd5e
+Tag = bddbd6cb5f6fcbd3
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 2cd38e8c172c4c7379d2cf1f843c8d775a4ee4ac3a284c112dc2c8c5
+Tag = 4a41be31e379cd7fc3e79fdd9611b754
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = c9b7220569cf1f65760526d74c9a287e75e876cb5f3ead4523d1bbba
+Tag = 08c3024f596f6db6a21453ce8a47bcc74d9e139cba4f412c
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 16187d36c4b2286511ef32f3eb9ffeaa6063198864d834b7964a18c8
+Tag = c9921089ab7b6282876cd3bfb047dd496586da464bdcbb157fe5dd3ccd9294c4
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 91a85d3babd47aba
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 4b45030698e7cca7c2c8bf941b52b684
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = ab29477784dd74908ac2c4ac84dc3c41f7a9d4a46b9ce526
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = f717a221aebd4f767c710b921676d8578b83c4a9c1ac43127f6853f9cb408409
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = d9658e2b6661f8c6935f84cb0f46050504399c8c4315caa794e7022e3397b1c14bd367fca40cd9
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = df8da79dc1955e95b39755e425067bc9beeece147e0e00da2315775fc17ffc9af86f1bba42e86b
+Tag = 5f3b524fbf6e9c56
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 064a931a8b5809672102c6163e686b1a8bb2ec91e8ea6bbea8e50d04df2ae42861f6c5241b6346
+Tag = b28623aa538494c957907bd3017bcff6
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = db529b60065fa1a51d6c95c3958999500c2a2ce7dfd8d09cd0811ef4a95fb1a13c48d4e0747d00
+Tag = 4f5e819f6cabae36920d7722668774006731bfb591665fcf
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 3c8b5789b34a450d3cab52b3230d96ce70940f84c89d866da1338e39b3ddc07e0e144371b0cbcf
+Tag = 615a728760df1e3503c3fc0fa1bfba9b013723e0a8d5da0e1e4905ef68058a64
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 7267587d3e42f44f
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = ece7c88ddc7e62c348c7cf4b6a8279bb
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 56aac97e187ee10fc56d544e14bddcfe951cf998b5f00d79
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 8291c15517933c9c7c0e43fcedb3a0ee5443d4dbb99615927642b8e20dfec06f
+
+# initialize with key of128 bits, nonce of128 bits:
+Key = 42db740da63fd8710aa33cd56e07a039
+Nonce = 53b415763697f859197adb3cfc5dbe1f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 384f1ffde9046f72
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 662ebe4346dc56bdff021568e279757b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f5bea2c42f55562e484628f093ab99aa42cce8b3072b893e
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2993ea4d8c76a8c2067769f408747e1353ac44e9425f327e1609bbb50095cc74
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 4bd00deeb2
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 851d8388c7
+Tag = e1c05b1215524ca6
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 9d8205cbc9
+Tag = 74850b9610266134ea6bad373367113f
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = b606133e8f
+Tag = bbec38de3ec953ba21879d5bf8167c304be22864561aa8a7
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 72023f4b0c
+Tag = 58197ba73ff22c0673db40396dd01949763c62d03419c5d9b500575298e57801
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = d8cadc119d4044dbeefa8b83
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 14347cc8d685497dde5ec06b
+Tag = 721640bfa88e8832
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 180aa6d962f463370b82fcdf
+Tag = 3d8ae07c835c6b3a69153636c22e2f70
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 526ea8c72af86440786aaa8d
+Tag = b67b8194d871fc6623ee54ba33836f9ac44f4d7d73ab35bc
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 8bd9bf9aa89162e62e13f038
+Tag = e1c9827ccf818b3ec6c16085c0ca32dfa2deaad19739b336128e3accac3ce472
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 0bf9cb88e4182588e319b212917b2337b6ceaf81786bee
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 61a46ddb518d8522299fe8f816cb1975c3c8919bfeb3fb
+Tag = 05e56f0c60878447
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = fae7b7aed111651ec82e0aa0e4602f9b3836b5dd0a3fd5
+Tag = 2c78baeadbef38fb52cf1a768e09744d
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 642d1db90fcac67e798fb0a80fdb758ab9896ffdc49206
+Tag = d9ddb5fc70ad54b3a0efc5da0ba336786d5eed5bf67902f1
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 98480f772ec6f6a9655907ce587481bf451b87f672bde3
+Tag = 568a69222d8e7ec1faff4c835016a834b279318cacca91abb7c4e09312154ede
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = a48d9bd7edd8a62ac35e26596d4e7b295b889de55326b24b27042c51b801caaa226783d08b8fef
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 31c084ed00e5531095b6d26d60e916e38179da35223b6463dfd98dc341b21a1637bd135130ecec
+Tag = 5036cf6a4a1635af
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 50f8bbfc94b43c8ad07889cbccd43a5fafd9797d520b3675e7b5b7e856e339b464251f64724af4
+Tag = becfb885fc55126627193ccad9e04b4a
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 96b7ea5afebe2579312385a9ac0839bbe63076a0416e7ecac1437b6f35a76cb2531f89038df1a2
+Tag = f180688ffa54c6bb93e31f59e5c9cabd32fd33749887c8cf
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 333a54f828f16f4c200898af10d5504ed21f1ef027e7efc0852c0750375cb9f7b29e808db244f1
+Tag = 60ee176c88a4a5deb4d6d3fa227e78ff1c546e126cc087c5bcd27f5cfcad9a44
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 75bb214bc37276b5
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 6121ca29283f083073a2c0969e3e21a5
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 68102e6d7e2f02584224e7347459ea0355c764d3cc53eb71
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = f482e5234960aa2e66a4849c4a44760ed045142c9ba41fd19948d15d62be1b75
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = a7df33d03942b8ca71dd5cb2b7dc
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 44f35fd999c8a908d6de49465d6b
+Tag = 0037caed0611c9de
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = f964c890209884c0589ce5564ff1
+Tag = 031b6f535d1aad26f5b0d768488a77eb
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 67d86f2a824948a4f1cd5798d214
+Tag = dad5e7d7e499a977c758638ba0aa1a72b53aec3553f29e44
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 1a7ffc606e17987477fefa9cd2af
+Tag = 9a8064b24c5e85487ff5a94501f621025d1d4c184ee8345944655ce9cace5c64
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 9dec8cd4e8b1bb7cabb0f4ba5bdf7a8639c98c57597dc15559016007c0da3bc9fd6eb1
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = c116ad713334414b4d7808be9405317df65974935848d803822c15bb00fa7ee3dd34b6
+Tag = 90bfd510f0c1eaf0
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 511e176a9c4d75d1471849a2e3609d0ff5d7a3f5bb6ed52f6fa1840053c1770781c31f
+Tag = b520a1e1fc740b2d6e2b91894bab45f8
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 890011e1ff1f949c271a33d2a1db1361d36c08b44343e384c8fc2ddc83ee7043003264
+Tag = 58fe2871401cf5bf3d92b5c37350141d7d934aef80e2626f
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = e9dd683893abd090a304b88a1acfd2716541675ea1e488e79150a6d085c0cf884705ec
+Tag = 5697c0187a52c349336c23fd81074e0b597c6fe78d07c0f20e90bc3f31ac36e3
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 8c2cc22837b2ab52
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 17c614996d1dd698829091f13446167b
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = fa3bae40317af7b05d49901bceb5da0dd99e247954ba53ee
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = e66eaa8528dad8ea11f270c5b167d5c064edeb6162430058c5f36efd0771bcbb
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 636344ab2cf4d45eb13d7fd73eb74d82048cef81
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 0fcf45a5ca3db09af8b17d72e062701907b133c5
+Tag = 8eac8731ee4e1a7b
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 10e369bfd32d04b676fabba56e4459f8a94f514d
+Tag = 0bbd416bc56a5e79b3c6e9f6c54fc3c3
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 453ebeaba798a8d78423440d362bfb7a5d17328c
+Tag = 92cc493b333245785b42285224dc39202b5cc6135a6fb3d7
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 0ec99d07cac9fcdc1f241d23538bc7a31657dc93
+Tag = 619789df7569bd6c73aa3c1088347bb8ddd96d471de4311df644060259d999c3
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = c413f3387ae60ef183e38c6e531b19a20f7ea8cffb14c692b874a1692f9280cba114174954dc52c43b8409674784b23d0472
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = d651babb9e9de2662230d4b4d866809947379ef095d5e9bccb085cba5207ca9071f5f8c1830cc1094794bec66987ed74105f
+Tag = faf00d987797a4d9
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 488e1f9934d810473a71525fbee45bde2496884785b4204033765babb898fd115212e21e12ea0c26c37b2b9ff31b050adccf
+Tag = 5ad61a06a269d00a8335965358ed5d7c
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 3477500d6392ee2944c3a32b414963c5dc2e5209b9d6fca11f20645cf7dc2067688637a0508cb352c7083c8aa47551ebf691
+Tag = da07a49fd7c934bf1712cfc831c2e9667cc103fef908c6d6
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 054bda9810ecb01e70c2daf8eedced8bb77b064159746c5780d4753e5b0d0f2e904e3bd9dfc4704ed12c2aff14947e5eed52
+Tag = 5aa96395131ca1fea26c0f88556dca97f245343d3bcb91a52ad0f5e3d426fc03
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = eafe1a85ccbd6627
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = d5eb46deaca3694122a6482459fc26a1
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 1cfcc8c33f6e084286c1cdad1727c7df07892ed4a4c117b7
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = c24f4403841b15483da384eaae4d102b3c3bcd5cf6547cb04172e04ce758ab38
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = de21858554df6811b35582ad4c57f41098924712b42d7f487ebdf388
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 29fe55450ca803f854b55dc74bbeb928f236d69ba80981e26f2f04a3
+Tag = 399513aabd315b83
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = e4eb5471a4d3f24977713b2843422e9bf05db9acf9113572c27bed86
+Tag = 3250f7a3b96cc426b33dff8c2f227b24
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 57d52c9c98314d2f3f482ae551ba2785312583bc9f502212c62b96e4
+Tag = e93b44f8b5c82a1fd05b4d873a9c044a740641c0c979f079
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 6a7d174949f330ef5ff0dff37c08ea742d7d99ac69229e78463444e9
+Tag = 40a149fcea3870cfede5aa5991a33869e795b58a919f6bcb9c7f2fb75422240b
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 03a524e949641261
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = a0df425bd855fd091373e380b040be98
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 752406e2d6b2786fd7f101c08704035cc505d8e445be95ef
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = e849e6beb2379aa6d9410a2d7d85728a99451ec2ba7e5be2a6cc9b6c0153caf1
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 00787a9120a6d1e25f69fa62588bc5b8a5dcf1a2958403bbaaded3183b0d300abfcc9d39c99cee
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 712ec462ed892109a45aeebe0a885212d9b1701e7e12c12b5b80d0ae78eb246c3f6b66b47003bb
+Tag = cc31da33745931b6
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = ccae15f5e5390b56248afc04e96486d742b37e7f4a6ee3c4bac14c89ff7312b519ba18d8871b8f
+Tag = e15bb47e543fbf9621d1ea3b20539940
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 0a1c34badda66199d5028e45e7d21ac20abcf04420a7e9f6bd7e136aaf3e3eeff3d41bad86141f
+Tag = 07913af604ba23ac56ede7e0627f43ee16493a52f9f4ec17
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 6f9849b20c1ceb99d61ceefde7b0e55dc71bbc6bba790c49dcfa6731e60dfbbf7de6a1fa214fb3
+Tag = 2aa6ec8c321113da12bff4624899ccbf9dcefc25d7b74b5fe7a398265c11913f
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 17854e80886e1f23
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 6bdc5897093eee6e9e53d968af29098b
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 99525e5d05896740491dcd96bd46a6f909ff234ab1d53bbc
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 4a9dbeb50323f5cff20ef984d1a5232c502af650fe844c3d8fad808150043090
+
+# initialize with key of128 bits, nonce of136 bits:
+Key = 43dc750ea740d9720ba43dd66f08a13a
+Nonce = f556b718d8399afbbb1c7dde9eff60c181
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 08b693f8b86fe57c
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e2a959a82323a216d32a5ad04dea5918
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 0288d1eb0df2242d93fdede8a047810177da4006e928a659
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d7033331a2c6c4c7ea39e40f69f4faa88d8281625ef079a34e81456ff554578a
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 85a305f53b
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 563507bc13
+Tag = f23a688eb7b524b2
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 25c18bb7ac
+Tag = b15de5812ef0dbaa86063875226c3d07
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 6824bbe2ae
+Tag = 6b836e1d9be33fffa08b717496b4b5a18d4e5e135cffd9a4
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = f776aeb501
+Tag = 9c7b30edaab24fb71c9494b15ed2fe799eec15d56bc36ecaea34d0adef185395
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 98665479ae97d9a803d8d8b2
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = e82ed347e1616191f4af72b5
+Tag = 48e06b5119b49093
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 840aea9d3033850b84185f3e
+Tag = de054bd843b45b097458112cf2b4a7bc
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 62ee15758b8af3dad60495d6
+Tag = e47df48baecca086989b11467bacb960f1127297762caff9
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 930c92c52636507ea12d58f2
+Tag = b1082fa6e6cad8fbc64f775847641c60fc45cc6085d0960c6ebe6fb8ed01cc5b
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = c9bee906691c71eed1258530171e8728d91c7e79264868
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = ff7a63832cc7e3ec8f5d7e42a60224e0178026065b7043
+Tag = 70e8fd6287dd1389
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 79cbbd712d5a844b5e533285c8d341573de97319dfa196
+Tag = cb25ebf4c076ded4b35fd9fea2ce1aea
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 73c6b3191360d0b13c9dd0dda844e1f62131331a4385c0
+Tag = cd439eac69680b10709b55e0628a08b41fe4f48be25a9f1e
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = fc6926132b95080f0b1607a927d32892010e62e13c579b
+Tag = eda3580cdc4c260ad35f75c58265a98e7fccf00bf66be6b6030701abc92fcde9
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = cf86b667e86dc2398e4d6918c273f6bb98e253ec419841a28de86048fee09efe6199e83828a42a
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 02641c942833ac7d50f741539b896c9c23ef0375f98c92667f10c5026f6652a49f1413f621f9e7
+Tag = b5205021ac629c0b
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = acbf2671ac06cefbc2760cad77d9e43dbfe182adda344fe0a6a5d32e87abef47a5c67cd4e446a5
+Tag = 86031f44ca62265a555418eff4994f71
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = daf051d09ef847f05df0cc03661b37b1183de3ea67b51e329497251d2bd5be6e153d2a26039c28
+Tag = eafa7bdfeb72d5a1be0a0555ec0613008e75e841615746d8
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 1d1c8509205bb06e4f35c4339a1625d54256552b39fae3bcc3bdeecb1176098a93d9e89c9e0e77
+Tag = 3ee2e011320268c61fe33579bbe6e3a75fdf7d44c187d99947c47a184cc5fcd4
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 37656057df19ffb2
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = da6a4868e1441c633233ab487f6cb879
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 055236698a1c7954c801ea8611387c60f94c1450192e596d
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = ee71b878a5c59785635f015c32737654c2769fe6f4b13841b0f5d407e0a84b7c
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 986dc613bd080e960ccd74235605
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 88146af5d83d05a0ab3291d980d7
+Tag = 9baa1874fe18736f
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = d3a1c47fdc65b1ffa73950040260
+Tag = aa955fdcc3d8f2b7529f7be2bf706c04
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 3a1337cc06a7ef938996843977e6
+Tag = 789fa9ff478138ce200cbebe1035aa2004037d66fd6c9a67
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = abd4f1ead9ff784f5760054c887f
+Tag = 0018015830f5118550a5561e4571000a8b2429038563bac52320d8147ebea397
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 2562dcd4ee1ea9d77378b5f0f04592087f304305ea910720b717267b6a48e98115fb59
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 4260cdfed4c120133bf387489074ad5fb18993dd84cd929fd1311ddbdea122cfe5fc23
+Tag = e093f52dd325c5de
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 873e2528684c467be4aab870872ce5dec0df2c01ca5671914a401988aea81a2ab02a06
+Tag = d1e6545685b892f253a922e3b16ef893
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = ebdc36caf9234ad97402af0c035786aaeb2801580deb7d69f35e594f113f904bf86dd3
+Tag = 5fc144596c5def23521728bcb081177be35cf8ac93592071
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 88c7946951e4cb39a1a1183db6a49986f0ee55f2d3fd7f2456d0fa2be6ab5e2c86f689
+Tag = 838c185bd971f71742729c207de93df1b61f2d202e6c05ab72b5c9bd2e6b5369
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = e6c2b8d3df2d15fa
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = f5fe9e454448248778f882f8e4032c22
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = dc0feb53ad576fc7260b868599a9d573fc143d0e5138b351
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = a623d7015b8b4c65086bd9409c0981f27b099a9db44dc8b2eb6f1fd52eba5c5e
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 82612a3d8a11081261bbe5c90b059c20374f80f7
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 81a851cd703e4209d1ed319a018caa823210cdc4
+Tag = 92e5018f5c3f8ea6
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 02a9f40614e555456bd929c3dfe7cbea9b8c6370
+Tag = 026e72f2e1aaef68167a5d30fa756110
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 6e1eee162d42482f1fa00cb91bf808a262d7fbb9
+Tag = 09a403682110bd98bbcc99bad0ae26c149dc477c6d26760d
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 3e025a3a4a698677537213a78403f887a62baace
+Tag = 7efb3c67855073f8bcde20220209eedd059b8080ce3d1212b0205c4355dd7186
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 07ab4f4bdd0b3ba380960f3b49393d7d4863da4d467e4ede646d118c10aadac8191579484f42eb1d36f2c7c052ee3f36f0bf
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 62c6951d4826ecae43bd024514a84b7b9168fd252b13717be4c842c375451c436769ed71845818f92e44c6688bf67c23cc4f
+Tag = 0df937d470404027
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 3a346b81d3408837ffb123d0920151a9c23c021e238ec1e5efefad5fd90e89b3dfcd06fbac5d019d8018bcba21c162de4bee
+Tag = 80e99b6a7b80aed72a5c74a247f446b7
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 0c791677bf4e8d8200b30d890868332a582a949eb22d158bb2a085b6e4e5be9f5902378b65534d930dff6b0fe9b4d1aa4cce
+Tag = 9ff3f7825094781adfb6abe642966b65a6db3966c6e33aa7
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = a9c288b19af0fda0b3697ec30d451f196579327ff95927d820fd3c9667dc097882327ef1f8e3a57b5e812df5059892011963
+Tag = 09f1ab5719d0d3e384bd4d1e24fca2b5c5a94bf2af904601ecbcfe2537101070
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 54da5b3433cd3be8
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = b05ef6209cf8f597fbc9f7286dd5dfcc
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 576b486502e9dbf2e2e18c3158339df497120589af3953e2
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 601f3ae6350ffdcb6a21b2be4eafc34969e4acdcb634338762ed3594d4e2dcf9
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 1aacd40952995c4d09cb34a60a0dcdc56ca6e105991ab6d494982bb8
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 0cbb49ec76eb8d4d6f84857e1e7d8276ee50f3fb3827d1bab2928cd7
+Tag = 8bded782e0b95e04
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = bc329a90cef36696066b4a8d77a60b33ed1bd300598aabff75182815
+Tag = 5c7280bb858d33f9c244a1e07ef0246a
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = ebfc35eff68ff47fa87424c1690aaba3fa7df68153fc6808e21f91ec
+Tag = 3a4ceeccff83e5a13669b86f9a519c0ecad0536d247cdded
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 243b30195ecc16cf57c4fbcd4e2c28e34b44a46e4f38fc54cc43ae20
+Tag = 9f47caaca90f08f3eae73fe8e84004a93d479e70eab041b4c78d3d45769abe54
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 8a5b462a309bc6f0
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 9dddf137998c6bdc480d2407c93217aa
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 754b6737ce62ee281397e68c69456bb3adfc1e7a3f614978
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 64d27bd85171fb18fa27762a48ea3ccf4e81930345cd4d694c56b181948cc10f
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 2bc6b65a42e5e8b7fa9a42584df0149ad3feca800f6424b63ffe6495d14e98a5ed85a5d81f0d06
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 608929b837abb72ec1f352efe79baf6894f97e761908853d41c7e941e3d302c5443f1c815a4137
+Tag = c57bb38c9313a50f
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = ba1b60e740aa8d20eeb8ff23599a1c8e3a91254c40ff5b2540aa51e13386513e5c864826e30c85
+Tag = adeb264cec58d4e2f874828d69dbbd88
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 3117bebb37741522cf30647112ae1d50c99b308395af4e8535031abb098270bd8c19d060633f17
+Tag = 40d4e5d8ce2df95b7cfbed4dfebdbcf02e964b96f3ff8cf3
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 612322972ec7d1d3f071651204d85efe127d5a093bd7aa29aa8628321ff6be5276804967484326
+Tag = ea1a939c3ef693c3c2e80a1bd0a06176723175dc71dde511e4d9cc36af96cd72
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = fdcc72125ca18361
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 80333443095ef0515de48faf79c3d2ee
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = f78b3f87945ebd3107139bffe1e3204be983acace4b2c809
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 9430d246874687f5376de837783d25732f27e18bda373d9851c1f41e4131e0b7
+
+# initialize with key of128 bits, nonce of144 bits:
+Key = 44dd760fa841da730ca53ed77009a23b
+Nonce = 97f859ba7adb3c9d5dbe1f8040a102632384
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 23066c6ba9421711
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 066d300ddf0e644e6af227b0e7b7c140
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e54cf910c4ccd13574f5273bb4b304df019e2442fcf9ecca
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a1e5f5d936fcafaa8fb289519917add473f0815c0c778e1906e9249e324bba92
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 752504338b
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = e636619bf3
+Tag = 6b6c7309ab0f6873
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = e2b3003e87
+Tag = e0160238d4f05ac0ebea3fdb1a00adef
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = f3d3e12bf2
+Tag = 29efbbd3f434b40e65675c870be3ded0be83a9b62cc3c11b
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 83310e8048
+Tag = 899c710b740b7917374ae7cd4033ea8b400edc645a5b62048fc38d7b29e75bdd
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = f4b63d32e41b112a126faeb6
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = d61f023eba3572a80016ae0c
+Tag = d7ba8e77225b870c
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 074de485ca4cb5f496d9145b
+Tag = e3e86a8d7ac5616c9af491d8c7747366
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = a810582f434236b5fa6e40a3
+Tag = 44bf5d370e0bd587cccc9eed6015faf9a612c0693ee9dd76
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = c711890a18d7e996973f709d
+Tag = d097ea645ac53fb3f2082ae924b07c6fb3aa79e168365cdb83f7345e2a65605b
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = c71d4949177f5e13d707989c4c73586f1df1a66cc74c95
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = eae1826a6557d8274c10f0e7adb7cb153765d3a77b0b12
+Tag = 510fc88cb29a86e3
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = cb0632a0451c1b01a36238333084c7eaa53bb364cc17d1
+Tag = ae2dee03471d59a596339324eaaf6e0c
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = edd93c48e55eff9736fcf1873e258e72171d2553daf9b3
+Tag = f5c443a2dc6fb8c937a1dfaf037363a16b9bc08d6b99a6ba
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = a3d19778725b987c7d63badc503beb417610ce33c4475b
+Tag = 3871084ce6f61bfd793630c3836d04fe469e8f993403c67516d9516b2d60fe4c
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 99c0fd1dd9e2e6a9650dbb9b59f85926d58c60a6a07374210da263cb92818aecf863100360c980
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 8632cb622017bb167e5a423e7819457b4725aef1da7ba388d8dd7a4143b0ece0ea99cbf9fbaf1c
+Tag = 21269544119b1f75
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 2049c19f9a8293a6a8644ee8ce15937f5f7693e663cc1566d555b17b2c2d7db4ce623d4beee0ce
+Tag = b18a0d9845cddfa39e4a6709e1601b60
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 41a3644243efc72a654ebb06baf91b58267d2f2e20b602e45f96241ce8d544b0a88939c8e8fff4
+Tag = 9a5ba73b8b4f31dca7b72237dee7f861c972abd54099b3a3
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 6477c7e71fd212eff5599ef87edcc1e093bd4ef846d97d18dadf717cf138bb61bbdab8c0881f18
+Tag = 0721f38e180fb29731ac7f0bcb068c787b586a67db2e65e071338bcbccdddea3
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 0c0bbe8955317ac8
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 7b8bf9e6e779231a5cc5f4f6090c266d
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 68cc3ac7edc63244ed3a86c9cea030b84c041318ec09bae6
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 5680206b3465824ba83ba16cb0fb1e8b51353409d9863cf4c82ce9aece174d99
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = a0cc482ae94b218f88325336353f
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = e623b8a2f95672b3927b26e9d070
+Tag = e697a7de526e9931
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = f065715079fe3310196128a33a39
+Tag = 959bc4c5b88d7e445795cc26accbbe17
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 065ac52d82649ef0f26ec2bbcd6d
+Tag = b1324bfa9030f6d89eff4711e0eaa3e49bd035448ae47537
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 308dd9e4ad619083f193a4cebf9e
+Tag = 889fac5d0dd93566b96c515e821e87cbdb97a8164632fc2bc32865d16a3eedc7
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = d9822c9e9f4dfb67d724032be3ab5ec045db0fcf658820000c200ed75f25d0502618df
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 3d1d6edc0aab733127a6a7975bffbefec682ea975dce6e2d1f11eca519e047925d0430
+Tag = 4df27cfe0d993454
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = eb64a5a172b7e5accc7fb87b644ce338a39c1df05c7bf7d69a3b5360c0db00b0049646
+Tag = 156545744e8a3bc780ffbdd02809d9be
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 5764dae7a09a02eb0b2d669cd0d77d60777cac7dac57445fa8e568d326b8ea234d3d00
+Tag = f54e0f9b9745224bdeb9e05b2ffb91120c465c1063e4e543
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 6a0e3092665ba6e7667fa1d42bb6040292aaf6caa728c4034a2298249a077b370a70e4
+Tag = 7df2adde74e5cd02cc0750d8bb6f91d9ac2264617710fcea43059b14b94f4e5a
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 9f8a368257ebc118
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = f6641a39775c06d2e685c5dc40f08559
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = de236321cc404f32f94471e437dfcb5e732ccaf36a638753
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 3e8d500aca1bf5da1c3fc614c8905c2151320abfb6f191432fc1b6fe10eae699
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 3b1b134b3362ae007555932fb00f7e367a70b39f
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 98c7ce58b0444154430b5c1378280d906a9bc9fe
+Tag = 5c294431e9f33c16
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = ae1ce08833bca9e6ccf5a8c75d5f046f9070565c
+Tag = efc8c6088a1f327be935470c9a73869b
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = c0e4bf02ee1a0f9085db74eb1e498c23ba0ecd73
+Tag = 84c619e95b33cf9836603f8d0326dcd112cec7861ba1bb8a
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 66d380a4117bbb191e803913d405e5e70e0c8d66
+Tag = c70a5a700501e150c592e0cc808e927f5662e371a0aee16e1b9cf06068a3bb42
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = e3191a36c25ee725e85b419d26b6ffe6f061afee8c9a57e3fb41de72211c9ce058fab49363ed489fc6d636386b85f04533e1
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 6b8cd1093157a062d52439a38018a9c8b77722226e5f8eac1da688848fd25688b188ff749056b33ec80dcd9c8deacc3c983c
+Tag = 6da8b9879a11d304
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 5f9a1d4767bf9cd6cb6c6be747a1006d42fb0d44686323db166e237d4e74c5b58bae48dd3ad60d627c03c982312be03c1dd2
+Tag = 6411ee3b6366f65145ec694e65efb03c
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 2e2f6fd0542558f4e3a3fa17fc5a783d465b62b832837a3c1bf8346753e9c73e2d56a5ebc60c00e507615a14d236234cf840
+Tag = b12848c813c3d6b299912435aa1c12b33e83ec31c792eeb9
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = e26aaa62c420b1c53956bed3741d9a2f79a74325b3098c0ca540679963e9cbe2d3d6a74eab71fd0092b6511c2684ceda4a71
+Tag = 0e68c6d8eefdc614ac36fa84ba25aa7d164688bbb223b9011c46112a457c1943
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 1f961df095ddd517
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = e4f155cb6ec04b2b2d6df6c0d89f6993
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 449baae4ea709432163dc77b5b19336c1f4522abb59a7044
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = a0a03fd426806270e1eff75c023764ff1d6746befb0e7fe08942f93bb1bce328
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 45ee297f08b8db057b6c27240d8fe1d0c0d5eb63c63af3a917498b20
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 4706bf7cb3dfdea63eddd8b8df832743d8cb820949814d98de79aebc
+Tag = bc05ba08776259e5
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 5f86598ce22dd05e11e721d1d5a7200959c9c969d8e2237386050737
+Tag = ab3e5fb694045205b26a0504e5650c40
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 1dd6b51d572f0f073daf5b1db45f4b600af1ddd48cd7722e4cefe7ad
+Tag = 0dbabb4935df2dbe793433bdb7cd98689cc0b221fed25968
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 153e54aa056e7d7ca124beb22ed8780f83665a971c7b21df6059c181
+Tag = 9c73b1ef72bd475993b214d575f06e2c2d4d9e1f588abee2c585388830de66bf
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = a7b51a53201a6c9d
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = a63dbc6a752f02c901b4c30f960b920d
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = a7eb47160a712707a2df5a09fe8bfd38d43d7048905f03d1
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = bf8d7c3c05925336fc7d4abd627cda1de7f5785168f854b40924c4b21d486fb2
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 62941c85f47ee9553196ff0648403484f35926a873db063d4469fbeeffec9506cbfc2cb9d11bf7
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 80ad7b91fedb664aa9a2fb37ab442dcb923081014a31967c2d1e87764d4d75437f51a2190557cc
+Tag = 8e582c8834a7a0f2
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 4f08a5bb012025f655530b768cb60d4355a6cda4050df138ed52c660f526946b237f5ab7c3796e
+Tag = 0e6290425630d5468c4b5e116d3d33be
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = c75b924a72a7adb2946fd62d9f8fead9eae0f4b28671a9e277c5e13cf3cc8bd5941e65d315f141
+Tag = d3dcb9a39dc5940c123200dbb4db179cc07342d72140d076
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = e8d76e76167c4dccbe156f4bb65b3d2b7a310acc4b98ac31513e9c7fd770e46b8aaa8b57f41135
+Tag = 1bf71028e2149ca6f754409228df1419b3c6a9ed7afa3f7593c94c763a0ea49a
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 409cc285af822c4c
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 2b2503db8c4dd83dd8b3c58bc28826d3
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 77887e82d30592a730f61965018d051e7695d9ac545186bf
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = c3aa4eca6da20f3287e5fabff87a05a0fc3e35f69daac03de409924b67136505
+
+# initialize with key of128 bits, nonce of152 bits:
+Key = 45de7710a942db740da63fd8710aa33c
+Nonce = 399afb5c1c7dde3fff60c122e243a405c52687
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 614dbdc919375c40
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6fa56542c1d32c393f9a502f68615e9d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 90b0152eb534b775436536287718b2e18f5a5e7e56334f28
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 1167cd1a073c048bc30cb6ce611b0f0c5116bcb40cc4dd80123e7bdc0e02d929
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 13ed1d376c
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 56d4d2dbbe
+Tag = eb85b85ca4352d44
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 43b7e9ec75
+Tag = ed476f52e2c1458a24308ecba84dd4b5
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = b47a0386df
+Tag = ae174929dfb47d90766c40c24c25c72f93ed07214cd7a0bf
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 6779ce84b0
+Tag = 63ade0e2fa5b32a4de76ebcf11c29e7653be3eb79c3045cb061389a4e3729747
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 3ef074284cf4944f1af8d2e9
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 97ec7fa0f38d76a0c860f46c
+Tag = 81dee9c68ea587d7
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = a47587884f5470ffbc507e42
+Tag = acbef47f4d8c121547a309df95d1198c
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 928f68d72c920422917d6145
+Tag = c5197b971d18af91f406f39875152b55aea98a0fa83be754
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = aa342b2090446846f3423d19
+Tag = 7427c37cf3a389c6c7d2ca74a341de6e7a23cbece31e0d75904e3e9411e7c013
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 2bc2599e3d63489b4fdcac229243f287754dda490b78c1
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 3773e5ce40abe2b8ea2ba0d73a3d7a9a8156647d80ee15
+Tag = 079286e28166ebf6
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = a950008a3da2732a60e00c5b16834888c553e4baccd5ec
+Tag = df95e2b5e50b8b971112f9700bfda86e
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 9296aa5fed526a6e581b088b0bf404e2ca26e00bb50118
+Tag = 8cc404794b72f277098024e36f5a60edd2a792d90c569e95
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 859931f1088d52f8a0aab21c21e2fc4d6fab5edbc9efe5
+Tag = 3a63463683625738601d237e4a8235cf7b6ea735d641e94df6f0f215cfdfe9bf
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = fee2e9f3cfabe237e3899b28d4b05971fce5dd1128ed0f6b01a8a881e3208e7decdd9f75b220e4
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 171b82771784912a3458b9c9a539aa3e77ba79bb28906d847723ec80d5f25b5482a2d245f59662
+Tag = 2773f65c0e8bbff6
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 9b4d3fc1acbd39ab3de00fa21f1595ed746dc3f72a2ba628cf94ea9374e539ab3e33028ab48c73
+Tag = 4d744accea2c51829ffb722ec6fb4ff3
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 4ae14482499984154a597cc0badaef0b5cb4cce72af3b5182c55f1564665386b8ce1ac4e93e566
+Tag = 782a0d8ace773fcad4be604daeefb42beddae55995a9aede
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 9fa7e5e67b586a60c49cf0cf28f9735aaf1e9c51aa691305f291d217a1e5c142ad391168cd94af
+Tag = 5056e982e3ca91284408542e03e5b90a41d0157f33c40e6bfd9b2f41f6a08a5e
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 793898b348e90d75
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 1c3622048fe235363c0d51674c01263f
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 983ec762af401e9ec34fc4e1e2fc1452cca494197b581ca1
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 92b6ffb8e2c215ff515fc7592688d349288d938f457ed4e5526b034611bfa257
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 3f5ea923e219f90064d537e73fbf
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = df0c7201dde58bcb10337ef2a3fe
+Tag = d370cba932dcfde8
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = fbf25477289a258759e7cfb0ba86
+Tag = e78770c9622d4ca6f54937173d83a12e
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 3a3c8fec6aa257e4e610a4538648
+Tag = dbb48139ee264884d0be1dbe5a393a2955a0dbc8ca9089c0
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 3a0d7d04fc27ca32963500f25e71
+Tag = 748bf5ac1e192f9e1af4a156364cb0afc1feed92b391e05c532850154e55c674
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = ae95270217325a22e81c1d3048d1cb242dabde7883356ccd79f4718f76aa45f2f64ce0
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 3b12beca0f91873cb5e61202f49c6e39051d8fe79c13cf6ce8502322f6b308815f1895
+Tag = d0fa1f3ec097717f
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 550346156a3ad3074570b7c5ee2de5db57f3fd318da6f4325b433eaf5c0b8a9bd304bc
+Tag = 08686314fbaeae6354e142ac0a8686e1
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 8fe7490b6c94be9e5a05f13c2ad216852132c7eb27b0e7e96ea2e986c30067a5a6188a
+Tag = ccd4dbfe59074a7d98b4935bd78ebd01c5e7806ef66007d0
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 00ba6d03f26650c8725741183172f9abf1b68e49079ac0d2c6bb904f8db36ecb6a2cdf
+Tag = b4289aace2ae02494fe8b8f2268fd9ace7a116fdabf53af04173c6c5a6fd71a7
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = b6c4ef63aecfe418
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = a21deadb17afa5b2ca4d381072aaafa7
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = f6914fc36902ea1ac84994da2d3faecf84eea966de5d5679
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 7a9fef49afe7b620e2e24d45b2c9ef093c6de651a2980d633a7aeb193ea7176e
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 33214d67bb644536e4c10c071037e04cbaa45040
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = e9211d57e0db57ee58ba7d792e9c3d52f29eafe3
+Tag = ea45a8df7964b744
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = b8c6df901f41b269350daaab8ccd65a947f4ef1c
+Tag = c8114a6a97da537c2d24dd66943840e4
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = ca7a9bf816bf688ea92f73284f26fe7cc33a1e3f
+Tag = 23eb8c20e5a23d148ccafa7e7f72462f863a15e38f35aaf8
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = da824972d69515b9ba255937ab050d128101651e
+Tag = 09d5d1fabf9defaeff6d147b76f37712157559b9f88905e3fc4d94b20ad061f2
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 9b9774826606e9f96ac02e00a12c51c3716c8a84c57a0e7dca462e39e5a1204a86dc1caa19b68a8d48f6b0e7e905031fb0f2
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = cc28e0a8ae5fd0268e3107e9bee9c1de64b3b551b36334447e772e526cd29bb491f3760557e09b68c595255e1da358d70490
+Tag = 6c6e6cb8fd70aaf5
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 10fadd45c727d7973d95da99d24b1a3a87c48151ae5aba62c19302df70d21f8a5d6663968f484d9753eee5c033bc6c2b6329
+Tag = af06676270fb77257041d67d8fa250ac
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = f908edc6869fdd2f9ae611585c6efa047779b12c3c4e4f34f4e6824ca9ed78eee49cec516f32cae17ee6b200a765d588899c
+Tag = cf03958c5958beb2f229f86b3e9e98aedcb29c4c48b58fb7
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 52459f696db06624d4bb88d204507067eb082a5e79ecdcb76f435da535db3aea842a45bfcf089205d3c21a2adb68bf2fc3de
+Tag = b41750203f067333946adc2445f47cf241c62a54ab4e3bb94fc0c6e3886fd94d
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 7edf05ab81b80f0a
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = d9813f155dd683bef188801328a0ed42
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 253b009afdcf645d366d2e1112d16fe0db654b84bd9ac7fa
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 8539219bda22ed394c13c1d165dbcc13ad555aa6c14be4d7d2955c1de1f610b7
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 8e6cf38a1c17f3eb48136d06feaa4b5925b3e2703574d2592c8a7db4
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 0ab08b5a03c0c3e27e46141ddd6c569f1405c2080afb3c51364ad024
+Tag = 456233829d6adb56
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 2c3a51ebe4f8f2c8d7861499a05b2bed28bb91e118ffbd7896ab62d8
+Tag = ba8f03baa3c0e926bc72bd06509c521a
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = f4e13289f96f4f2bf1e603ba4dca70cd39ca696a6999a0c41394cd2d
+Tag = e76fc306d7620630d3dea632189d003ff2670824decffdfb
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = fd639c7a8e8e3793ce491472f1a82ec2b2c77cb9f81142dd795680fe
+Tag = 063059d0d7017aeb1f89790cafed4515451de3f2182ec8f4d2e4b5e21f8af5c5
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 0394fb18db04eec2
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = ec33143718fd5697efe12202bb0714bd
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = b7e6fe2c035865c9a8edc3349fcad746149f7c771543c930
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = c681dedaff8004a5800eeade22d67d27852fe5b1445cd1cad752faaae6d43d9f
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = a0904b56cf08f14945064410094630f036dbc7b00cbdcc010f1ac33a30f7ac32f7922c78ff59f7
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 3107435af90607c4377b5f7f7db7b809b0bf06ab4fa9c4bf73e5c2b07b6b1c38a6e62c1690894b
+Tag = e28a9a31699b6fa4
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 18cc40dd598593e5b445b21995eb259c679e3f7b5d4a14382d529c175447cce20201bfcb98b911
+Tag = 86b3db83c1afbaafc594e24d46912daf
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = f67f29130f5351b2763b203693f66afd195272281a9c9fe2e9901549397376a5d71ca6c3c3475a
+Tag = 4273cedeb517d2df9f91934153ceb1b439915ecb31022ba3
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 4aaa9c22833fa8daf2f1851b68281b6642b66ae881b7e751a8fd3a072ae1feb29d0342478d1b9c
+Tag = 44c062551f093640677d0ae20cb4fefaad2701886293d2753ad35484206eb034
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = ed46376959925aca
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = b1817f1590f5e0a5612945f63c6a3e6e
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 0aebf94aeb68e4f81a98707533b193a6b58c467824012e14
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 3948e3281e6cdafae5bf2b77742bfa25d35573e56a6a527418201feb061079fa
+
+# initialize with key of128 bits, nonce of160 bits:
+Key = 46df7811aa43dc750ea740d9720ba43d
+Nonce = db3c9dfebe1f80e1a10263c484e546a767c8298a
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7ed00808c860ebe2
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 8af6b2d9d7923d5eee7c7f7062c51eb7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d31fca44ec6288756de7a9549e0b96260874c5181be8c72f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ee45d428a69cb597d13b4071ca377da1db7be9b3a4e3a099134a7663659247e9
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 55bbcba005
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 801792d0b2
+Tag = 86cf84bde0d20769
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 08d2b77da2
+Tag = 678c9c2dada334af7e70da43deca9014
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = c6a15c3938
+Tag = 9d2fcbeffde13c6d5146419a2646e67887855eb1a7afdc5d
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 40846b29b9
+Tag = 53c4b8a336d07558272c075320a1864d09a9311c5dc22551ac91272e4ba66528
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 936485a7c4450873cb582017
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 843152fd0f30dde40d7582e7
+Tag = 78c9039929e2d2c8
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = d4e5809205cd8cb5717aae8d
+Tag = c66635492df045d3d58102fb9a7da23e
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 6e5ae10052d9ced0d0965209
+Tag = 45a1d430c97bf0f4c07997458f51494a9cd6c471ad6c8e18
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = fb2b0676e85acb99d58f1eb7
+Tag = ccd1664690561689bbd6f74dde23ff693d82def8ce19c49cd47ed1c25ddd4540
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 99564bd843468de127c26ec78dc85fa71058892b490f29
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = e03bfc8c5c87c5a6de92d8368db704592310c623f2ae33
+Tag = c49daffc8c55148f
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = f0df83d60a7735f491da3a7e23483210ac6ba2b4aa3256
+Tag = e4b457c9b3fa575aa78a904429bfa126
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = e33a5695639b55512f0f32f43b8cea8ca8b287946450a6
+Tag = d8016037b1fdba31e41332eee7693d2e9a147f3f408f447e
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 5949d5283ab92b8ca8e03baa5a43b1805c5100575c50e1
+Tag = d53f75c8a1c1977cebf554c1df70788adc50f5f179b10644147776746548544f
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = bf2bd2fc9f3e082f3c1b3d66ac7e8d4b26c36945303ae35705141b7a239a914fcef921fc714c44
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = d580861525f8f3633977fd7992af35e59a78f2918af1ef1c82578540c3b0033d593041e7c686b0
+Tag = 689fdbbfbda1cbd5
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 7b542138c7684558cfb30411fec717f6ec460c639e079b93e1fa643ac32fb496db99f99011eba3
+Tag = fcf8bb4239287b6aba4ab7528613d2c8
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 0aaeb95dc4957b2054a1a9ba5ccf9293a151c2f611d1c8ba1a6a62bff0e576e52393d9f717f968
+Tag = 58f512f7ba09497ee819b217d9060fefce572e3637226601
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 8a90d2f3104ffe8c9749343f4bd037d5a86bfcd88387365f37ed3282813734703343c85a1c5257
+Tag = d325e641f07db9dae1539a4594d40665aeae281bcd0caa04012dd915ca978609
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 4537384910ce81db
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 3c9118f7c99ca1f18e3df9baf4130f8e
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = bf89fd1a8eb4d943c4a0a2cecd5d8a1208e0b306c8c3a053
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 5c6b65fc8e680eeea89cd73ab43078fd4f0111e350668c6c0046e16cf5ec1c12
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 25e90f55424008d5ea42cdc5d169
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 378ecc3a9cdaa3efa7bbc1b17028
+Tag = cd40de81fe0a655c
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = af694b9d4b9dd7ea838a429c2fb7
+Tag = d50bae611135678b3a161aea68aa238e
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 1eb45ab7a051a4eef86075b7d2eb
+Tag = 321808c5f6dc828c0ae69eaddb14675230502ecc1cb1605f
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = c2cf5f91ee93cc6110056c88e8c7
+Tag = 526f179353cf44f16258e3d26373f1b976031eecf251a4e318b9e9dd4e7cd8de
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 7657032263bd577dec35bce45a68a04db9d3553dc4e8a8a2772e3df66eeb08b9881b81
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = d25cd5ec8404134a61c1edb010e16ea0dc335d058d44f406f15e0229b28a4e9cf2d329
+Tag = ff0441bf15ae6cc9
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 6a6729589ed5908ee736bb30f4a1c4c23cdab5ae59b3932d6a1680091da4724318cf46
+Tag = 19af0a62599ca7ddfa7524da9bad7ec7
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 2dd24f562b3886034bed15f0e5171c86919baef7162de673c3c715fc5108221b86b888
+Tag = c6adda11c044fb15d01c9c51e9e12d6488dcfd33ae0c3ec8
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 93483b825ff9624b7ade1aadee7ba1ca6cbf6301bf6f0cdb6b9789b1c1dcc804726632
+Tag = b801ad81d0da4b2fafcb52faaa58daaef0134549a3c298be3eb937039353e577
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 3f41c5635c74de2c
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = f2abaf57568680869884725afecc2de3
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 8730323914a3ebd71d1977347d92d20c6ecd7bc77c9fc7d6
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 05a36b81d2d3168b044ac6c36e7b0bb9ba92a1d92ae0a4b3a48052249f24b5f3
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 5c8ea81134c7854279bc1e8344cc008b40418d07
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 542fe8807de4b0f0a5390ea049409774091f938a
+Tag = 9ba2511378e15df7
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = ba9027c09a91d8fabb9137f42f23a8922a381adf
+Tag = fa345fbbfa584444669f856de6614f2d
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 8f09eb8a59c28186b223df491dd7a7e745768e62
+Tag = ec250b3692b7d122f49ef11e2104244f10d8b8095bf4c146
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 8b3e4e8b436daf541adc2fde7940905ae8be3744
+Tag = 6c54f5f04b626b74c73340eb80df24713dc002703c2195aa5076f98db3752293
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 77338fe052018200c50916dedd409e2406cc0e97be9f5f87f33f38f416779dd01a14051f1f12ea9fb041651f7438f4dedd5a
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 3e60bb2164064321f9c26014533ae1dab75c0f8ae726a0ecf047048117092d28be62e3ab011d4261036c8e65afabc5a998ad
+Tag = 38016f659c711fc6
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = be6dc54affe8e8b22383370070b4bbdae2e286b5861be4c0ebd890b76d3dc8e71ae108b199bd88042ebdf0e3b11655783f11
+Tag = 85f20ef30b5392e66e21839350a24f89
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 3b974066c6379ba321a2d311c9684e2b3c2f0e6a4e8d08f0aa85f36f2043ff502f07e40ebed023bb62c989186c44ed954cb5
+Tag = d3bb98776d2b0114d318259a9092ecab1f5234fd43169471
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 481287357be25ec442fe361247dc4eb5fbf1647dd0459febb9b47c56bdecd05d1baa9fa3d95ba6df5883a8db2c088c3b2f2b
+Tag = a39e97e4e05be70a259c365a46066dd11cdb353b0749e96791d9092b1127d7f4
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = aba911e5d585646e
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 0cf054a4b6e983d4710ad0cbc78f479d
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 2878703f6239627d2d60c225b9e096915c2452a9266490b7
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 08adc07b3ade462273d14dc977687d8dda6af4a71e1eeab5f33a477cea68cd69
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 5dade3c16ec8bfe366e214ed7888852edf74f6202b266a55d6e371be
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = ef4a52f21a1dc8e2e36f1b55829d2d3657e19e2d1369781ff340ac17
+Tag = 5e34a959e8215cef
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = a1cfbb12522ca196cda22d5f2f31dc0a3d45f89024b53c3768f3032f
+Tag = 6fc81e074028a38ce757a296d8f5c5c2
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 6f5f692e2015ef5dcc4eaf141b1f54db7f669e8e56f5288fa141e61f
+Tag = 257a8c2ef5a506044f62623a8b6235f48b438896eed4fd01
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 499e5f79b2274d1ad70704362b02e7ff8b67bf2426c1ba075bcf5126
+Tag = 68c83c9e99bef7c22b5a841add99a34b58e439d1a20b2a3d1f02d7247ba49f7e
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 163c086b6c6c58d8
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 7b18c2e9d19fca8f0460cad271c2fd0b
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = ff1f5dc3f29be60946913565cce422a466010a4173b62802
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = fbbe4c865c4adadaf2520627a4768dfe285bdda7f63669a99547400e0d64ae6b
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = f24d982c51f1e6a6f8d044f477e52e7d493bab85e69aa0133772239368d7a1dd40daaa1c9e5454
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 322eb7edd3905b75ff82ae53853c73603d5f7f97da9609c0de9512b7b71113ca6c15221ef4823c
+Tag = 395f6810d8c2624c
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = fc5e5a8e3f34352cf72214365d970d511732a2472bffa527c687903b4f7911d5ead1f213537709
+Tag = a2af251c92bd02bf77a72912cc744c41
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 74be6f852339a186bbf988e06c23c487c3a2ae2aed69a2647f9f0536b92b070dfcbac26429327f
+Tag = 3e09b58110a504b3eac0c34859d732dd93b35ab6528ee9e3
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = f800fd2757d6cb4559a900c2832f5ead9cf8978c5824fc0d93cb9aee84958e78091f14759e8140
+Tag = 79e2989631cdae5ad85e26a22e180bcb764ab2dffecd695ed30ad19041599a26
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 3f72d15d73a3ab22
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = d5558615d3b1b0f38c64bd47361bba14
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 4798cad89ce0995e5664bcbed9cbaecff6199826eaea6bfa
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = fe686a4fb9225f3a72e15a0e4175dc8864a4debaea74044dc2ba114ec05d8f3a
+
+# initialize with key of128 bits, nonce of168 bits:
+Key = 47e07912ab44dd760fa841da730ca53e
+Nonce = 7dde3fa060c1228343a405662687e849096acb2cec
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 98e55d145ab4e595
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 7d0ea62bea186268c6f84166c5c90d34
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d4e456b2806e2992e7fb605bf01ad9332c0bbd4f96cb1239
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 0d60d4dff1fe00f2d970cadb4e924cc896c5f56aea5c21947aefafb6219f9dbf
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = c92d472bd0
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 88cd1802a0
+Tag = d1d96a9cf3f0d759
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 17d40ae318
+Tag = 7d193a9c3842368cd43105a9a839a5e0
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = e51db05ced
+Tag = 20dd7b3416933f54572cca2277366a339e7b0edf9a434d13
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 4c3169da1e
+Tag = 524fa76f9110e7f443e19a77ee2aef96f63a0c025c5c68ef86b9b8ff4e5f2b88
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 8248d71834af9f44cf8201a0
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 79aa6140d438ab774aa5a1a4
+Tag = cb2e323cd374fd46
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = b17d0fce4b200222d6490869
+Tag = 84689e0eff6950d78522c62316187bf5
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 50a8879f793022449fbf79e1
+Tag = 7c3cb831a47246689d5f1dddd0e38f365479d131b585a220
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 241b92f2f28838c86e96d197
+Tag = cb39bc7eb7752f4f83e001500ce08391336f56f6440a109865eeb316e93db123
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 652bd4ac41b8fa294331c8c48d1f1b57e44122a56398b7
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = c9cdc1232823a119d7f95f3f1e153ef3b7dc98fabb6248
+Tag = adadf19ef4bb0a9f
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 624648b05519dbfebc5d23eb8ff5b859d6854f2054bcc5
+Tag = 5170e38962ef5a703488415aba68db7e
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 868867a4f4cd5425c78536d6d6ffbc4b2e8074f5ee8499
+Tag = cb465041c961e245558c0e2da1dbce43520fa5d57bb41ee6
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 63b68921a2831452dcf7cd18d702f68ee94c3c2f91fdd6
+Tag = 50a516dfad2728c005ee33b63ef8f604411700787cec76ee125a66224ede80d0
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = e345a9847b1432307f728be55da3f081a05ba748a9c97dfe10f9674211947b645bb1f17c1a9fa8
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 228ff7c3c857653f40ed3b63bc8f0e17dd0dca5c038a9b4fb7d5fbbedeab17cb93f78b137fc66d
+Tag = 487b2b3c788f5cf2
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 85b3be9e385130324d20b7fc8bbf96b820a8fbc87d85a26f1bb72eb7542fa5c9c4727863479e02
+Tag = 8db4ee469b108494e33b76b79fd98258
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 187b4f068827c0e8a0f470dd977b0b522fd2cf3312804b88df72a74447ddd084a957f69fb24079
+Tag = d28de7692c5ec5251248790f2f62511ba7a670d1177e0bed
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = f0cc37741b8111f7945134056e957d2b8973d4f6a01c3cc1f52356fd173a787fae974dc3215b74
+Tag = 5406a951a122e8117cf2764a9b208ffbf3e674e684bd2c6ad555ff0736e95f64
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = e7a9ec1054226b55
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 5ac913c7f78435d670106ef7f92fe176
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = b1b5b8c3fa2858afbdd434ebed360972091c29f2bf62dee0
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = fec3b5385d14dc5133fd2b753fbaed90259dc621cc79e611779b913117d20a3d
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 6d0c8c71f607047040bcd336747c
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 63c7385cddfcc73f8bf6bb78e1b2
+Tag = 098f8935a2a57d53
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 94901e4576b6b81bac972cad62ae
+Tag = 3ef23cfc8f17c56565c1ae57090095ee
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = a5239584de0c7477ecc91190ab43
+Tag = d98218f60938ab00d2b43a6cf55d36786f622b73b6693598
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 0d42be531c2e3c4188c88f232fb2
+Tag = 3d1cb7738c07f000cb559617afb4ad51bf2f66c66e3dfaa9e118057c71760879
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 6fc60500ed269b0b617a530b3f3aa2d84d0df995663bb4ffbdb38a800a0750c1213abb
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 13e8c734718426e20d0447630d5b9f421a164cb55be6129d57611c89e87cc5bb2e6c9d
+Tag = eaad23164514eb19
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = fba80654215e7a9c83ce1e07239269acc5e403f3fde55452febb6a9f97ffe133811174
+Tag = 63a6b45484fd99fc84897c71d64cb16e
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = e5d38b21ad9a53b3fc4ecd3339408cb2ad954ab90a4be8ce01be5545d58a9d1906d4aa
+Tag = 163507dc4f78d2c45940c68471f9a54965884a0759d6f98e
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = dcdfe90dde761c59e225b794fadbbce8c398371e6a884c994ce3e4d3cf378073cd48e6
+Tag = 55c1c0615d47be76fbc84fe9d2d45a298a9e9eae51941700f3395c0f33ec89e6
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 2e135ebfa1510f4f
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 65950f21c2e78cfec4f760ff25e55e2b
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = e138a836bd4cf533c39d8789d21ee1b8f9fb85933eb4b8bc
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = f9555e1d4b113a45726db931a09e8113d1ed400f3f3f2981ba41e74c4f2a3b60
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 9c3bcadfead78d6347145a22fbf34d7311005a34
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = c878a39cb19d81deba05c6914616182122d4bb00
+Tag = c9f5503e640c6ebc
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 5e0b2dc5aa5050e0ec9504dbfeb77706d18a3894
+Tag = 4b49b35d581c2a39327f1b805aaa4b2f
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 4dbc0dd407a9a4ce228c3c476e82c9c6349a04f3
+Tag = e6e72985aae538d86cb43c1e0679cc224ebc48d73c992518
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 05c33451013e493f6fd496e8d891d86f37f0e32a
+Tag = 05895f6f07c8a37a4600a72e0e8192e91c124806175276a290aee6340e5492dc
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 0dc25942f1f9fb28741970e6e9bcb0900186383f169462216591a2b730a434c49d514812856b1893ecc151a2d348b187eb60
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 001398111db015dc6dc399ae449fb18c73415dce0ff539025f0524509749490194166b659ae1b589e430594ba0d7617e8d8d
+Tag = 2316170fb29aa3cc
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 86e85d93df0579d91678ed3cd7b4244afd5c6da66078f8ede67527a5eac2dff627d5269bc7cf2402439b2d7eb7825653daf3
+Tag = b1c5b755d633b9aa5d94f8e4d1c33749
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 341af93a7536ba66d5b73b02dbc7ea951e34f576d5ba8e67cd4f060a182865415e9259085c4c5a3d4886d3fc66bc748944ee
+Tag = 1dfd99e63641491b03fdcbcf880aa2f20c3a1b002c0bd25e
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 9d583398d0639846730ebc19c3a8809eb9d50d2d61c07cccd03f020b1c76f151f629bf4bc554e011adeec2d43d08c454dc88
+Tag = a5f5a55af466d4ffeff8fad10ae5ed03c81bd714bc2e0c41eae8a3cc02f6bfa5
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 6f7f158faaffcb35
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 30ba324ffb13962c46adc81d6cc93c42
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 7056b7761050b989a042bf2d6249bea11e317a73af1ec347
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = c1cbe6eb37528006f9713f76b2ddfcfe0ff26b43eef113909657622b34990948
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = d667a18ef3b7e548985c35cb579b74f4b6a0d95afb551ce63d9e923c
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 107a44c8cb67c25c0cb647ded93fa8a463e3e2d46fca7a2de666fa57
+Tag = 2a549f7d7af0367a
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 6789ad7219f62aa82a11c3e89aca30901a57491b92f2e0b4e7725956
+Tag = 156477dcd404dc87bd111cd4f69029d2
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 9cc873e6a50399f766bd215c38009a9e7254fe5e85e4e09f701a4178
+Tag = a3ee37a0675bf52e8c36ee8de2ec4161daca1eac79b1a387
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 02b2327ccedbff369324c59f4db7ecbca353d40281df00501975007e
+Tag = 9eb400252899cf7f9094c82e7ca5e7671d180b44cf0700215363c70406de75b0
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 0752775492e73cef
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 6127c3fb77e4a7d1f769e012eb47329a
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 790ac6fbc0fef5142cd36a4796c236c0f5decb6eb1f9b653
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 1a41b7352705923bfdbe43829bedd379e9907b151a374b34c1ebf01d40a0c7ab
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 1c7411523794cfa8b9c80187eabc4b951a10c0c882f6c44148ca660d7f844c5e03c9f10210780f
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 1e3afcc1d6ecbde655d7029f8b9611f9f3befcd9b1e7e5e85d36c2751446b4d9771444cd61c6f7
+Tag = ceaac5e17acbf531
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 27838af1589dc9e7fad55211732aafec91e9c7c33f5b9d73240ea7590fc03362194d9951d0722c
+Tag = 746983ef1a1b487303de8b67bb22b647
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 72bf5f08203cb8e524d69c5df149a0cc7e6f7e09e11d200043aa45d512b9d63ee2da90cc811b95
+Tag = e482e84ece25edb12782d5bfe26d96579b7794a111feef08
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 4c00a04ebdc81526d96421287142b7a1a6ef8b9632660609a824e5c285186de68ac54f29fd31ea
+Tag = 83b6444862c9717ec8c567c6aa57d073502dbafa4d3f0a3d059120b01434c133
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 80e332cf9ebe92a6
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 94d730c451edd7bbacdad27b24bfaaad
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 0232c929c6f315d95803b43eac539dd29851ccb5286cb4a2
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 466842e559a3d04e7f3e4d42703dbc2e45ffb68d15b564bf6cd3491db4a9a843
+
+# initialize with key of128 bits, nonce of176 bits:
+Key = 48e17a13ac45de7710a942db740da63f
+Nonce = 1f80e1420263c425e546a708c8298aebab0c6dce8eef
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = d6c572542c6fac4e
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = cae84935b92d6629487bd7de3b54bd57
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6785d2d93eefa0dac0bdcf7550edd9a3ea91f8e5f807a019
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e35637c4202d64edda5c1606556c3bc46564f4a7235d99418d07215fbb6a60ad
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = e48a560eda
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = de629e80e3
+Tag = cbfd7f68395b2089
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 537427e66a
+Tag = 498c218d16ccf7cf256ba172005491bf
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 2321e6fca8
+Tag = 6a9f50349402acd59f273df2b83af73158f0b894ace8598c
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = a3e44b9b97
+Tag = e39c67307123ea3a4c826e9738eb11fadeab34406ff5a5198b2182cc8471fc26
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 24c2aa54132576ddeea71159
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = d69b42d82e6a842b3080f296
+Tag = 43cc93145468428c
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 879a705a388c3f3f943aef7d
+Tag = 70a732c00cd23335de053c5bd6f7de10
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 62bd63f2d7edb6f32f252977
+Tag = 75499ce05e3eb17801aa296c4af94985eb595219d37d80b5
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 583088e8d58f55b0a06b4bb8
+Tag = 7c88a8b39c85ad053f07202e84b67ca1c4de0424529ac82f50f6d67b3c6e6dfe
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 59bb20ffd940b594cac1fe32dfd44a9f0fa8dcdde1d41d
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = ea1d4380f8fe6424301cbeb086ff8fb5309eea148cf2c8
+Tag = fded030b54e6a717
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 8927cf5e725b1620a5f27202b7b35fa185baf551b011ae
+Tag = 86ec7c4a6948411960d00511c95408ab
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = af98b9471c71edf413dfdda3393cc450c2792f38fb55e4
+Tag = 3ccb349283fa19180fd968a90b838ebc99ab1ffd847c3759
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 90ccd242b5673d1b99d3ceda0e92e67ea78f0ae0ad2b97
+Tag = 4a8bb14b3e1ed8044db14815dfc9128cc6c86063d3a629db718ba84bdade5131
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 2d7d04fd950d9f0583a06078cce1262ed7ee530db9318b6255d37ae2fafafe0fbb09fa769bd08e
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = f691e6ac706e4dd97bd49d05825ecc9b37de8fca6448831374d7db372a3825b93b38ebf46f13d9
+Tag = 525174ddff6010af
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = b978d5cca45d2e32c0cc638bff30619221ffe5cb908a7cfa3d4ddd2f82af66881cd498a1ce32fd
+Tag = dda66d2aa8a42cb6577cbaecf77291f7
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 3207d64aedc0784088dcb480e5b80b33a6f0b72c71dbb54ea2356dbf7c1e92a74b2e70c6e1c988
+Tag = 7e61dd357a6f4764dfa1f977f67c766d0435ee3a131b9517
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 62190f8136a18275a886c2720593c3cb884a9b92e7492f247beeae00899ef8c74fdf8887a4d808
+Tag = 5bd470d562d60f828e435cd2675d56ec2ab102604a3a011dd5fda450655c5620
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 822f8ba07685342b
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 7a3cd1055d5f0f9f6c302fd4177453ae
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = df28423ec0b7f32eea350b8ff046756716cb2b30a404eb66
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = fbce3c34d6755e4c18c0fbb78c9892c3950067d34f99eb55c289e97dc9519d2f
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 67f2418d8ecd263c2c4909826a38
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 3a87f633bdf74c242e200c9e1bf4
+Tag = b7bb01402eb6332f
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = e11f55c217397170b2987f584dab
+Tag = 713c532200aa4793d38267e737edfdf9
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = c49aeceb5ccc6d17c7b7101408b6
+Tag = 81e5e2387ee01b19ccada0c5d2291fca6001d637212e0e10
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 7acbfe74b3fd7db1456a93028264
+Tag = 026ad508fa505269683b33a96fd3a4b6e7a89e440c6885276144c7a5eedc1a33
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = e792a12ef02d5a55b09ee1ef56ce9e4946f45ddf2dd4ccc53e90730f5586a44c230a64
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 8d751d5515a3a0acefb1e5db806e9fe227de072b750e6117c9d4f3861dac7feec6368a
+Tag = 9cf3809a0df6dc8f
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 88a7d81fcbf23b610bebdae44f0028c8690ee886cd12d632d0ac5392289acb2b7388ae
+Tag = e9764608fcaed6aaaeb70508b7ccf5db
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 25c1a30aff24418d9a9723ec3747fc88feeaa6a44b6073f97988b3a44f847e36bf383b
+Tag = 834fb27fddbc6b5c48dcf7bcf6f51635476033ad32596223
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = c6eb271fa588b84f2ed78cd27668bb92d771490d27fec07d22bdf90e6677b169d27091
+Tag = 0c5af46232e515dae8ad343b03e1503038100d89f9ba5f54ce3e1e2d7ca9b147
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 6c994e1c528b1d9f
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = ae03629171cd92652434f7de9c83420f
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 47b5a507f8b1091fb7d5410f70fcef93c7cd1b074bcf9824
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = d5a4d4a077f46b94508ab8d6c87a2ed99cce51ffc051b9f09b446f7db6dca6b5
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 21df09533bbafcd78dfc22df9421abd86720482d
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 8b18169be5ec0cdd03716e157f190be344c256ff
+Tag = 8be16ba3b4937132
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 8b42c89080dbf7a17cf361a62b83cafb97f838bd
+Tag = ab8c39056f3bbc386550ce53ec372813
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = b497df8a04e620e5896bd4bc8a0b2f53aeec1f7c
+Tag = 232b1d4a1181fd12a9e44037370f44465fc0c1ef4e5c7f2d
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = f35c321277c9d47214906f768ea2ad76cfab9eab
+Tag = 1715fe05f00d32acecd18ea357cc55063c8e104ffe3aa14ecedfb5694f987732
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 6b687ea98ccf8b942a1178dfbdfa2f11866b89483c14a5a51fd22a9478b9480cf871bd2968ad13b7af48c3b47b7c0e51bdb6
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = e00b169a06495f1f69e0185b80c470be4b209f90842de5dd751b8358210160435bef21ecebf93137d8e51b688c10536aeae5
+Tag = 5c8ccbff10df7785
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = e9262018a6ff375a7f399c4f4525da720949a2423288580cfb84fe533f2692ab71ce511620999e9dcb3367a929eca99b0731
+Tag = 3007b398e5e6114b8d67944d3a39f85c
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 3e9aa5bcf79bd5929dffd96ff7e86ad15eba1213e057d62d2f88fc3c6b5b6ce0ee6a30332f3b3f76ca30eaa47353fb145ea8
+Tag = 1454011749d97194b3d28b0ad942a59d2c700690d6a812c6
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = d676ec98dcb13b23a7e23e77fc09021d7d25d632f4a2f0b90f85a8a2210b85c0e464a78ef972820600f5977ddca5403dd02e
+Tag = 6985193387422dd95eb45ad2ccd7ab0e441dd0699fcf7385cf43e4ef200e3eb3
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 9be84c78aac8f7ee
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = e33a6808e1678bed630aa34f34e348b7
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 6e542a03a1d413449cefaf67fc10af1d9769d52d4ac17394
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 98d1d855feca56c64a0806179d3b4aa0b7d4c3712783469bc81ae5f415c20f8a
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = aa68c26321f5ed3117d202a8aa98012705488e3933ed8f7463666e66
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 0e8c33510941a4bc4c792941aa4e23becc865e3418fe87196c65faff
+Tag = 43a3c41096d2b120
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 0e8b41ea7b61eab24e0c5db36c7087dc593751e0ba8806a35f4fca68
+Tag = 901913e71d0eec2f0403098306fcd7f2
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 7fe7e06fe144d51ef30f07a68a84abcbe5067e4a6447eba29838c061
+Tag = 0ac814c7731d6bb5be463ca62b08ba906e2c3455056c3daa
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = f2966ab1bd7a710ee7b588cb5b6d597b0fb01a780403837caafdec67
+Tag = bfc78ed07ededcbd47eb25ba9d4dab7637f20bd62404a086ec24e9ec75902575
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = a767e5f1edbccee6
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 464f0b6604abebebf06f88f61eb84481
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 3d74081ae259c09f4cdd4a675aa66f52b5a3c86d9e320da3
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 75b92033d4cc4693074e695aaea2332aa15315f1a321cab67359aa37f63385b7
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = c506fbc9682eac90982ac3ec8a16022fd05e5545919739c5cde7bf9b69a618756437781867311c
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = dce9d044b052b4e056b2068a42d15b051ea0c9ed2e0c2f0bbd1b581c48ba2d211c05ce874dd79c
+Tag = 48c06c82dffe2c32
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 22c256f1a19f76f27b25b293fd454e6d86ca1e571f73528539a8d0bb9e71e2f924374f5b26a5d7
+Tag = 23f7428a3b103ba87233cba1c07e7a01
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 742128293aac519722f2b03d348d5f2b0fbee6f919d5fe7d0c1f9757cfbff2540bb67081885c3d
+Tag = fcf56946d8ed92d9fc56642d3dac4d3ab7652c7967342e10
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 1f76f1244e6a1fb5670c8c7d8e76460eea76836978bf66d596f097530afd65f88929fab7e8dbd0
+Tag = 426a8c0fd2af0dc92e8447ae3cdd1991564afbca42d093bbcf761ca0ec30e60d
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = d99670fcec3ec66a
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 8c6317e6079ee6c75559862ace0856d1
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 2fcb05eb4cf3660ac336cd77b838edca421a8fb3e3fed778
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 8eb4d79f78358facdb1a8bea6ee9110274828e3fff0870e6f138b0ce450357fd
+
+# initialize with key of128 bits, nonce of184 bits:
+Key = 49e27b14ad46df7811aa43dc750ea740
+Nonce = c12283e4a40566c787e849aa6acb2c8d4dae0f703091f2
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 2d589e129d067a33
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ded15b2c750a1b406aa48e6dd3a706b3
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 56f2cc9a085295ab19d04db47df782e8da5d2d3c122f3385
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e4fbcd9d1614ac9fb7051782830e309942e7a1b837e74e83482f3fbb60439a10
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 0857fe8a86
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 0279013957
+Tag = e1461e2c9cb53ecc
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = cccb0eaae0
+Tag = e100b884ffccc24f5cae09a65b93d417
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 0e52bf7c69
+Tag = ae15a15cd1064f928fb8c0e9c93bf3a478fc0b8f750306dd
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 7f05888460
+Tag = 09113629f4084b67c3e464b8bcd72708fab2b016eb35d5c14e73a0653053224e
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = da3afab264cf44512890b9ae
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 62d4112099657a71d768ac82
+Tag = be926567820d9cd1
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = cceb40dc601fd08113026101
+Tag = af0e4b7c9e501cd8bbe8c88e0cec3b94
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = d36f071111994b073b1aff7e
+Tag = 266db0dd2fbf83fd27eb13d0322b955fff80d258ebc1baa6
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 74c934d4d16526729ccf9e2e
+Tag = f402d916a2e27a333f1272942c6ccd1cad825543e956a99293fbe292ad8b13db
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = a1dcc971909bf1146b039f56407675d12c1074310ee080
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = ab2a37b711189d24c3ddbb7c6451b023421b65118dd985
+Tag = 513ce191b70ba75e
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 5a22b78ea54f7e1f34b93acf10f0cf81f3bc0abf808a1a
+Tag = 473c69b48491e4000b0d344af508c9bc
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 8bfd130a17bf80295c969b55a38700680057c4121a9ee2
+Tag = 7ced79dd46f6113559aae8102d0a1c8e4bde6e3144ca6a3d
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 2fa5d7be5ffbf39b4e17af19ff5dc74eca8d7f66e6af5e
+Tag = f5f03f8bee03400f8c8a06ddc2d80655323b6c49a8bec93b0949e01625e2fbec
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = d83f881fdecc1d76c31a3e80f2ce43b51b66651b054f4cd5fa489461c4d40d119b3e3b915e85d0
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = f3535d008400c592248570c003e1921141350e6f3df43510f375f1dee295c25485ff1652d0d6be
+Tag = 649bada92e672e81
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 47c43d7dc14da7e19130ac689c29363c63e09266477d2d8da475ff9d9a84d8b26e67e3ffa0091a
+Tag = 995c48986a6c76c34fea068ee179342d
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = a1786667edd1a85ec108ac74014ae98553d1f63275d515cb36b7bef5458801b37e850f0b0f0636
+Tag = 4f4460c262664454fb3c0ca55b61d5020dea929b41dccf95
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = e7c99fae91d5aa2b366334c5fb05a3212f98fc85ec24536ef2029afd6549df39b18483e41bf7ab
+Tag = 48ca73d1d6ec5ad11f6b8dd4ef48a4650cfff7748487d5a6b92dfeed01154f3a
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = c8354a50cf376fbf
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 89a11af77f85c1c571a089779c4f22a4
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 65a2353ce8a4bd57d9180177e8e49aefb6014cd7a6b25805
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 15ff387db106338743bac45c31d5ec8936311ea3c16d8d96cb4145d7b4c2f7b1
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 58bbf87e558ad4e3bc52e4d6921f
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 915d89f19e2dfe970002928b9571
+Tag = 09af4552199b19bb
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 3ec8f29bffa40574cc17830a491c
+Tag = 1a7e5bb5bef9bcf4e824924d2b4b386f
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 621ee39d3c59957fd32e615e2c68
+Tag = 0dc9d62a4cc52bd01f44f60a7ed8fa37ecf8cea9e3cf11b1
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 4b63f136ef499ac72f10dd8681de
+Tag = bb4525238ab71cf8518ab79032224a549a636002c6794ff734b53b32c5953fee
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 77e9f1813fa27044b08db025cc5c51832af4350673e1b00f70e8081747c061c85ba2e7
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = f7b9dbde6fe8386ba8d0a6ef282d7ee9c3e7b39fb5598418271efe5bc4f12cb3da24a8
+Tag = 84189404c9a9658f
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = a5b85d4ac2a7e36be42591b54107c218f09e845b4028e045e3e1f5464ac9b872e46e48
+Tag = 781b16212780682c99174413b368fa99
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 1088a862c3ab27a889f09c935dee0f25e11dc3e5f0cdf78c6346522aa237649ab0f9f2
+Tag = 7146d65179c0cdf6e1013877703f292fe63a57758fcb195a
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 9c6d9312e7c1abdde6a54881a8bb33280c0677fb31cef7b1944413efc94d4a37e246fb
+Tag = 34a8306626743b1759da8792d2fe806bb05b9e12a25cd94340c810764dfedd30
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = e053c2aab3e9972b
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 3abd3bcf5ebcd4fb1694d4bbfc40d267
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 6c935cd25defa54aba5f7d62a65611b270c541bab7d57a9e
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = bceab5369eb9e9079ba7477c486aa19abfda974475c1598920e0915e52141d67
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = f1944de1b8a7dbfa0958a59ecfb8869215022f4f
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 5a2535beafee0a6735f823f2535b486db27d20c4
+Tag = 46e05f50cc9a7734
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 7e6af08099036c0c5aef982e792ef9278f10fb50
+Tag = b87226a4033b77e69f5c5460e55d3e57
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = d9efebe31c82f40b1db7dca11cb6d60aeae3fed6
+Tag = 1d104c81f931cb17ba9550b574d019af35c5ec5b0c9af610
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 6c840f6d97b7f953a52763d94ab7b14e35f1df82
+Tag = 1c15de6194033030661a0dc50dde34d8fa402ea26e75030bfb275f49924b2491
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 54516d174ab6f33cd950416e01d23a710330eb1ee52a4d766dc8221b9122b0ce1f1204d88246c3c4fb80f861bea122eba045
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 4f9419eba3341d9e88ea1437152593033c8b28cf9c4c67a926197812ea6b9372c7f1e81b42f33aaaf9d2399fb124316c49af
+Tag = 7951b2b4234ca09d
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 020dae918abb5842a24be6afe4e954ed7a98b9127c76b074d622021f4e0517df8fc81a967ac8d3de054349e0d478c50ae0da
+Tag = b18a481c849f0db1b469672c1b95d2f9
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 4772c6c170f6476aa135d2ce514c40d40e139e84d6ede5ac77526d189f4910971070217e460bd5d5115316017835659830eb
+Tag = 5cd39fcba870b59ac428d3a3ae20105328b6d7470ca5f012
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 217cfdfb80f688b3c31232f2d2e6453b5ad1965cbcc4fc4dc1aedcf6e1f2200ef0814611c64880199b052947fc02a9f41f1d
+Tag = 5759a1048416636102214d9f851241a49fd0b835a576a8d7f396e9e47b061ac3
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = c4a3468685f83826
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = c4aab19ca19d332e2e74ff4248a621e7
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 1d2986e262feca92aba5a923fc5b3bfe75040286d5997bde
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = c2ef74f32526e43cdeadeff9d7d105c648b1349f4c3002244ac41bc0f45600c7
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 273041bde58fe7d3b104849514cb57d1d36bc3029db1a297d20c75ca
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = d313d740238139b8e4c2beec62fbbea2d0adae3537f494f1ef7b1621
+Tag = 69a504faf4c124ec
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = a91495100b0b5239307f2c60641f105b53b9ca6a5275c73d47ce95b9
+Tag = b615d82cdb3c023cba8f42df211c354a
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = b96548e7e506df70dbd6fb5eed71e769f56c97078e4d79d2a7fa83ef
+Tag = ad33da043386fb467e3b969205ade4d6b0c68a6e5dc30130
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = fc0cb61ab319396e1892844a4d74ae0fde96d0e381c45e61e1b145cf
+Tag = a3522a6a4ddd7e3f618600da85045f5747025e3519ae2409fd9e8b482a5515b2
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = c084ca7a8b52eb37
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = c4b60595cae4e88bcdecf5aba0de330f
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 5c2a57e086ce22c2a843403ac10653fd1fbc397f9d4dc019
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 96819479239b0a9b97cb79da32fe0c94ff2774915b5049d0c831a06c4817acc5
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 915f077b177d6af83cef2c78b42c992b3c31e5b2bd3a93031a0fa21b00a679868b8a01e2586620
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 3b431df253fc98ef915ffa4b63c5089cf9248284ccf9f76d780325295a16a1e152a6dec953fff1
+Tag = ccb7aaf4e21c163b
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = cbd27966d95b368790ddae120372964a2cbdee95c93270d0caa746c519de2f1e0420599193d872
+Tag = f474f4370261c0b916982f83cce45026
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 4f40542c6f4caeccbbbf5c3f64424db776eced53f7eeba628f978682bf7897425b891a56f85b93
+Tag = 2be5dab6b3345d758e86be0f1d758cb733b1f8bc5b0964f4
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 9163c7b2e25b984174e69f4702aa3d45f2653c140e44b773590536c784029e1b924985a3d339bd
+Tag = 4e5cb9b7e4ad594d386ac24fb5ed00346af845ad640ac8eb651d23a3b99326c9
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = fc8441374a52c1e1
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = de8e4e4afb7c0b4d90fd655cb4d32f68
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 73d35fc55ebd0a75f91208f63e4f38fed3107f2f7efea7e9
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 0e13739e36bd359bf21a79f24c4c5bad52e80db31470fb6139ef3cea91710442
+
+# initialize with key of128 bits, nonce of192 bits:
+Key = 4ae37c15ae47e07912ab44dd760fa841
+Nonce = 63c4258646a70869298aeb4c0c6dce2fef50b112d23394f5
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 646c25311ddfd278
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 3a987c43153ed94198a60e439f1ebe13
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f600c91738372441fad457fb0e152a0677d6e801cad206fe
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 790bbec5a19eb53b719106eb5ce2c2545dfb733b93924f57d0265454fca065cb
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = c097c20abd
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 3eb646afab
+Tag = 49cef2416754483f
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 7f6b04241c
+Tag = 4de7229410569be81e76777fe1c87dc7
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 9afe49540f
+Tag = 893e7a1994c9a958e006623fcc25527407bf5067275def52
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = ce745cc700
+Tag = 8947fa44185b2f2456bfefc4bc2e08686e256399539e42af849bfea051a136eb
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 0fa638993165b323b5b0d3e6
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = a13f00950dccc7f76e907951
+Tag = 232a05879b80fc30
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 80d0b3da23569a7af5c51197
+Tag = 2af9e69a89fffa6ec470b336335cd329
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = eea931d49d11c6eb056f1d63
+Tag = 1d44c736c989572e96c7518d05aac0ec53c3192b8ac9d28c
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 9022c5d8f0abaf352c4d0987
+Tag = 5eea53acc31467f6e688ad9fe4e9fb1da6c9d812306432ee8019c0ac43edd4f8
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 8ddc6378ef66ab67a677566aac7b72feeccedb5c9591b4
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 004b38cefed0898c963572cdd856ca075233899d25dd28
+Tag = 6ddc4d6c87568885
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = bd579c1e03233c6363061231d790663c7a25190d2151f9
+Tag = e11378be8261063d230b315b2de90374
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 9054bc711c7aab5678198bcd5457d9d38beb87eb9fae1d
+Tag = 1706613284b134ba56f3bd97c6f8f98ad25b748c9161629d
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 26bf2464a602705221625c8f70d45a835b7b3c5d617b9c
+Tag = 975be353d9efbc3e4cef9ddc0abcda278b2183c8540993c10499ce491fef6965
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = e6101a6eeff7e1be082dd0e72a6a597f36e597d0c99dc02bdbc1010b6b8386626a961599f37cbb
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = e8278d7e69953cee0e85ec59294e0b8fce3e6fd114911fcc67fda1990c111bb7a868e528d51288
+Tag = 84b430a1d53d1079
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = ce38030169e10ed9f55707223a845903d22717e28ba47f3f2241eb1be4b9e190af7d41cec82822
+Tag = 3a95155955ec94d4d7db1c461e9f08b8
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 3ef7aa901040c8826f6ea355415781f9863150ea86975d5f574b3f193d99c62f7451ee4004bb94
+Tag = 9d3f9226b35ff43c17416c3de72ea29b211de353b8ebcb81
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = ff7e494d99bb594d6d833f109ed8755a3e8984d77f9c612cd46be47bb2196759b1b3912e835b68
+Tag = dbf9b4181a58646a3c846f6518fadb64c81eb8ae3db5b0c01b98a9355b2bb157
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = f5d1b267c1476758
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 8660209d631a7b7b0634a7e7cb49f46d
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = bd720e0cbe96e3aea303c180c1ee8f798f5bcf6778ce870e
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 379b7b30337f57d29d827f033c6b43089269dd3fba8d8dc428c6a17852cc83d1
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 730ae4fe58d3fa53d1c7cba62386
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 2beecf41314fc1a41d09f24ea4a3
+Tag = 330387c518482d3f
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 99267c5009d862a7d073d2120bd1
+Tag = e85654632f2caee0ce6870a8dcfa2682
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = d80ce82646418cfde5e061d91912
+Tag = 5e9cf86be9b8f8d2c37854c239b0b089b2375e318130fa39
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = aaa6e8bc70c5cdf49b0fac3ae11f
+Tag = d40a6eb29d82ea6feea0b78649645509e9ada283a8234feb5fffddfe2292f439
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = b74ca5f35993cef1fd3ded30bab1692ed7fe063b370eab37500288e775c677f105754d
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = b9d4c1d0a23db122b2e4670c3deb249f75e61c9774d5042a92b78b128d39ca73ec30c6
+Tag = 3b957d2cc7a5c71e
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = cd12516dbe96d31e2ddb676675a676e7b77e5e532ea322768b4f34982e1439f63ce912
+Tag = 841139d2bd13a53e34913a7c3bc42ac3
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 06c0fbacf6738b46934270047ddc2896554abcfde7edb1c1e501dc68713fbf56272228
+Tag = 4c088713728fd4e049438ad16e43fd5953c518c93987713d
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 2d552e55134df82ac4acac926aa38ea8cf3f211e1d7dc91522a58c6138bf2a63b5e380
+Tag = e587189fe843fc22ed72e7a6151073e3ff7a4a8ab631c6770421b92f4da31668
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = d40299502b65f3c9
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 5af28cb2e4873e6ed92e7c64f93f32d8
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 92bcc22be507643b112dd1584173e60c79f9176eb698be16
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = ae932d22d03658331c30efb90607d412f96cac15d2d721a7926d6f278a9799e6
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = d875101071af56debf1a974639d972eef220cf9d
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = d8e92dc7fba0c62e6a862bbd0d5a8c92fac2372f
+Tag = 268f8c293aadc195
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 9d32d21ff1f3f34093a90b79df638cb40ec3eb15
+Tag = 2a6afaba1b150a5473d3b1c6cd536610
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = de345a3a290699614ed242ab488e66d1b0ae5b87
+Tag = 946ad4fb866584ced895c2deb720eaf603b2862398422fe7
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = ce8626dc17f2aa596b4c6d598a0ab2648c085b02
+Tag = 3e8403b9cc9d464f4f72e5aaaf81e0f91387a9531464d42a74288ce30e7df438
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 6d6bf0966662f7752996eaed9320164f96075cebf2d8303eda1d18684a5c61f2cfaf83a9d74eba64c21b1f94654359db545e
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 05e72acb04a839b46f890ed98bd8508bd137e5b9aecddb13a496459e3e385c5bc44ac69a67975a6bfc5026c07ebe115b1533
+Tag = 744fbbdacc6c3894
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 112724dbc0d465778389253c26f4c8d41b61c67a077a4666b6eccb3712984e070e7c899d33a8e4628a7444d893595d470620
+Tag = 6a56cc445a3f1df7754877a89785401e
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = cef426870a26c662a847c934d5d77cefb0110fb953358e9e7bab8f697e0cf1c6d8e31d8e6fa8c618779c01a3ca230737c7dc
+Tag = 62a504eb88de496396660fcb43ded7758fa363e76c3e2f6b
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 5f53b4f3feb898a412a8451574363111ce15f5136fe6668ffb639502a492dce9d7de600af3ff6c724562a445d5073ec39660
+Tag = 901f421d8efe1da6a1c1013b3bb269fc037b5e77f2adb03e3d5b9ed6417a8ab8
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 51153fc4a1b8fcc1
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = fd10e1c68f0a89e7b1aa4ceb6dc0a2c8
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 9d79e3b923c98d1eb2f17804bf2775e67418140d47872f15
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 93c300b68b9ea1d3b58304061b8c5b7c711cd2717fc072663848a99f3e2e3b0a
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = be78d0cf9894c141ea1b98288aa86835f544fece5638e16a675c0e16
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 656cd6d4dd7d522033ae8de5708d79230d5d4e0938d28dcc8607dcf4
+Tag = 818ac80d8931033f
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 23d1da181b0b9d2d1e29b2c70b7d55ffc51fda4f55baaa1ca66bd763
+Tag = 15f3d2599dd31f7b0d60243ca6a8f1d4
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = c7b3ece05ad8c9d4bcf53c00c3a987a8a8f48b91b69809ea21a47561
+Tag = 2c373a91065d6274a62f805474cf502a72dea005bfb44ddb
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 4fb669733eea468e56da096d691aa3a64a131bc7677ae583afaa88b0
+Tag = b233559f1191894dabb309f4d9ffeb74b40983d562f556868bb9d0861eda03e8
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 9302a642de6c4119
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 0349ad92bbfddf5a76b44af8ad6a9978
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 5fb91765b30a1d155ccb2239afb6bed78ddef65d716848ac
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 1b0bcee2e8089d2a951365352665213cdd44b755dffa09e7533c998c0abcfdab
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = df94b4dbccf6cead254be157d128866523cd70067a022aa98aba383b7316ddce1583ea3f194587
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 6a4fb26ec593948894dbc7be771527ebf7f430c1b8746d833623effc279890313d041fbabd5e98
+Tag = f2a86e8cff3bcf64
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 4930aab085dd7d11d07b44dbebc56971c121e4df04cfb5ac999ac30d92b5409546ac4b3d9267ce
+Tag = 8a06e025e500c9ab6955fb1d71ca03ef
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 15a6ee5e0d67d66c840feb3f53f579e754a105f8fbb2c61b4f857f02d16b83342b12140d0e6d6b
+Tag = 470c4b278c0a3494e86691fb55d94679437ebe661b9550b9
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 9c4644b54fa551c7c60beafaf8e47ddee95c40aa2a44af4a074823bc3a82b76409370b761d2461
+Tag = c8e1dea35cd8f793d20852ee5019a7af69ab1edaba32f36d515fd187fc38bccc
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 047867d96cc5e30b
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 7422ebbe832768bd984f371c5d4b3c71
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = ae4215ebc133fc7e6b5f95d52dbc2313eab15118c99aecba
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 5621b377c59798b5386a0bbac0b48f944af2f917d907849f51d2292dae31256f
+
+# initialize with key of128 bits, nonce of200 bits:
+Key = 4be47d16af48e17a13ac45de7710a942
+Nonce = 0566c728e849aa0bcb2c8deeae0f70d191f253b474d5369757
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 8c8b3389415d8267
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = cc760016f116175d8f6ea898c1095dec
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = fe6af8f11620410a07512f2b5c1c49ada5f4270f3f76b993
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 91db7741d968d1a0069108e200397463c8f90b0b5871f584fd4140c563c2aa01
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 688da7b484
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 3aadcb4981
+Tag = f50c0385171df904
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 850c6051da
+Tag = 76ed800b978c7e3dcf152f6c0cdeb033
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = c54ac744fe
+Tag = 001038eda06aa84d8726b9364d2f357fb2ef1aa4e4227ed5
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = d6c3e1dcb0
+Tag = f13ffa7988afc8bb4da6ab0c30467f860e4df173480a137fd128d2d20e4f7610
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = e24d63cacf3c5c3fb93dca41
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 118d82c8ddbea0289ccdeb35
+Tag = c2de42c5d9f6b81a
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 9ea440015af1fb8df74aaada
+Tag = 34dce4b7ca9db1e732e8499d1afa3f16
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 00641898d9ba761f5859acd7
+Tag = 9b3df5afb411f90220b20c364dae7d6941b2b04b65a8ae28
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = d4c10bdcfbe2d220781f182a
+Tag = 49da6c9fe4e68a2d3abf2e8f2047c689139713e8770042a3b5229d43711d66c8
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 54a1a21b12c04834aa39860cf499cab88115a36df107aa
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = faba64f79cdd68bb5826c0f48c11167f96c7aaed05d07d
+Tag = d5f40974d10399e5
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 6feb3267571a87007a555ccb0af3c9e21e0e5cdfcb3b77
+Tag = 156822c201441823563d277155a25f7d
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 46ef8a0e9fb33d9745cc9cde2d4b8f8976acb6f08e2bc7
+Tag = 88e15f6c0fe202e95799b9aaed8db3b29bab57212878cf12
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = da65e128c9a64ef1bdc776eb94b5641460ea13afa8136a
+Tag = c37b361df629567762efdd1ce6c1ddd6a88c6c6904baf1f16319979fb83c9cea
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 95565c9d2ce1f00b8c86b6a2dc1953e34a0dd6fcc6aea600b56810d9a302fddfe304f6256b599f
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 58b83a037b52119ae727b7c7846d1d5a7c56187481e11ff94858f8db116e77aea8c37c0699eab8
+Tag = 20717c608e5cba7d
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = e38b6b868272b5bfb6ef3344ceb2aada1140c39d796381e7427a32344e4a0aa4dd6aef1601adff
+Tag = bc2958bfa997766673f873f3e213dff5
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 4e38879310f0549dd1d41dc8f10a10da0139a735c3d0cddcbb962a6a012e11de732c41cd3fde56
+Tag = 217e03fe3091856a52a87b115d21991e0015dc5966ae4378
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 25a1505c2e0bdaefc599d2a03ddaaa0689d29ecea4447d1b1c837bcfeb5bd3e200aa0a49097102
+Tag = ad6a72be3def350c73e3ff894da16ec1f449edbecb550c5322ab75f1888cd0f7
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 6f21ce226c59b8cf
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 1ab4b1864fcede48a3fa47d04c378f49
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 4e22a4cfb6c21700dee958b0f6ff5cdaf21b6c0a7f41ad98
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 831bd4ccc797a045f5daa4fd28c1912bcd6340ed9f0aacbb5bcd752a91166d67
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 023093f6953a45544252b8b76231
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = ad1c6e8f1aefa462e6c2b9f62a91
+Tag = 1f5f6dfb3d283bdc
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 71b389dec01a171ff24cb766d53f
+Tag = 2a4910ba3041360e51bb79b7ce1085f7
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 419a6d6d6811d6cb06422878d64b
+Tag = 586893d80676b11d524c644d035f4219764f497a17d10384
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 5e358cc4dc46cc519674adc56fc4
+Tag = 8071aa74acc582b243df99a985828e80d6220b5b691b94462d4c05fa5b6fd9c6
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = cb8d2f912bf7a774e20b7277783e7bdfff49b27a2576e45bd444dd56efd5ebe5c11371
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 30a1fca11ec278a28c4bead29f0adbcb7b0ec76e31dd35b442b4e65839ea14d9db4136
+Tag = 417e84ad67a0b45e
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 80e1306381f08a20ed944451786bfccdc529b9078c01ca13da2f0633eee46d46b28077
+Tag = 4df05dc5c1dab8f9041efa3751da8ec8
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 578f44a923aee2925807b33ebcbe5fb4b780ee869a6d1e8e77c8af1e96f14d0d60cff6
+Tag = bba60ae30fad71a8e3c56b43b6e1d9d65bb3ffb0a7feec37
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 994b703c4a5e3881b07f48b38319ba3e03c167807390abf79e1a8f3351dc84de38835e
+Tag = b2b1ec2a55b97b49d2ff49571d963aafe9afceb236425ba3dc846ab2975393e6
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = e544a35e991659ac
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = c2e181465cbdb3dd3fa5df16ef428ec8
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 7394e75cd5875a6e676a89270e881d0ba0e7ce3cbd5f5061
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 5f2d6aa54eed96b36b31316b87fe26d93ac4ada3dd2be608bb196da150493c3e
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 2c152129ad1ba570d0c96688f9df2453ea61029d
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 9049a75e5961bffbf6560589ed304dbec0fb6df7
+Tag = 2dbcfe5202bcf697
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 4c9048f50b4e7a51637c0f7127158656027c3ffa
+Tag = b2c1d321e5dc0e98a3ade8e59147a145
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 7360ac045bbef16ee7d42a1bf8930d2fbd67711e
+Tag = a1807216351ea3c36ea75f4cbae5376d010caad032e0c334
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = ba9838a3ec8b8127c6e6f09e3b3f9e2fa6399709
+Tag = 62907ad14e883cedc9eeb1b26fe6a269a82dadba9d0b8288f6431828c2843406
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 31d070bc61dfcb10e08c5d406ea9cd9fea808becc341fe39de213789e045fc1c4bc3afb474093973f0192eeb0413c5f543aa
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = bb3664b6161609d3da083bd5e6e3186b8eb5348fcc451755861da13e827319219de5d9eb8e8bdf17f7c4aa081edea238990a
+Tag = 628cc8556fdd8fa6
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = a3209271ecf5ad17b39e69883fdcedf8729125e6d1f4fed8c350f1e8197bfa0ec7d81c8f3368170880fcde1a1545ee2eb275
+Tag = 70a0c69a65e6284d6a94147444cd763a
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 90010a7e9aef1ec85a8a42391155db70c15a660454996c87e77ccace3c39c9b0e005413c6f018e28711da45e212b076ca635
+Tag = 5162df8c34774f09fc9cbc1d8df8b7b7fbac36b49d335387
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 4a94731f413f3b03fec1d034af0860085084d12398c7dacb629bcfdcd3e42f0c64675157614f37c04770a662b219b37ed55b
+Tag = 7cf98f303fb4203862cbb3560eae8772539d4d93e923457f3e57c3099a232d80
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 4305c395a04ad484
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 8743a7b2f58178464657e7e6853b0093
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 9d93b0b680697bfd07ad1c6d8825cb66adbacb0ba4194f57
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 5fb76248849ed011e93fd16df9fdef440e4bd29c923bef1c138b2b72bc3eefe7
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = f92bac8dcafdfa70fba66ab701f11627e0488c26bb42fb707b1031ee
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 2d01a08c0d3156c9ccb436e86c539eac2439d3e03e57fa15af549d11
+Tag = 3cc5082bb934169b
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 5d67d3f541c1329366c081da74d5ebe79851c894a23320d99388b5fd
+Tag = bc4164fb0d71c21beca48524f7b3af78
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 8225745793eab1fb6447e2c533861c9b09c95ee5b3e7a273190e8919
+Tag = da17166bb10da5217d849643b1d330db01f5043bbd7fe0a9
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 974bce2c057f9bfc9915677952286e6b8b29a9ff168c757632b17ecf
+Tag = d1d80adcc7e49221dd56e3eecec5e2081b12ecd34716e413b9b56e5cde5124da
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 50356eba7747773d
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 70cf777b80a2db9fb80cc1def0ea0106
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 1e6946e0cfaba0f022e5b863fa5b97748bcee1d6f0a41506
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 722a1d69c9a301638576afe302b4a110f1afdaf326889c524416036021e14e1a
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 063516c5993ab1935e08ad9ed62e407c6fd3e3f17d0743d4e51f236d2d928cfbd7f17bc00cb675
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 0344d3c0c66d31dc6525d1c2f4081a46ed3a83f8fbb26799ace0028391c1e7de7c9f8132101fb2
+Tag = c40f532420b882ae
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 6fd6940fa46928da2f64566745956638ce3bcdcd42cfa90b789c7071042dd23c79b8a103ab31a5
+Tag = 6294335bbd47d4ab7c75c684e78a2422
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = d8e2a597a169bf8ade85c4672dab9b9106981d33ef2f2b4d18bb8be9f31e0d0ba8311dc45fb70b
+Tag = 976e3eaa1cd93a321c87613e9713a586afa33dd55126772b
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 0a870d968005e2a1706784a5bbe16c64b48593dcc13aa0f439df0224661c4713404608139b7935
+Tag = f7d21518bbbfb71fef78b12b1df978dbd343516e31830a0906d8e7335c2129b0
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = c2043ecc4bb054a0
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = d4f53b585d4cbbbfcb057dc1f481d7c9
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 04cb1b5f6251e8b24250b957e72904978f9bad17bcf0baf2
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 33642ee3a5902da9139e1e026c2452d1816f05421d1563e492266120de203e20
+
+# initialize with key of128 bits, nonce of208 bits:
+Key = 4ce57e17b049e27b14ad46df7811aa43
+Nonce = a70869ca8aeb4cad6dce2f9050b112733394f5561677d839f95a
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 43c46ce4ee991032
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = c77313c45549fb9c81039b27810d9089
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = dbba012e8e8c2db59c9e141fe0e443f9a5565568419609e4
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9918c97420b4e4cd3f60f78b1ffa8c157df31cb0a8dd292bc3957fcb2b4f047a
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 685ea2defc
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 3e97b7bc9e
+Tag = e09d59b4a565e87c
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = b690fd3920
+Tag = 8fda851f437055ec7e00ea6ef8fe6756
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 76bc7cd0a4
+Tag = 6c6a4d3ddc3ad550f83987fdc297dcb4ddd5ee10d84cfa7b
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 25cb8e1008
+Tag = d9ad01b89e1b28981d46094d398b771e867947e8b18e55805ae7829371249cd6
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 6480e36c71a6683f1274ea6d
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = ca2b53e435bea1718c9ad3d7
+Tag = 3c43e44b9f3e8950
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = a46ca3db31a54534c27ae3fe
+Tag = ce57a8cae0308c897caafe0825fed580
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 39d2195d85cbebf20028426e
+Tag = 13fe92419dd0d39e084693b9595791e8c3fc646845380371
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 1a5c9949860190e9d54957e2
+Tag = 7d4acfaa4e4a21b759c6d6135d73ef7af292edc2dd832890421b398820a1d63e
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = bda8fbb4e775e5106bfb4163fdc2f658ada4fe1a76c372
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 1d4e4e47036894cc98af93c07541bcfbc1836b83e94d58
+Tag = b1718b409b9fe2b0
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 10bddf2773e40bbbe8c95694edee522f113a432b498ccc
+Tag = efcb1433768530a80e5f6e109796eef8
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 366e96177214e162dd4c59aebc91d994527849ae428716
+Tag = f23520d8dcbaab04a5996799e6e9c1c55fc63cb2bd0daad9
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 0082f39ba6448fca1d8c4076abf4a6667791da7489f762
+Tag = 697c15b7b5c69e527a300287f00a9209db23ae92cac9d85bd2e32b6299028d56
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 781876327396477ce48c21776d42bcb4ee8905de114cb36192a0baf39ff1c1e5aab3d4749cf028
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 142e51785b7ced16fe35d1bb9c1c0c66720e7d42dbb5ccec28206ddb972a4c9d18662563c61516
+Tag = ecc8814c20609160
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 94bfa30d888cd8cc603377b224dd34d6285595b696ef77053ac1ddb5861a40d65ad6ec82c0cd1b
+Tag = 83a41d08b4d775d6f4834f920594bfa3
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 20418aa3ce3acd57129f2298b58b98578fdf3ea8e8d9600e34bc3bdce8324746a1ef03e3d12c6d
+Tag = b1612afbe3845107b4af735ead93639e80214e58e3f61446
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 919822d94799fa468abac2f9915a30ad6e10c7a12ea308026aa6d2b2d3a3e3a10d0389a9dace7d
+Tag = a6416b1576b72d04dc1fbafbcabd76e18528c1c7b5460777767d5c163e9ab90e
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 6348cb3111498c34
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 0240f8ed9b9cd4563c42baf132287187
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 69e4a0849ae5d4d7d5e69bf3d479a6c29fdf083b689d40b5
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 1e956d56c2f44898be2025e4b21970ebcb6fcf335d1e260f03b4a19f1e1d7742
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 26678d8ee9bb37643b39bfbfbabc
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 733fd90613c989afab394a98515d
+Tag = dd8a00ed266f0c1e
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = bed570275944448bb391e4a420ce
+Tag = 95b6e8c0fe8f315c524879d7b3b8f412
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 0e96b776bebecc5eb5f19f4c2b5b
+Tag = 37704b641e63bc5f528002bb7f6beca1a864d3a0cd32189c
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = fa62cd4cee00625a6fb365279f7f
+Tag = 3c2f3d990701e1721306ebbd514451016340178e453795dec53456862656344a
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = b00c94f07d4e0ac607aabb8db8add67c81cd7cc8aa2c0855540ba865952a4bbb104a67
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = d12cea72aa7111eec77498b2cabb34a798d14933cb25a903ffa5b48ea8d38dd64b8ff6
+Tag = 35a1d2ba1ef4da22
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 8e1be63a9b2e0ae31ee1955dbf0c9f06211fbc0a6924fb2b9d6db23e288435e1fc3f43
+Tag = ef6dc60ceb1295cec9b153b76948d642
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 6e61f5e6b8aadfe0a0cf364c42d7a2ea62963fabf6e95a84cf82ec0147f3f22a3da55d
+Tag = 79b1dc61760a3730b4a5010e29476bb4c61a5efc4128052f
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 9eec90d19a674e25b1ff69bacc46c72e34834fe3d1daa0f0431fb6da4e6f2151585de3
+Tag = a0ec9b27d7573e91809c6ff0c3d550e4118150c34b8ce261393755e6b231b5c4
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 100800c0195db8f5
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = e16b25513060b860a8283605c62fb517
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 3db190df589aac365761bf669584172f824a0e7b6f5e0083
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 45fe96ec9e3ce10dac3c0296de2fa6127cfa90173ef9811154ccffe863c246b7
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = db89861fbda42b7fded6cfda708ab8b70d2a7b05
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 9a03a8aa38b284a65b95ec5566db542db3fe6a34
+Tag = 927240adba78d7ea
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 4e872266c42966d4751a41e4db8e80ac1007bb75
+Tag = 5394f4c1ca12402361956e6fc65f868a
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 1aab03eae2e64a5c67337bc6d51ac4ff6652a604
+Tag = 66b3f1d65c4da6896c7f63a19d5e68340fc81be7cc8cd4ad
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 52a5eabcc546b1ea35d0f4f2db96626cc962c9b8
+Tag = 3caf6b739267c7ea4f7e7993755905eaf0d38c051e161510a2896ca4174d0abb
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 548c5ac4d62f2f84c32484227c6c507c7fa5575306b61bcea62f83bd71c6ae8e6e1a92b68916e3a84763dd91b000890c532e
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 51dc6c45ca67155147ce821861bdd292019835c6236b897a495397ad1c3fbbcf548413427690c5cb5cb70688abe2fc292d23
+Tag = 186894478f18f504
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 984bd96cb2aa30c50242f075223d1c71fa75608d0a654acb7c2c837d8c5b693028281b99854b3e9116a79921dd3cdaba2adb
+Tag = f3a7778a07dbdd19ffe02a7148b43101
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 701aa225217be0fbda8ee61f216caa08caf58a41bd93bfc3460cfb272acd5992c8a36690b7640f23ea13be5e170aaac0f69a
+Tag = 7a5ed1bda05ad7663b5055bf9d29a1c13eb4fadb88f462bb
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 8453502b0fea1fd2d1032b4bedddee830fd9704651104760d8f9bbd71866244dcd41826ebe312fff80936147bc7e15b7f2bb
+Tag = c093ad2a41a02102fc29589cfa16425d960911e1f11d29983284836604edcd1a
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 2bafed5f04782ff4
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 282bca0b58ef01bff3af156b0f7be6c3
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 35098c74538e69827cfb496d6d7f2da120b912390d82c37c
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 594cf022b79240d938bd62aeb94d9e11a5a239602a08137b5bdc80a16de13ba6
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 7d6a3b46f9a94964b5e9ee8e160fb5ba70af1f77b7b4b06bd868bd0e
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = da7b41b5275e3bd46b004e7c4ab6516782f6c0db76392797cf322891
+Tag = b8b85050f94a51b1
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 1a429920a1f55f164c81757b9279c16c9d0b999438b67bed013d546b
+Tag = bd4684d6104eafcd45ca72480147d842
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 0fb85e9e3dbc3c6f53054a4c379c49405183beafd9de7dee8c56e7f1
+Tag = e4ac5a44e4c0845bcdd8a9a44a7229afd447156d55bd5c0e
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = da7eafeb5bc75a3a2a97c4d14ccc9a901aa497f75e0a0ccc26032bc1
+Tag = 2117e5cb2c730c77b730a537c88df8cb27c7a486ea1ca2bfddc6ca199b959637
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = d23607ec70d11fc9
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 29e218e3b78f60250788462403c112f6
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 129ac62eeb5c94e651ee37892b31fee01d009e95d55bd6d7
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 9734965c267169c857c1402cdf47ff6efccc648dbcf8244ff7903caa5e235398
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 3e9e98e04f2bb0d9a9ceda9e790efb7e4fab7e8de95a1165de9e24d6027e2ebe99439d7ab8bfe3
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 7a9519a50882d20e670bc8d9ab0c304c267bd5545774792441d1e63981c0db1e29d73c91723de0
+Tag = 70ec6afd72f008f5
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 4f070f39ad9098d068607f870b02179eb2f21e5d4a9416ffb5be28c6d078c748200fd6859531ee
+Tag = 201652dd1e506f1b6032f2322c460987
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 8d9a763f25f2b53c6b509a000bc6a1684737372ee64b7c425a94651bb77ac7fa4def6199ba2b41
+Tag = 88e0b474a981a7951a99239cb311d7591dcfbdf7b4359628
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 2c0adc4206c998ed3e49ae065df595a64dd69b3be67d1a88922f113c908cd77a796e939191d956
+Tag = 54b85f8a7125f6ec5ddc751fe2fd75955dcee06a5658bf59fe47ca14eb54a3a0
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = fdeb15b3a1ebefac
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 64903906595e60939d2abcbcca80eac9
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 4fdb41bc802025749c23e87e9a8bb6f897f6d684e4608ce2
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 49d422a9b417abbf71257647f2e867cf9d01ca60d55f0230d8215d447c823b74
+
+# initialize with key of128 bits, nonce of216 bits:
+Key = 4de67f18b14ae37c15ae47e07912ab44
+Nonce = 49aa0b6c2c8dee4f0f70d132f253b415d53697f8b8197adb9bfc5d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a3faf93a9cf2abb5
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = dcf6e3bd26892c8f89b2f1378e7220d9
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9a558c75aa57cf146847acdd4770e258da914ed1aae30218
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = e6a1484d6fb672039bf024f1d58b83f7b6ddd4b64bb47d7a693363db01a72622
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = ae8ff2ce7d
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 72c3f0b548
+Tag = 8a7f01f2e1d5f701
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 0b1bb7f826
+Tag = 01c90b7d2fde6aed759f8e0ba8d99cb3
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 2d1aedfb2d
+Tag = 7bee99dfc909306780be4e7c1f602a930c6bfa713f706fc3
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = e4c79656dc
+Tag = 78b0a8120b7802d11531187f412e9a989668abb299528151513547d5376a293a
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 7e75a3afe813dcc575773074
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 186647aa7a77f3ec6486eac5
+Tag = 8a8a8f76049e9b7f
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 9405ee2bffad0dda2d383df5
+Tag = e6e4a7d5db6051b977e2ef960d513124
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = c28665d8290288e6838a89b1
+Tag = 960de23f6d0178712c96820ffbf51b82ec8b66e7f6dde518
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 4bcad4df3f7e7f7c82e2c835
+Tag = afb507aa280c77b60ff724c8c41551105ea9642c055d6f08ae77037c688508c0
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = cc4dce86cf5464b7d1c22659d2a748910bf83f729bfd58
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = e31a9cdc9e66db34728303d78bc85e71388d2df2661cb5
+Tag = 49dce1ef7b5fdc56
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 33dd81ade1c3c3dc77f2d69bb3600ed9a0b9a0f5a47102
+Tag = b434ca702b04b00c33cd780329fab968
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = a0bab146334e74c34efdc6d3d86912f39da5966ac9a0a1
+Tag = a61f4dd5f76aff91c2f809d7471c32a0728f128da5e610e2
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 25459d0448655dda8433d518a7937493a149110bf107c3
+Tag = ef326cd52e2d0d3da80cd5ecba8cae914a1fe676ead7e83289e6a194fb4e2b9c
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = 617e77174d79435ef726ba8962f285fddab9ea2a642fd5f5fccafddac8c0ded05e5bdc7ceef8cc
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 385aa8b69ffb49943e3b58ea6be45b90e0bb66d359e2028455da09212576729a77d23edc92096d
+Tag = 95ae1d59f4ca005e
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = f0337cbabf513b35b89ac314a26a76037949e024c2a0e30acfbac95baf675a17ba228b8953ea9d
+Tag = 519d85d3c02654386dd03ee5411290ff
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 196723157cb74b2fda5a096da269d50d1728437e3ba50ed67c370ea213431d7e7d8b179899af30
+Tag = c1b020d79d76e738367fe735a6969966c2fa3009172eeb2d
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 8c8c61b3bc2d8454735c3e30eab6250a7d5ecaab24b668e6b5c17e75d0eb0d8194675253ce3fa9
+Tag = c9a2a42a753af4c865341b32ed54d25100942db57a63d43a5a56d2f3f19046e8
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 2eb18c4c29e31bfa
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 9cce56ed4f59ba011d98f2ab352e2e2c
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = c9e73d90f4f21dcbbcd8eddcb9fde674b39add255b9528b7
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 1148bad74b404d38a1aa287a60652d1e7a025beedb41a7c8cd73d034f959b6b6
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 657ac82a7d6b8629de5e8161b6ed
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 23114a2605d46eeb5f955f39b8d1
+Tag = d915b2e3a7e8043f
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = debfa777feb126645a71648ecad8
+Tag = aa8a6898e6602035b8d7113d88992f75
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 439f558b1410ba507a70dec86b2f
+Tag = 0d8e014228301a7f04aec14528fd290348ab664add8987f4
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 3a2e833b9638db4e488e5bc45c12
+Tag = 543293da440e4768b93927ddb18bb53c4c5b14a183029bfb214c4884b03c4605
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 6eb45f6d57e916b4ba0f427c1e102d4fc0588aea1975acfcc25295bcb7d5ac3c8ae98b
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = f93b550284e45a9072b288a3aaec59cc20d797dbbcab2a68d38e5b893b6ff012ed380c
+Tag = 3923d415d490b823
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 543d63a39a253df2adcba04ef87d1f0d9702ebdb4a6de7a2592adeb1e6d8a6d48b308f
+Tag = 755074dc863937c6eda2acec0026df70
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 459639b0980a953138f47d4a1b685dbc3d3ee512ff5e46c27c933631c12e629e04f64d
+Tag = 62a70549d9b67d06c6cae46e5d74fb1cb2a2b62906e976cd
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = e8841a7061ef0b0a1fa4255bcb133639f5e1492be75d78049be6f7fc0a1d46b4b00f44
+Tag = 87774e8ef2ef7ee97ee54a3990b5c2e42d5977b78076da34ac930e8ea2a7e970
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 37fa5d11a3e458b7
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = cedd13abea52477320c9277c45cdcbcb
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = b468b9c9fd39d6b02a30b84aee3c49609b67e738ad5f5a40
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = fdcb5c225a7bb85e897fc9ac205b5fcdf9f30368a8d1b837d6b8964c0d46449f
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 39aff98750abf001c8501c74441d2395467e3568
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 836ad6a51828bb8424824c173375448c94f31d18
+Tag = baa3257bdf6b381b
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 24cefa13b287d32295cd0edbb27d485bcb276338
+Tag = 08d47af3c3e06448160bc854d193c500
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 32565b9d6c2ca92ad2f22fa703d7ed7e4142a7dd
+Tag = 843615d07770ed5da9cfd2c38955b994c07fa55a9867470e
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 654d6183a0f54404c9a6b0f421179c7c57e8813a
+Tag = a0342b72c019b6d8070d5611ede5f28ccafbbcd5fe9796cae55d865ec89ff784
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 2bd250c57e317be16e0ffb6151009cfcc6bd54e351631ed734a5d7e422e560766299d0b7f12b471147c2f4c5cba855f7b32a
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 4cce1ae8ca4f6bb118b90da0b0f57a800ab188f433895f11885ce4c2fbf5505482e90d91b7ce9d2239acb57deac740e5dd0f
+Tag = e2b2f97c1d010c67
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = cb449c6f046424fdd81853be47ef3450a6224ed287c6edc2812be2232a50f684b6097db2532a014c8c1b39dd6a08536729c8
+Tag = 4bd673ea0d229c22a454f6c99117c901
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 5cdb2d2baa44dc92fd9dd801a6842db5b740ccb305a899c2209ab14ab95742456de7102215888478df6ff84b1d40abd4cc00
+Tag = 98a75396418c273371baff7a10477136c99871a5077671c6
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 5c24672a6ec7b0f18ebc821face4197dd224bfc591b4460e181cfc29ee7620c9c68b3d4950817d5b4da63d4dc1437636e1e8
+Tag = 1b420ae7434783985e36db5008daba3a1743734fa9884bbc7a2bc331ed7fb4e1
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = cb155b520b302a8c
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 757617a6c6b7b2b1340ee003685d9b8c
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 398f231a6909f85a31b7395562b7e50f88a448c9ada1ba4c
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = b7a041760e52cf73fb969de9777b2dbe56551f5f37b1990edc92736b7d412fa5
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 490e8ede05fd1fd8249ee5a7eff6b7e77b061377d0c0b985bec494a9
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 7e0d485bc63e52ec528d9d7f043523323ce381782b3e9301304a73a9
+Tag = d11c9108580e4056
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = af1cbf83316acb58430be8b719cef11ac51b0bcdb9b6112ae75b57be
+Tag = 6cbd637e38f77547a5dea29aa941a4f5
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 8fc784e18a4f5ca8203e50d24cfb15cce9c16494c14e62bea12f6c8d
+Tag = bfca13b70809511aadefa29aeca4ab8acb838dcd72ede103
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = c612543c95eacf3d1547ca6e189edd9f66f2923a75a211dc513e5e5e
+Tag = 7b0ea1b499565240a9608b05347d91b6946e2e6c2042d2036dae082987bdcf90
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 644f8ec631c85425
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = ed920fb092d5cf873f0ca4784f1b0a9d
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = b5c860337d94cacef04989931a84a26001712c842460a1aa
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = b3190be9224ced7219257b4b006fdbe83744e7a708cca186a1df5ed8f39270db
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 506ec68c2bbf68efa94092889455e103930d547438286a1f6f45e75ccbf8901fa2822fe0375957
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 96f6bf7e4e53fa44720d7205e71fd96d1aaac05dff27f56f71aa253fbe2d247f9ece09541047ea
+Tag = c06fe889caa783bf
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 17da72cbd23d6ded91db67454a56ca1eac1c901b481f5d2dca1838efc8f2a643b46c279ac784f0
+Tag = c4bbf699c776cee6c09735664e063f40
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = dbaa2bc1265da01e4264a1fddcefd2c8d72b942048b6e501c1bc655611a82755a6c3cd06e5388f
+Tag = 2f2156799aaefcd32426c15669ed7207bd2dec8682fdebb9
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 856e574c2b68bfc8d3cfbf24459bf9f66dcbf98375598645b5ca44f5b0196aaec99efb78834d12
+Tag = be50f92cc7e45bc4a3ccc3eef17a8c63935a31dd9e020f4f393bf5bf47843d26
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = e35cd5cc5e8f7ca0
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 6388b6d8feee2895f6eec71179d96ed9
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 90b895a3d55734f7670d00bfb1184481f547ffc18c548987
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 85d22de58801952a05254e1935ba6eecffc9d87751632e2f06740393dd9e6973
+
+# initialize with key of128 bits, nonce of224 bits:
+Key = 4ee78019b24be47d16af48e17a13ac45
+Nonce = eb4cad0ece2f90f1b11273d494f556b777d8399a5abb1c7d3d9eff60
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9c1a35f6f04519e1
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 6b28a274a3c5ab927f9de267b9cf2350
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 978c2406c47b2b2d02bb6243b795fbad0af4d459e44372b7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 509f301dddd05dd16d5071bc5dcff07bb7034eb22087a9188abad2ef6258f25c
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 9c1b93c8d6
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 560f10b6bd
+Tag = c6490249b200e4aa
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 3b2100c354
+Tag = 2a3e81ce64c797b2e6e1cd28773427fc
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 1ad11bca9d
+Tag = 745f00ec656e824947c792d7cad848274bd85428adc22b95
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = f15dbda13f
+Tag = a5c63e97a23b0f613f9676362740aa07440a5f7e32443afc36e8cf2e91feb580
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 037239eaf02890490f9a8edc
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = f6ec2c6649dfbf131ee25361
+Tag = ebd342ca32d96635
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 02198a174bf31a01d58987c1
+Tag = bb99764887ba647a9c0e2c1f114b072b
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 3408e0ef96958c426b9f43bc
+Tag = 448b016543699774d10008f7e4571596f94a98566fd96c34
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 133a2eccfae3f976c9f40a3c
+Tag = 1a948dfeac8a9612c376cf44ec4741c4162bbc56e258521b2617f30f515b4e85
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = e828b35417184280655255514f7a2c42f512ab9ef79378
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = cc08c4ea7cd7d0902f4d63c1cf13e83b13f367aac245f0
+Tag = f0303b91ede8f11c
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 1960a57a1c500e51c81d8083bbbd8881cf845d66fb9c75
+Tag = 8988f587c740502ad3afea288f7553f3
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 6921d7c9e3310d3ce9cb038cd3339e607a2cba77cc4b3c
+Tag = 2e829dc6ce7a771fbef6b42c871a7c899d91e1fc91535966
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 589a0e3a66622265f8c23fbf5404c93a8d7b12c867f004
+Tag = 2cf0758ad7d50fb4df6065188a038331c8b7fecf11539d144c190c6e36e4c15a
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = d178387760f9f610fdbf82fcec1348d79f151a01c489f137111f6b93f2ba0d5870882a4809beb8
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = e341b073b9196c5770e1233cae347ed7c3a3707485cdf51bc75f5da6d372a4b0476b7788e635dd
+Tag = 3e8484e1bfd90cb2
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = bff4938c143ac9b468679b410cbbf60bd955328cd940e324b4dd392fc4d030473413c9300d5aa5
+Tag = 5b56675677b54fe35ff1c651063a47bd
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = b5943b89b5fc352de9311fb23041f81f49c682c67371c4e9c89003293a8922ca7c7b45a0017a2d
+Tag = 6edc50c59554861730a31b5af2afc897ff80d6c581d03869
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = 53f780109e9d9eccc5bf7ae5e6f82f8565b5fdc47731c903b482f06736cadee1969ac636e5e3c1
+Tag = 6a978593dbcb038b4643b3005e71b188d02ceb411182cf37b72e4f009d2d9786
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = d2af48fbc825aada
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 81766464ca2611b7b9fce21142136a7d
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 7bfa5adf776b8a9f7202a1c43e2ac2b161451f2166119bc6
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 4dce94f4a253c31678cc6bbada14562fbeaa8bebf4f2c0020ccdc3813ae11ccb
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 2abfd5198bc583155243b9e36e37
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 615646f2dd889310c55821789438
+Tag = fe9a4722f051ae68
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 4cd5c12061541d991cfd71d11361
+Tag = d0ee12e6872eda608dcf5b33c61cb21b
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 65c5ecc05ff365c60e84c73bd5e5
+Tag = 44c04c26440d5ced7d61df920085739d2e94f374f3d5bbc6
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 0b883ff8e2c8a85566183fdd7444
+Tag = 66a1fdfff6c40d3229bb5e825f337a56e40bc3930804d74214ed270508acb208
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = bf691105622a46a3a01061514cd19ae70b483957c42872d32f9df5993a15d756d4061e
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = e36f44efdfd388ae1906a9115bf7a32b8b38dc2badb187dbc2aa58fa8a2336feb0708a
+Tag = ce869ce0bb99efcc
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 75ab0058b34c27ce92f14193579dda0c6dd76ff9c159dae74a9f7411cbc031223e1118
+Tag = 50cab8398fd55569f8e61797f8e09310
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = 06e0cce120feddbec0ca155c6f281a82dc0e868a1f37f26bc365d5b3f06fb04dac7524
+Tag = 30899559d95accb6ea65297a8f4735bed3330a56c67b0cec
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 31127f2d611b5ac22be86d1ded216d52ad007f2029f177cd7ef34ec5649c99d0bd5d18
+Tag = 06bccefd279ab1804b9cba71ff4eeb159872a2cbb01fb29b75312df5ced72741
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 9e3c80a4fae38287
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 15e9a2292d697cb28fbe9f85c9e80cf3
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 5a96e8e88775abc7cee11b66b94719dabc7b5639b02c1ad0
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = c33a514167a1e8dd5aa02172a4b59ee074372d3b82218e52c17dc77f61d01990
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = f1de892bc0a26ead6724955f3f0e455b878b7563
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 607f3adfb0ac248b494b1d4b129b2baf8e02cc7b
+Tag = 40423a16cc2e43ad
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 7a6449515c4c4acdf81d6c9610de6c6b33392d14
+Tag = e591a8f8dde8c330744b08a931a8698b
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = bd10f9de46a74ad6a734e173df9acfbb9ff14732
+Tag = 3a1cc4240518629173075cdbf37be0ca935af74863a97db1
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 12b4528d63ef6016553537bad09596c867625ac6
+Tag = ca9468a090839039e2ad3d080ee6cfb9cbded1d092777d4dcea6bc90bc31bce3
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 98eaffa79aae69d68b4181f67cea659394a800d94d2975f1885f35a314fd9f9491bc44cea43303480285979f6378a1c2ae06
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = af4d534186cd0cb4cea45f2997ec9c752cc61a524ab1a96fdfed6acd288561698e1f3dec151ddf28c8111756a0ae60d793cd
+Tag = c9cfba91fccae51e
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = e2b134f1f547760fb4319127a06e82a1e3b2a60a37778513fdce2c6cc2c804e344aa5ba7d6b1c6e78348e94047299a890248
+Tag = eb681ae50297f7dfaf2f8bce6ca6dcfb
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 41e7ab486134b60aaf7c8cdaba157f68ac4648c7ac71af1527e98a43576f4ab09ce89b4d2ba2bd2937560281a055a3ab5875
+Tag = c0da010cdb4844b46a26ff25f88b10e5c7d78a04f8af08a5
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = a56b8255c0afdf906473c48a9292efb0d2c95f259503574140a04a58e117546b7a3ad682a1d543dab3656f80a95fe91e040c
+Tag = 6abc2ce84f4277ae7e22f49d924ba42acfbd01cc6382fa2b592b81eed203cec6
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 31618aeb081a29e6
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = c2a215116790931e4676b2a523d79b5f
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = e34dc0ccb760785f58f3d64c2caeffc004ba75347753ba85
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 5399ce71563a3df9bd8071d4d9c4498816d4fe75c25c8e09c5914403212696f4
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 5841402ffed9bb060703b5c7c7db610f7fe874ac97d1e84f973de1c7
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 3c062b8e0084071ad0e4c19f9198e372cb2b1173049bf7303026c538
+Tag = 6571bcd9e8b97412
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 90d017d50c994c7f9f3cef6751a30c9078446fba4275d6a0ba150681
+Tag = d7f6ff9544b652143a806df8e8e11094
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 9dce2ade7583d8fd66e9ca6a10449eef3e00f4cbb5b3b3a8a7a36607
+Tag = 18e3df34f0006bbe6d00d2832dace10cb4dabb2bb2e5f359
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 6aa0c6ff5d177dc1efa79fc78e44ff95a25f2798e146c18924d31b75
+Tag = ba7da232adf9472815cc577c849bd968d126cf9a30dd4e99e50ff41c240f45e4
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 107c6437bd196377
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 01770076c2fbc9d0b237200d05a53bd5
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = feb3dfbd1a2b11b502f7ea807030f91a0c588578bc1426df
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 42fbcb6d2454f9670d208f8085c1c67f47bb1280ae43120b8675c11e71645972
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 6ed14fa2e612cdb65b676a8ff8c2a2b280922c8c4e3563128b4d91fb0472f286873601d5eb17c5
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 58e3878c0285a0654a8200387b2757b701ddb04e87713355352f1556b470de21b8c9fefb3d3d90
+Tag = 1786908cd80daad3
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 347ecb3d55c4895c2353dfd015da68e2421f9eff43990f7dea40dc803cb68a584080ae12fea420
+Tag = 73b18629b31d99610012b50a71a3f381
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 3ef7ca726b189e80b4885cdbcdee4d65f5b1333e19434e960c0f769a176ba984016460e3d08494
+Tag = 19c2ce41a8adcf399bca10944d644915cd6b4edb39b04b5a
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = ed439eab0d041de2faf7af78864ed409bec27afd0827b9f8ee514d870d0968d38f920d7fd21698
+Tag = 8590bbcbec493e5fa275384d5b9d869a2ecab058fd09469fc3e9825c8a9c5161
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = fd17a90f081f5a57
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = 09926320c5e5e2e687ca23de0f2ff5eb
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 3f7eec26d084b28b23ebcfac2391075078a74084099dd9d5
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = e057a0ba1a669329df04ef008d5c082fa95f336012fb01577d79dc90bd045de8
+
+# initialize with key of128 bits, nonce of232 bits:
+Key = 4fe8811ab34ce57e17b049e27b14ad46
+Nonce = 8dee4fb070d1329353b415763697f859197adb3cfc5dbe1fdf40a102c2
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 921b9d300960aea6
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a72b96fa9916a72409f0b7f431edcf1e
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 4883fb9c39dd54e6d9b8297746febdd75dc3ac09074d2859
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 5cd3196fba1463b85797212bd46ed7565684d79f3f525ed2e81440a389706588
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = d98e8f139a
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = ac9dadb0af
+Tag = 6da52ba0701b0162
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = f484deac42
+Tag = e296daa542bfabe2a939b21aa04b114e
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 3aa86f55ab
+Tag = c6275d327a68eef603b137a956fc41372c52c955e4d2a87c
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 48fae8cba5
+Tag = 24c62d1cca4288dfc1f4a1dfa9f8bebc16b033427aa70cad08f3bee19f10be45
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 534546718cdb185257bd93a4
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 7805d03ffbaad12d647387b1
+Tag = e5ca3e3b32d5b327
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 3a03faf9bfb1706252c1f822
+Tag = c8c333f310f3fe794cce9253709c7dfc
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 0593498bd47a358a0a6e3d92
+Tag = d0bfd753ca77b599666f4752ef08eae2c7a7dc74fc25bd7a
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 7bf327b0d6ef3a0639430044
+Tag = 8914d3326c991f0aeacf6f7bc9a4149f610d4baff45c9ec150d64ec220014c11
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 8436b3e0525376a4f3e8509fca6ba845be4d2302815d8e
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = ed8afa313b527cb7d571801d70f7af42fa2824215db168
+Tag = cfe5483fbacb6cd2
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = 221298d3d4e08cf57eb1c61342556bcc8c0560ea610722
+Tag = 41f909a0b53311307be328a8bdbb87a7
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = c9603054da3459f664867f7904442ed0aeb63e374e3fa3
+Tag = 2a804a8d9c79cd40bc43606afc0ab07b4261ad5f60726300
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = bedc6c09f18f263457249270639163226325ef69b02bff
+Tag = f4fbbe56fc8985b34553abd3cbf01d83f9acb23c932dbac8cec47e0fc6306a7b
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = ff2917ba01905612ee16bbe1cdc60162b956d35d1204630f5e03ad3ffb7860cfd904db6fde2cf7
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 8f171404e895b01a69d239c4309188914d28845dca0add2c006ee35ea619f21f865a9195bcb4f8
+Tag = 1ea2da63959ee680
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = ad8bb1fe2b6b2120846b0efb9b131d8bb405743da13394af157b02c9c778dd3b6c7a7f6fcce5b6
+Tag = 345250685764ed964a65ef90844aafc0
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 8c8e41d99c5a40ca233e175f0e218aa38c77a4fd46cd54b606eede0baf2173451797e5973ad2c3
+Tag = 7fd018e5859ae363342fa3ff1487c15a3a70823540dd0e3d
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = c13b4e626e5bdc29e78b3e81188a307919517e9353bfc0fc58d4128e7ab5104e9db9459e28c2d9
+Tag = 405c6e39bff61841f4a703f344589dccb327771999e6ff469dea005d87480dc6
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 46d05f1f7f8303ad
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 2c3e3fbb4ba6bd1c5fee79c5f852705b
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = af2d0613075730c9afb83dac3d8f56e21251f40c8f48b8c6
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 3e1f30dfcf17f47b867651947633cad4bff032a12a2d3df6105452dea7279e86
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = f4f56a33256f32ee178da60b1c5a
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 780d027919933cdee00df0cc79ce
+Tag = 1a7543f6c0cbdf2e
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 69cba28f672c4faf4edf28053361
+Tag = 864adf4f0535c9420cbbd6b9c4b23288
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = 0729907070557b8bdf11fc8ca6f3
+Tag = 72e778e70ce7db9570341ed870ae76fc287ac1e536451f69
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 9e447ef6c87e2eaf3fabc28032c3
+Tag = 5feb2f8867fe8203de42d1d99b27d71fa40de603a5e7964f304b78df5020a892
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 4d070288f3831b3df8bcad823bf7e8d1549aa3e45a78d96f954a0250b7645be0584f22
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = ff0d52053becc661b292cb619215e42d4f4d295bcfa8c857f78d6acb57d91876da7f5b
+Tag = dfe7415816837ffe
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 5e2a9b85b5a43ab79a33522393037b68354db4301936d69a3585648e554da411051036
+Tag = 144f56e7d86307c912c9f38f1ba8af60
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = eed8d77170f63c3175d11e87bb63520d32260d5c9ae2cc4fbe0ecc24559ff702881add
+Tag = 7081c291fb0b17da18fdda660a22c7b1c86b4644acb4b481
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 37402b7d6b87d70be2cf6062040dd7c18cb62a47f50b2ad852d6f94a4acc027fd05b04
+Tag = 1ab0321bea328c7dde54736fc3d5df30c3f873b5d6f9f882123b2e4ede285122
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 4db073e38d506e68
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = eeaae2ecbb564fc1251151b9f1431009
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 3988d139c92611f5264542915514841e166046eb99d069a8
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 6aee9629d92ab95e1b459f3d558f4ad2efa04f3d7c9bb933a60123a0a1a5b199
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 758b68cdc7b1db675fdacb23de4f0f932814b0c9
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = 11161b10fd02ac7b8c297a92c4d15745df173c68
+Tag = 9fe49a0f5357985a
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = 1bf751db9c5cbe8ad0a9ffd216384b5f208dee20
+Tag = bd7b5e4dff0b3062756064d3987150b5
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 8b1051a88c8970c0bd4aa9410b7912ee5936237d
+Tag = 7ec0c7959208a7335f542f691a7e21de015ff83eeb941084
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 85d73a693e40c6b81bb48c59e2e13d774cc781e8
+Tag = d90762a3c0169f658bf82421adc60bd4dab7aaa12338201b140abda1fe7e686d
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = 725c6831464a85da017a37cc8044a5ac2cd6f8df1c069a8809634fa299c90c5bef0bb8a546560bf9c5e1bf4e083154771fc7
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = 1ac592bb3b0317ae8df8e0efa161b008a2ab2caa106ca84323d8756025a5f3c43f8f7b2497f8a687eb3e37c2b4a810298acb
+Tag = 37bb532ffccf2759
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = dcc520dde2d3105cd8b2a0786240f1803fef2a1c89d107101ad37987aa7e0b16e419d2d81177386ca31a049bf16d27c6a8b9
+Tag = 9ba436e3aaa568f141737f8e39abe6be
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 435bc14854fba456b525df2a0f4ad6abf84a8e832a6b8c74cd53e7b7596fde0c00cb6a91bd025833b6dde547e7bcc58d5e9d
+Tag = 0a0e258176bdeee236362ba644182f558212ec09f478c97a
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = deb684853bef475861b23cbd8bc3cf14a92b44cd71c08362f120e74931e2bbfa9cff39ac5e43efae2610bd8c9a4d4e8c5ddd
+Tag = f8e12fdf9e9c0e97065efee3dd2c2ed8fe8061638b1f43db7c87c4603abd2704
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = f3b8badf8a2e25e1
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 124a1b470d2a445af07828a71ce8e045
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 8089fd52deb3bf3dab0fb0cd14b72a6518880351a0845087
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = feaa7ee5a903a012dd150e1c6cb405a11a625cd1671ae5d6daa1b78d0412c586
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = a1829addc245eb517636bae1e3a6257a68786446a163c760936504f4
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 712c41f754c0474b3fed81af89add35a2fa507b8109c5166736e0f04
+Tag = f9edcdac71e51e1b
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 583d1b134eef798ed4be0343c8ab52bb53b5c2c7e8e1017179e62582
+Tag = b017aec82d9ff05a0cc976ebc7543182
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = ee2221fbe103560a973670ad4a9f63063873e521141116a9bfd6b1d4
+Tag = 353cc626f41f2a959aa20022a6edbcb14bcf89300f0bcddf
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = d02c58d86779aee641d0a153c23a8e0f037efa568f8359e443c9cbd4
+Tag = e18353d1d9c85dc9b0b83458a448fd6dd0ea26ee388996cd192b04ce227ae661
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 01f2a8882e01d898
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 53e54eb1a7a7936270c736e7e9acf4c1
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 6e8100e190f1b02279a942143219bc4197e18619d931a2e4
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = cfe06d1360bbd2d08c1c1eab8ace885174f67868f80aad1cbde3584039467590
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = 6c277e98dac15c0b628e823d774e405db5d154b903faa13dc7f8d69a0bc00f432242446ec7fb7b
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = 5ab843bb71a20c8dce926789d166b1436f26208e109ac7323fa323d1915e63afd05771788e2691
+Tag = c5c5f25bf02d219d
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 1006ec40ebdd51fa01a65e5f96f5c9e12bf28094f6f3bd39e01fd8059a4a33a7c1830f6314f1ac
+Tag = aa6c2a0d13cf4776049815a92ca16682
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = 5e11a0589ad7238eed4d81ae5fb7113e7da107ad84538b92a0dea6248d04ebe3a39524a61aa13e
+Tag = 578e9a123b2a4cee1d56b0f1046eb43fb666959fa4734b6d
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 672285171b373a848bbdf65894629ef936a60628254d5f7901ad25bfd6078e7edabfc09092d2cd
+Tag = 0df292254e6ecf633f3e8adc2356edbb9f11295b985549ebb494694df5788266
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 573845b07a8fad5b
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = ab66a63979bdb28a42e405d6c8eef1f7
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 376c0719a65b838a66aacf4461d8cba51f34c3a95b74f5fd
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 8e6ad3f7f90f6756e77ecff92f4a546d7540ef2b3b8909897265a71c60bf7573
+
+# initialize with key of128 bits, nonce of240 bits:
+Key = 50e9821bb44de67f18b14ae37c15ae47
+Nonce = 2f90f1521273d435f556b718d8399afbbb1c7dde9eff60c181e243a464c5
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = ebd30e9e313a2dac
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 70f954cf9e356852dffc1d80ea2c4bb3
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = a4fc33841f9299b9795c9c15713adec20f4af4f36e9be3a7
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = f9d86dd8acddb7dc00eb2b40e96e74713e2239819184bad32d45075102847846
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 5d0fc2ac2c
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = d3abe56016
+Tag = ae5f7d58bd0ff1fd
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 0ef70f58f4
+Tag = 1cd68ba1675a8a6673ba28c7d4ac0c86
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = c7e259d367
+Tag = 64b0567a3bc2b0f646ce84f1226db80b62b39bcc958f7fbb
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = c365a3f3ee
+Tag = f3c8fd3d6ae47101896124e458e522db8c7a8508fe21f7661bebab5f0464fcf5
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = eeb683da8a662a87427d76e8
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = 57cae56780d344664fe48714
+Tag = c970c0b7276fa64e
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 9debb6a7052677ecad5738e8
+Tag = 9f0c257198844558f5e1c96adcdc2159
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 12cd7c4b98cede4ececcf091
+Tag = 29d4bab94bd56daf30b28a4c6e8f5bfc9ab36b50a601390d
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = 5a6af2e79e4eb7961e15242b
+Tag = 91b9c4187e13c2db1c602a3cb9945554c2a4ae9d6afdcef8892c860166a0b34e
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = 247a139d95d2856590a487168e1311b50c67bc6d0ef8fe
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 4e85df0d7674f28fa58aad338ba015b863d14d922c558c
+Tag = 4c13a9ec7b6e6fc6
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = bff00222a5da19c421bae0aa4938e4aa801ca7b9ceb5fc
+Tag = 619e10deb16fa6f7fd30fc0c5725cee6
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 7c2db844dbcb8ae88a841f9ed5276bdb58318bc57032bf
+Tag = 24364ca519dfbf19fb995284bee83d3ccdf5d30270a9752c
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 64ecb92afe664a3f618712a88c1a96127c7e66a353f8d8
+Tag = c73ab81e6e093c49681d7d865a185bd29612aeaa29f5fc3a5955bbe6a08a1f9e
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = f0918babfee8e768b7c9765eddcd22c3bde08357e5d40ea497a6b8945c06b888008e4820aa54fe
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 32503d047ed44110ad766ce1da8c60613c6566ac40b1e0722eb6979c552ac1008fd57f3049996d
+Tag = d6d21e854a215149
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = 8f2f0f0bfdb3005b2a826d3299276628f9aa05b8ee0248fa37d3f29ed7f6169f6586e91c4ebc57
+Tag = e8b2277e9a7605e328dbc85237064017
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = 1fb434ef6e495e51be104e2bbbf9779a33a3c8c22966e28a8d3af967f73d35ec54362313dc0188
+Tag = edfba21617cb619fa6d1e377032b5a3856b3d8d1cd507cf3
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = cea84677846b5adcaed24f7338e0740d0f0f6a64a0daaef1442b2937ebfae7d8aa85da5ae66bdc
+Tag = fb58b323f679a92acf1dea74953d1a995fc29f40ba502805320716f2bcdab536
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = a8a5c56d066ff6c8
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = af619ee846f2ef63c977d90d74613bec
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 4b785c50f64e1e791ee68b710c275f001684c69deb7ad0cb
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = d68bb53ef943f9e6f850b4baaf75e7e078f2f0185fe6d818d28485a869ded8eb
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = 2fec13b63271181a123b2d021fc1
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = a31deff911912651d1b42dc1e112
+Tag = a60750c4fbb528f1
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = 90d79525db328c6477b638dacadc
+Tag = 2fe3f13b2f95425d302432e673fab224
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = d5e44ec6d8d1c1edb6684217c179
+Tag = 74a81230ea2b0e69e6fcbc6aaae823384766b99f0d199856
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = e39770e55dc28e58ef67c1ed0044
+Tag = 024b45b05c50fa286672e6f348f6df75fa8285e2fd0a091a34b27001eda29f0a
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 3874033367ff60fb0da89402394e91df8873bdd7bf86abbd463806a20dab3762c6197a
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = e78cab60fa1f9cf28cf8bafd3069f37e507f60867caaca21bfe41354f27fec8698b1bf
+Tag = 248e842ea83c4f61
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 54eec166fdec5fa5a116600d43247dcd1bebca19d099f1dc3d6220f748f36fc0e4bcea
+Tag = e2b7475fb980b3882ee12743c9d8a6b7
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = eecd3676eccea8d1e49d518dc5f349a9f5bd723cfbc4a9c4415c3b8fdfe8d69af8768f
+Tag = e4c2942d07aab15be86738ab649c70dd86fd96d6938d730c
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 4628b1a81b9785abb173afafed24f3404ac2dbf02b660249293c008a50ffcd6d858358
+Tag = d0e852cdce00f6bac7e19eccfd3afc0fc9adaf86b06abe45bb6e995027a377af
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 5950f1249710c2c2
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = e86302faff0319630097a57e9a8db6f4
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = 1b66349f98e4301e7f8edb0a53cf70a6e2e5a36e2ef6c98f
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = 1a32ffbc275bc1031f4f10fbefb4ac3bbf294bf1f3526c6f1aa9f8ea64a097e6
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = de75ac0d35c369826b77a33769b6797961c4ed64
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = cec1a3de80959c98c1df56125541ea40c7b03976
+Tag = f06b06dde481b9b5
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = e3744664863b17901ad9228fe512eaef7956a31e
+Tag = d585f2273fbba3edab19b9346ca36de4
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 9b66a3069425dbac540fec93d53abbb3bfbf21b0
+Tag = 0c151055e70607ed7d0df631d3d8fd4e7050c5f39717dff4
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 1af203c7ac98980686b14e209b41cc3714c1f913
+Tag = e7ed47e63dbbe08834f0ddaff15da13879ecb7af35dd7c5028ca8d6ea0754883
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = d7973e15d57f6cb7da358c92a91940e8e4099d5a2a1b05ca8171ddc91e1c70184e1c6f13bd287bee95c556418fe436b78c15
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = e27404e52d0c45b7958da14fe9bea049d84863292973b973e91ee272ae3e77769c73519891c7dd005ad80cc79d9e6a9b5029
+Tag = 8340351a01736e55
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 70cd2966ec5928b6bf70849499d714cffd3888eef9b01d5ecf15b41c6adda40a2739e6e0758f123848c7844798f97a8d7795
+Tag = 9e3848b573e731ed70aaff66a68b2abc
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 36ce0c9d461cf4f758708607483b7c0c7a6f764c78ff1ef9613b87aff6658b0de030afafc89cf5321217e75ec978a01b5877
+Tag = 1ab1c43f896f6a9182f747af4e535840db588cb5d12c08a4
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 62adb3be14937c0f9ce3599bc5269d34b7617daf5ebc8dc583a1fabf870370f2f7a7b5844be19854101efd0a745efcfd61bb
+Tag = c54c8945aacd16d9bd7882dc4b95bc922223aaa57681b95d5de0aa4245d8dc2b
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = a37445c64950c2f7
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = b8577a33b2e5bb74bd754e973a8618d1
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = 6a0464f7d6e48f151465f899a7ec4e9313b362a31d508616
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = a5d246134917b3bcea0472682e0bac060822582306b8fbc22614470884b34fd7
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = 0d21a38610a2ba577e72195da50d594b65ea621baa9c359fab59e8c7
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = d2ff8030e9c82e0194c51f4d38474de23d18324cc5ad92b8da64eb11
+Tag = ed10a1dccd84323d
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = f2a764e1e94bd4761f911f4ee19159a16939372229266fe0756ff0b1
+Tag = 4d70ea72a234eca178c0696520f85194
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 25ef86ebda459eb3ca87566be6410fe85bd740b15f82a9b87e5c71bb
+Tag = 79f8ecc1e575ac90b0d12b29529c800bbabab236aea4ad69
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 0f17ee3eb7cb79d1b3040756129aa836ce025c5ecd36c4ccd2eeface
+Tag = ef55c9a76445affcc7cab82b049739a46b2f3e4a3e7f79821fe9e0285349318c
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = cfb8af284ad241e7
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 2d34ed3bcaa4d41227e4105d4284c6e3
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = 99aed609c0480a48d270ce0facde3beab30ef94b26ecd9a7
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = d18fe0d1b81733a84fb6050b3794a5f1823d0f252a87abef41c8f13785a52e51
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = a0da85f3159452d9edb6e9c7c7014928e50f07c0a2d39e2ef36c299c23de8acd1d2fdd01c62dfe
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = ac5fc178943cd0da7fda2ce6a84e14207678805f049bb2ff5a437f54be0ee1d39cf34db7944d5d
+Tag = 909eba08f3ffbcf7
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = a34197bbd30dba9443ffd5fe763cac63975c26e723ca015b377e6f1bb4d5c0553b258ac5a983b7
+Tag = 564c4842213b49e8c75de31e0129e8d8
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = b4ce36854032a0eeb99a4ede5c46125ba0680aa6e9e1622c9ffb029dd5e4eed2408b735876fb03
+Tag = 4f66284dcbb276f849b7e52b41613e85b1bdf25a087a06a9
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = f7c9da868172daa2de875637b7b8a4b9cc18b43a08c7eaaa0f1ceae67a10e374bb36fbbbf50722
+Tag = 738ac5647f2bfbb72028f92df7e306662fa2ca68b77037dcf00ca8a5d330170f
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = 9b778f94b8819fea
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = b7cdd460b27b4e8ae5a25b7c192a222a
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = 2b379002d457bfdb46d14f2ae2d56edee27ce0cf042c126f
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = a7119d18df6f69ca57d0578b1f9d8493e7470eedc4133b9aaa9df0c17cf2801a
+
+# initialize with key of128 bits, nonce of248 bits:
+Key = 51ea831cb54ee78019b24be47d16af48
+Nonce = d13293f4b41576d797f859ba7adb3c9d5dbe1f8040a102632384e5460667c8
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = afacbad1139fad62
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 007b88e7de80df7f8b2f1cdcb02f4b34
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 9b3008d2a79dafc96bf16cd84ce3204bb3b33ac09c459743
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 83bdf85e90c5a5d1f3a685228f2f98b3410db067f789142ea3d875ec70d4954f
+
+AAD =
+Plaintext = 6f901031b1
+Ciphertext = 0041e5934c
+Tag =
+
+AAD =
+Plaintext = 77981839b9
+Ciphertext = 91dfaae494
+Tag = 0b2165dc0eeea7a1
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 5cddd1b4ec
+Tag = dac375794b093e9fff39e5d3570d51e1
+
+AAD =
+Plaintext = 87a82849c9
+Ciphertext = 3219ec10e0
+Tag = 505607bfbad570283ac7f5af555f0808cccf296087c0fe62
+
+AAD =
+Plaintext = 8fb03051d1
+Ciphertext = 28c5c056b4
+Tag = 33c897c57593307c004273a95149a3f7f34dcb0a0bf7d59992970a20a7d32d47
+
+AAD =
+Plaintext = ddfe7e9f1f40c0e161820223
+Ciphertext = 22f38870c2b11b00790ba9a6
+Tag =
+
+AAD =
+Plaintext = e50686a72748c8e9698a0a2b
+Ciphertext = e44242904f08971e91f58cba
+Tag = 49fdf5dd10a4a6b6
+
+AAD =
+Plaintext = ed0e8eaf2f50d0f171921233
+Ciphertext = 1d6b4655e277567a10d96d77
+Tag = 245a0a28f0cd714874bae1ecfdad1ee2
+
+AAD =
+Plaintext = f51696b73758d8f9799a1a3b
+Ciphertext = 8d1b773f2644c1f254422ffb
+Tag = 86a6e2c59f459a3dedb4de771caacb03b2d1fdb6f8e3d858
+
+AAD =
+Plaintext = fd1e9ebf3f60e00181a22243
+Ciphertext = e80a1995b5637653ecf9e3c0
+Tag = eb4ee3f42e3464758b6156ad75c42259ec0a9b800c553687e70df7dcde139faf
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3ebe
+Ciphertext = b0048784f97dc860fa08c64119450e9642672d6083b597
+Tag =
+
+AAD =
+Plaintext = dbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6
+Ciphertext = 5470971b64be11e717d7a1eecaf4b783152ebf98219630
+Tag = 871adab1f42b943c
+
+AAD =
+Plaintext = e30484a52546c6e767880829a9ca4a6beb0c8cad2d4ece
+Ciphertext = f45f76c296d37f5ea71aeaa3b8c8c31a3fe4876a9d4599
+Tag = 95ee1286afe9abbb325e7e56b6d1c19c
+
+AAD =
+Plaintext = eb0c8cad2d4eceef6f901031b1d25273f31494b53556d6
+Ciphertext = 3debf4460427eead975271d8faddcc51d1729010095e19
+Tag = a0070735c678a94c901e3a6a51c2b511be09fc26ae6ffa00
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5ede
+Ciphertext = 44a59ba3a880c3ac70a6232b663f2734679ebc9fde70f3
+Tag = 2a555f49638347dad979f7059a220d7e7ded5328e327349a5068ac5ea4ae5c67
+
+AAD =
+Plaintext = f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e6
+Ciphertext = c8f52e1a55d3ab524279513b2aa65b7b16ebc6746b249b0c2ad27f9e2f598e0e00fcc700d7311c
+Tag =
+
+AAD =
+Plaintext = fb1c9cbd3d5edeff7fa02041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee
+Ciphertext = 118596bd4a6230939cc458a321963bd559a33ba32d26ff5ae74ba1f4d1c9cb0559d8ffe358275c
+Tag = ce81a9a8924a84cb
+
+AAD =
+Plaintext = 0324a4c54566e60787a82849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f6
+Ciphertext = dc90f7a000ff157dc5c25d13270cd3e29b7e58ecd4b0d66f092a8ff5a2e0317cc9afa776e4891e
+Tag = 35dca607c6bb19bc7418f63a2aa7c26c
+
+AAD =
+Plaintext = 0b2caccd4d6eee0f8fb03051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe
+Ciphertext = aa0eae3d877e63fd5cc52294cd4436dd1ce2804ac2679b48d98a673aa2e6d8913e262a3c76f2c9
+Tag = ce00d9605be78dc54ad552e5ee3dcab9e77d0315a699948c
+
+AAD =
+Plaintext = 1334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344c4e5658606
+Ciphertext = e8a2fc3da09098901d7e28d01c2a9b7743b999a82785d197072a7d4b37493e947052118dc4496f
+Tag = 3328b77045ba4971406df8968bfa525740e3a99044002d39c9a09a3fa6a76283
+
+AAD = 5eef8011a2
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 66f78819aa
+Plaintext =
+Ciphertext =
+Tag = 64f6ea09e3d0c65e
+
+AAD = 6eff9021b2
+Plaintext =
+Ciphertext =
+Tag = 043960e4baa6e0f43c86fa8ce1b22cac
+
+AAD = 76079829ba
+Plaintext =
+Ciphertext =
+Tag = 8d4664383f50713f16d172dc313c6cfcf69ebb3d69f260d3
+
+AAD = 7e0fa031c2
+Plaintext =
+Ciphertext =
+Tag = 67eeb7ef4477b06486021d9a6a36eb97a5c26905c58b20a82f17b1673b09e5d5
+
+AAD = 6cfd8e1fb0
+Plaintext = 2647c7e86889092aaacb4b6cec0d
+Ciphertext = b439bbbe3688867c5df5f324285b
+Tag =
+
+AAD = 74059627b8
+Plaintext = 2e4fcff070911132b2d35374f415
+Ciphertext = 79c9e0615acc0e67bf3d018b53f2
+Tag = 0e3c583e22a877b3
+
+AAD = 7c0d9e2fc0
+Plaintext = 3657d7f87899193abadb5b7cfc1d
+Ciphertext = fafa9efe93587e071bd8c5e3a142
+Tag = f681d00064e393ea91157c5b0e644a68
+
+AAD = 8415a637c8
+Plaintext = 3e5fdf0080a12142c2e363840425
+Ciphertext = d473b3062b0c11063a726f0c441c
+Tag = 0f6c4840ce93e52f5c4a3eb252cfaf4ea5f73a900d41a9aa
+
+AAD = 8c1dae3fd0
+Plaintext = 4667e70888a9294acaeb6b8c0c2d
+Ciphertext = 8ac937960eaf4a97cd69d5ddaa29
+Tag = ba51d63a387159c6eba1911ea793f0b80a3c92f69b0e3856aa782e5bd76439b7
+
+AAD = 8112a334c5
+Plaintext = 70911132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a121
+Ciphertext = 609add8c4a11e46623b8909ded6b05f495b67639ee4a3d8bae04cd89aceefa8bb6912a
+Tag =
+
+AAD = 891aab3ccd
+Plaintext = 7899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a929
+Ciphertext = 148e00e93e60314cc3b36cdf6471389c27375d9ecf02528be54325bcd48ece2215089d
+Tag = ccb0cc73c7c35665
+
+AAD = 9122b344d5
+Plaintext = 80a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b131
+Ciphertext = 5158e79a799fec8abc5a0b256b4b066ed6a11618418d6af594edc4dc9c696c423ec30e
+Tag = 35cb33ec0fdd7a6e013d153f8bd02b67
+
+AAD = 992abb4cdd
+Plaintext = 88a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b939
+Ciphertext = d5505fb0a3f8501f436051304e323b33229bae66af8fd52354fcf63db27963c6632ea6
+Tag = ac66fe4cc4b5e4a004b75224223e39e639cbab68785b368e
+
+AAD = a132c354e5
+Plaintext = 90b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = b2cd919663d3f67374789fa28864cccfff02130d075d30be3884a7095b9040f13d54b2
+Tag = 53440aa907f6423e5fb53db7354658236ec2e0f823d1cdf88e1edb7b91b8ff6d
+
+AAD = 2abb4cdd6eff9021b243d4
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 32c354e576079829ba4bdc
+Plaintext =
+Ciphertext =
+Tag = 1a584a9ba7663647
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = a982c5aca60d81239035f0851fc1ae13
+
+AAD = 42d364f58617a839ca5bec
+Plaintext =
+Ciphertext =
+Tag = b14cfbcb89d93db0faef8181bb65b73f3d7f84af93c0147c
+
+AAD = 4adb6cfd8e1fb041d263f4
+Plaintext =
+Ciphertext =
+Tag = a3a390be4c31846f508414b193ac256bba87d519b8abc5ab611998525449b30c
+
+AAD = 3ecf60f18213a435c657e8
+Plaintext = f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c2
+Ciphertext = 9ea13e5199b10bf717cb954c9afa0bf14266023c
+Tag =
+
+AAD = 46d768f98a1bac3dce5ff0
+Plaintext = 0021a1c24263e30484a52546c6e767880829a9ca
+Ciphertext = b83af5745f399706506396608d8fd2bb901c644c
+Tag = 98fe423098776dcc
+
+AAD = 4edf70019223b445d667f8
+Plaintext = 0829a9ca4a6beb0c8cad2d4eceef6f901031b1d2
+Ciphertext = f9edabaea15756c564bd8f92b52c2b73560f52b4
+Tag = 7b247debf0dc64d4edc7357a8304d50e
+
+AAD = 56e778099a2bbc4dde6f00
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da
+Ciphertext = 19ed47f377ea0f0bfd3c6a911e62867e30fee690
+Tag = 977b1ff8608f3da23e2d9a429e3e2090a6abfa63d63ac593
+
+AAD = 5eef8011a233c455e67708
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e2
+Ciphertext = 22e16192e6a5db087edac2ad40044f1b1583335d
+Tag = a9875c2b7b9fe75fbaa1ec028b52d6019c7afa85f55d5b3af0bea939be31cd65
+
+AAD = 5ced7e0fa031c253e47506
+Plaintext = f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2d
+Ciphertext = cea7fb9dd17f9fa5293fdfa61f3dc9da37cb520797de7f17901291065321884f3e22f12667b4bc334a4d46abea795b56acc1
+Tag =
+
+AAD = 64f58617a839ca5bec7d0e
+Plaintext = fc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435
+Ciphertext = c124dab0d0afa67a1a523492a84c016718b41f64524e145611e3315357f03649b0a05b298bc3d8d6a2266e5457cbb5ddc5b1
+Tag = ef0911e3a0ab4ff4
+
+AAD = 6cfd8e1fb041d263f48516
+Plaintext = 0425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3d
+Ciphertext = 0c7e5019696144600ad913f8fa815b781182e66b3e809bf7ff6bb05d3d128c9bbe8270c8b4f123b760298ae9578dada0d339
+Tag = ea203308dbb255012b7421ae27ae532b
+
+AAD = 74059627b849da6bfc8d1e
+Plaintext = 0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445
+Ciphertext = 5e3b5261fc1f73ccf3d6e8840723cd695c3d4f8078409b39a925d586a9c2d45342037313b7d1382811c1054978d4874e63dc
+Tag = a0bb1a4ca22fbeca66a290a1d16bfb084d27863d0709a407
+
+AAD = 7c0d9e2fc051e273049526
+Plaintext = 1435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b8bac2c4d
+Ciphertext = 283b714fdbd5cff77cf513fd514f8e2b07de66c5bd3ede5525ff578d204cec0c274d1cb2542e85bc8f0e7f0ded2727e68c60
+Tag = 54219904125df2a19c61f9193f759374eba9d1b1cfe362ae0a4e357fcbb9d0c5
+
+AAD = 3acb5ced7e0fa031c253e475069728b9a93acb
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 42d364f58617a839ca5bec7d0e9f30c1b142d3
+Plaintext =
+Ciphertext =
+Tag = 597f7d80e4cd3c6f
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 84d178af9b25136ede7f3f86677d34ba
+
+AAD = 52e374059627b849da6bfc8d1eaf40d1c152e3
+Plaintext =
+Ciphertext =
+Tag = df52c29df0bad3cba0b2f31f783426b9b7579470d39b09d6
+
+AAD = 5aeb7c0d9e2fc051e273049526b748d9c95aeb
+Plaintext =
+Ciphertext =
+Tag = 151872ec8a52da0b77b459cf129c943b1084a867b3a88a406d88f35d3f52f1b3
+
+AAD = 56e778099a2bbc4dde6f009122b344d5c556e7
+Plaintext = 1031b1d25273f31494b53556d6f777981839b9da5a7bfb1c9cbd3d5e
+Ciphertext = b5a89ce6dd9d5dcf279250f3ccd66ef79c77b76bb278d4b89a1662e5
+Tag =
+
+AAD = 5eef8011a233c455e67708992abb4cddcd5eef
+Plaintext = 1839b9da5a7bfb1c9cbd3d5edeff7fa02041c1e262830324a4c54566
+Ciphertext = 6f59157fe3dba15567cc7e09c530a912d35e6e02ee63a92a57bfb2d0
+Tag = 27befd6d2a2cb9c3
+
+AAD = 66f78819aa3bcc5dee7f10a132c354e5d566f7
+Plaintext = 2041c1e262830324a4c54566e60787a82849c9ea6a8b0b2caccd4d6e
+Ciphertext = 1aeb57a4179bb255b7845b45c2ac3d793ee8c70e61e696894aaca09f
+Tag = 8566733a62fd7efa838cbf04ca056d49
+
+AAD = 6eff9021b243d465f68718a93acb5ceddd6eff
+Plaintext = 2849c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 7a39fe89df2d48d651658ba53b032bf12c4cd98c793e3a0e7aad6572
+Tag = 688a5a2bd3c7ce6133f707d2f39f84732a96ad899370ff68
+
+AAD = 76079829ba4bdc6dfe8f20b142d364f5e57607
+Plaintext = 3051d1f272931334b4d55576f61797b83859d9fa7a9b1b3cbcdd5d7e
+Ciphertext = 5c2ed374ac585a33759ec4de4d89abe36b7bd19fd851d9dc9530024f
+Tag = ceb7574846c1d39d969d7c85b174d172c1a6c92ab436da446ff00bd2528340c0
+
+AAD = 30c152e374059627b849da6bfc8d1eaf9f30c152e374059627b849da6bfc
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2fc051e27304
+Plaintext =
+Ciphertext =
+Tag = 5afba10831074812
+
+AAD = 40d162f38415a637c859ea7b0c9d2ebfaf40d162f38415a637c859ea7b0c
+Plaintext =
+Ciphertext =
+Tag = 6e7918d43d7061e8d010f9d894958fe4
+
+AAD = 48d96afb8c1dae3fd061f28314a536c7b748d96afb8c1dae3fd061f28314
+Plaintext =
+Ciphertext =
+Tag = a0473049d6ea11562a57ea1baca99128ad620245b1438706
+
+AAD = 50e172039425b647d869fa8b1cad3ecfbf50e172039425b647d869fa8b1c
+Plaintext =
+Ciphertext =
+Tag = 978c61fbf40a37edd80a54c4582a694de3a27e09bb2e21c432eb70125be48df6
+
+AAD = 57e8790a9b2cbd4edf70019223b445d6c657e8790a9b2cbd4edf70019223
+Plaintext = 1132b2d35374f41595b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e3638404
+Ciphertext = c92a81ce261e6a33efd10300a769854f4099816cca9443204c6905f391635649ec9ec121adcb11
+Tag =
+
+AAD = 5ff08112a334c556e778099a2bbc4ddece5ff08112a334c556e778099a2b
+Plaintext = 193abadb5b7cfc1d9dbe3e5fdf0080a12142c2e363840425a5c64667e70888a9294acaeb6b8c0c
+Ciphertext = cd299daf63ceddcd5f0e97ff972d4a6587e3b66cae8fec50d4ae0af6d2a12660d69005bce1b3c8
+Tag = 51be8a33246a9973
+
+AAD = 67f8891aab3ccd5eef8011a233c455e6d667f8891aab3ccd5eef8011a233
+Plaintext = 2142c2e363840425a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f3739414
+Ciphertext = 5dc318e4c859f73c8bc2f0fa3fe51af08676107cbdd4b93f7b9d348a29cd1593236a9afb9a9ef9
+Tag = 378221cb3dd4d6f001941f5b2568a0e3
+
+AAD = 6f009122b344d566f78819aa3bcc5deede6f009122b344d566f78819aa3b
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9395adafb7b9c1c
+Ciphertext = f00a6b2c18839f65000c60d504f8b70d6d6b732b7916c69ad2d6cce801b2c9034872ba0307d44b
+Tag = 96b14922a4a48f02e47eeeb8abe7429148b92467e6089071
+
+AAD = 7708992abb4cdd6eff9021b243d465f6e67708992abb4cdd6eff9021b243
+Plaintext = 3152d2f373941435b5d65677f71898b9395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a424
+Ciphertext = 61f5e11c57af8d68c36b35919cd85f1668ad9d8a8b51c56ac34b2ac5bdcfc73d16b51b0e593321
+Tag = 682fe0ad9762feeb70cff0305a93ba1ac869c8e72b3023dea015832c7d78fc42
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd061f28314a536c758
+Plaintext =
+Ciphertext =
+Tag =
+
+AAD = b647d869fa8b1cad3ecf60f18213a43525b647d869fa8b1cad3ecf60f18213a49425b647d869fa8b1cad3ecf60
+Plaintext =
+Ciphertext =
+Tag = ab0c282b934b9e99
+
+AAD = be4fe071029324b546d768f98a1bac3d2dbe4fe071029324b546d768f98a1bac9c2dbe4fe071029324b546d768
+Plaintext =
+Ciphertext =
+Tag = e0eada988c08d36f47b8d431ca7eeb38
+
+AAD = c657e8790a9b2cbd4edf70019223b44535c657e8790a9b2cbd4edf70019223b4a435c657e8790a9b2cbd4edf70
+Plaintext =
+Ciphertext =
+Tag = d6b60946140a47bd1ef631d1cd1ea31e8d9380c3a3a3095d
+
+AAD = ce5ff08112a334c556e778099a2bbc4d3dce5ff08112a334c556e778099a2bbcac3dce5ff08112a334c556e778
+Plaintext =
+Ciphertext =
+Tag = 5e0025cc39174801324f0bffb9b9ceba4ecb8c45e6b747121bf191a1dd7c462b
+
+# initialize with key of112 bits, nonce of264 bits:
+Key = 0fa841da730ca53ed77009a23bd4
+Nonce = 1374d536f657b819d93a9bfcbc1d7edf9f0061c282e344a565c6278848a90a6b2b
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 80bb0db0a2eae70eca069e66f05c264a
+
+AAD =
+Plaintext = 3b5cdc
+Ciphertext = 44e1ca
+Tag = b648f1ee367a792f9e219c4e3dbea297
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = 791a79719aaf37
+Tag = 5c66d03ddff1fc8415d7ff2405072974
+
+AAD =
+Plaintext = 8fb03051d1f272931334b4d555
+Ciphertext = 0b4ba004eb1c30fc9c770ed7d8
+Tag = 4349cf1b1d75a458be00001b22819bbd
+
+AAD =
+Plaintext = 4162e20383a42445c5e666870728a8c9496aea0b8bac
+Ciphertext = 82310c9a888a4ee60aff5ba7f2ae20d52028bb80089f
+Tag = 15d46f7b2d090ff35693fb84c9567011
+
+AAD =
+Plaintext = 1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8cad2d4eceef
+Ciphertext = e594e8b1d42aafd30b3c8c528a1b3da3abdccc8b55eecaec3d66a640d901595c6a4b8373
+Tag = a0953d2f8d2fa9d55f61611f05ddf72b
+
+AAD = cc5dee7f
+Plaintext =
+Ciphertext =
+Tag = d2f848da5f16f3dacf1cf93000864fde
+
+AAD = d96afb8c
+Plaintext = 93b43455d5f676971738b8d959
+Ciphertext = a23ab55931b65443eacf970754
+Tag = d19953e02f45cab60f1422ec41cc3b48
+
+AAD = ec7d0e9f
+Plaintext = 99ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829
+Ciphertext = 1ca3868deb53de67a47564e14136f335582f8267b1874b2811ef5255b9ce64fa
+Tag = 4da633c2248e22e446e7cbc26ab0fbfb
+
+AAD = f68718a93acb5ced7e
+Plaintext =
+Ciphertext =
+Tag = 172b0e174c4cb1a20e225a1923df4240
+
+AAD = 08992abb4cdd6eff90
+Plaintext = c2e363840425a5c64667e70888a9294acaeb
+Ciphertext = daa10539460955d5c9cea40e9b46ec93e66b
+Tag = 7f43ed971830bc8e1705d94828dfc84e
+
+AAD = 23b445d667f8891aab
+Plaintext = d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d0d2eae
+Ciphertext = 4da8adf2bc57fb953fa600c15d0532fa6a616626a080456f8af3d1fa054c6ef77dbaa6bb04d4ac7fb52368a45f
+Tag = 8118f00406d7624eee0078086f27af17
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 2a7e8254ef0a268e5aa899407044c942
+
+AAD = 7d0e9f30c152e374059627b849da6bfc
+Plaintext = 3758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3
+Ciphertext = 7daa418cae97d98ac9e43736bdf4e61bf2df8a242b758cf13a
+Tag = 80647c306fa5e2d60604655d8b7b0947
+
+AAD = 16a738c95aeb7c0d9e2fc051e27304958516a738c95aeb7c0d
+Plaintext =
+Ciphertext =
+Tag = 7978a639bc01a1a997ba6c8d1d415383
+
+AAD = 38c95aeb7c0d9e2fc051e273049526b7a738c95aeb7c0d9e2f
+Plaintext = f21393b43455d5f676971738b8d9597afa1b9bbc3c5dddfe7e9f1f40c0e161820223
+Ciphertext = 74e0f71c2492316bbcd47c8b43ac59ba6d8e28439c5ff449483aa5dfb5e3e5659552
+Tag = 7d8af55507843d3ad81907c7ec122521
+
+AAD = ae3fd061f28314a536c758e97a0b9c2d1dae3fd061f28314a536c758e97a0b9c8c1dae3fd0
+Plaintext =
+Ciphertext =
+Tag = b1780ea60b64dadf8de2788f31127f6b
+
+AAD = dc6dfe8f20b142d364f58617a839ca5b4bdc6dfe8f20b142d364f58617a839caba4bdc6dfe
+Plaintext = 96b73758d8f9799a1a3bbbdc5c7dfd1e9ebf3f60e00181a22243c3e464850526a6c74768e80989aa2a4bcbec6c8d
+Ciphertext = fdebf0a6d8805c1aefb919a146944581b1cf271664704abcad8e593dea548bf628c44e526ded0966d783a558b1dc
+Tag = f9a76717c54b081c1f4625e4c9c72f56
+
+# initialize with key of104 bits, nonce of272 bits:
+Key = 6e07a039d26b049d36cf68019a
+Nonce = b41576d797f859ba7adb3c9d5dbe1f8040a102632384e5460667c829e94aab0ccc2d
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 65263ed4a4c6824b94317c7219e368b5
+
+AAD =
+Plaintext = 99ba
+Ciphertext = 2981
+Tag = a9b216f34a3c060c334e6ce665343fb7
+
+AAD =
+Plaintext = 7fa02041c1
+Ciphertext = 7d979554b0
+Tag = 95935102000241524addcc9b13809b18
+
+AAD =
+Plaintext = 0728a8c9496aea0b8b
+Ciphertext = 08cd3ec9bd85c12746
+Tag = e2396459fb3d8ff79a5c85ae8240df1b
+
+AAD =
+Plaintext = d3f474951536b6d75778f81999ba3a
+Ciphertext = 60cfdc34cdbec54598f6cf45c08706
+Tag = c859d97154e5c7c4a1ce6578debf966d
+
+AAD =
+Plaintext = 85a62647c7e86889092aaacb4b6cec0d8dae2e4fcff07091
+Ciphertext = 71081aa098a865b575245d5fcd91bc7de0dc0ee140a3cc36
+Tag = 6326c89e46d475729ba3a2a9efb43322
+
+AAD =
+Plaintext = 61820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d4
+Ciphertext = da25dad1d3d10da36da89b92f4880954d1a8aeec49f13ee6fc2771937c37be96034020768a19
+Tag = 2dc0b29c7382bbcf43e01e09455a9819
+
+AAD = 2abb4c
+Plaintext =
+Ciphertext =
+Tag = 0e5bccf97d218e747b0bfdba200984fc
+
+AAD = 35c657
+Plaintext = 4e6fef1090b13152d2f373
+Ciphertext = b6078adb120297d5f10dc6
+Tag = 7b02a68e3af4f593e9ce02790a06f109
+
+AAD = 45d667
+Plaintext = 6e8f0f30b0d15172f21393b43455d5f676971738b8d9597afa1b9b
+Ciphertext = a693d6b34525bf709463b4c03cfbfdd6bf37049f59b27e216eba2f
+Tag = c50e0df658470bdd5a93b69f5eb1faf7
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = e732c9dcb56275bcb2e33c55f0331f2d
+
+AAD = c152e374059627
+Plaintext = dafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 6ffa40a56aa8c2f3f7545fb0442751
+Tag = d54a5b072397d900c11fb3f4d5f20036
+
+AAD = d768f98a1bac3d
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
+Ciphertext = a7bea38b54053a03e791668f677d7855d3c5c8afb364efe8e55bf6fbadaae03c102fb24262
+Tag = 93ab187d3d587c932fce016b52139464
+
+AAD = dc6dfe8f20b142d364f58617
+Plaintext =
+Ciphertext =
+Tag = 4c80d87580b31566672a9733412c8f85
+
+AAD = f08112a334c556e778099a2b
+Plaintext = 092aaacb4b6cec0d8dae2e4fcff070911132b2d3
+Ciphertext = 15bebc4da7568daaa2d11fa04ece29930a21e1dc
+Tag = 962aee3bc268a18a2a0dc7c3286e0c44
+
+AAD = 0e9f30c152e374059627b849
+Plaintext = 0526a6c74768e80989aa2a4bcbec6c8d0d2eaecf4f70f01191b23253d3f474951536b6d75778f81999ba3a5bdbfc7c9d1d3e
+Ciphertext = 1a751b5d063fb912fa176d75a5056198068713f52a611b668ded10e3a573410779c36af17675ffc75a74d6e31d10b9b9c5fb
+Tag = 56e1af2c18b8cd6b11e8ae665deef7b1
+
+AAD = 4adb6cfd8e1fb041d263f48516a738c9b94adb
+Plaintext =
+Ciphertext =
+Tag = 45bab40e6dfc5403840a5e0e5e4d8e4f
+
+AAD = 65f68718a93acb5ced7e0fa031c253e4d465f6
+Plaintext = 7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2bab
+Ciphertext = e99dac8d968eb9d356a0a472e2968b6b09b5d3a8ede286f1ea76b6
+Tag = 64b7cf64e36a0bba04afc3abb930accd
+
+AAD = fc8d1eaf40d162f38415a637c859ea7b6bfc8d1eaf40d162f38415a6
+Plaintext =
+Ciphertext =
+Tag = e550fd79795b4a75b7858b35802a2d1b
+
+AAD = 20b142d364f58617a839ca5bec7d0e9f8f20b142d364f58617a839ca
+Plaintext = 395adafb7b9c1c3dbdde5e7fff20a0c14162e20383a42445c5e666870728a8c9496aea0b
+Ciphertext = 68a8999c9eac30dafa96c15a32cca4e65692592e36568f0f0891aaa661987ee227d39e41
+Tag = daa26d67727246e095193ae4a224be5e
+
+AAD = 9425b647d869fa8b1cad3ecf60f18213039425b647d869fa8b1cad3ecf60f18272039425b647d869
+Plaintext =
+Ciphertext =
+Tag = 0ab87b33ddac31d1be0eab51efe906fd
+
+AAD = c455e67708992abb4cdd6eff9021b24333c455e67708992abb4cdd6eff9021b2a233c455e6770899
+Plaintext = ddfe7e9f1f40c0e161820223a3c44465e50686a72748c8e9698a0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475
+Ciphertext = ab62b80f5387fca0d2b24ab82250a6156910dae8fc66e5219aaf21889f92cc5df15682083b1cc0b18393dc3d89ae3dba
+Tag = 7cea555b2de0dae2456ec1b9fdb255d8
+
+# initialize with key of96 bits, nonce of280 bits:
+Key = cd66ff9831ca63fc952ec760
+Nonce = 55b617783899fa5b1b7cdd3efe5fc021e142a304c42586e7a70869ca8aeb4cad6dce2f
+
+AAD =
+Plaintext =
+Ciphertext =
+Tag = 327b0806f61b8765b507aae0c476a3d1
+
+AAD =
+Plaintext = f7
+Ciphertext = 4f
+Tag = 9d0b4664a554ed4075b07a6d629fbee7
+
+AAD =
+Plaintext = 99ba
+Ciphertext = 6d1b
+Tag = 91775b4f99717abafe35b9cef77defa1
+
+AAD =
+Plaintext = ddfe7e9f
+Ciphertext = a8401044
+Tag = 50664ab134dac07c6344dab6e1bd63f0
+
+AAD =
+Plaintext = c3e464850526a6
+Ciphertext = 3d293cb7f04ac2
+Tag = aef9896c28f091372170c1ee7b2f5fa5
+
+AAD =
+Plaintext = 4b6cec0d8dae2e4fcff070
+Ciphertext = 25075354d42eeac4d75e97
+Tag = 468ded8e424708483367e22c4e0713c4
+
+AAD =
+Plaintext = 1738b8d9597afa1b9bbc3c5dddfe7e9f1f
+Ciphertext = e974e5d263711ac9253ac4f2fed2d4c2a5
+Tag = fc6656cb539bcb9a14a1280fbc0fddd9
+
+AAD =
+Plaintext = c9ea6a8b0b2caccd4d6eee0f8fb03051d1f272931334b4d55576
+Ciphertext = 45bcb5c8e54da3e9e6f335082048a4ec9f2f4dd2ad20309ebbb5
+Tag = b22f0363301bde245207ac903bbb1da4
+
+AAD =
+Plaintext = a5c64667e70888a9294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5d65677f71898b9
+Ciphertext = 9d3ca2ffead458be4e3819089b849665d804e4d1109efd5bdf75de6b5753ff5f29b09b25699f8d6a
+Tag = dd0b8643aac1ac1ca8c204f8d78d4e0c
+
+AAD = 8819
+Plaintext =
+Ciphertext =
+Tag = 264b562a3fb403f9446de24831d8b131
+
+AAD = 9223
+Plaintext = abcc4c6ded0e8eaf2f50
+Ciphertext = d6489b339cdfdd20bea7
+Tag = 21365177fcc931185654631c4b5e756c
+
+AAD = a132
+Plaintext = 294acaeb6b8c0c2dadce4e6fef1090b13152d2f373941435b5
+Ciphertext = 78f50b904c30f69643111cb9fa51261f945ee676208b3a0703
+Tag = f102a9a4e57697f3d5764f784c2f60ba
+
+AAD = b748
+Plaintext = 1536b6d75778f81999ba3a5bdbfc7c9d1d3ebedf5f800021a1c24263e30484a52546c6e767880829a9ca4a6beb0c8c
+Ciphertext = 50798cae1d68e23711de4c6b5b77dcb7f1c999972d1bf2427c35e6b00dac7313c012d2ed2845af0ee60fb9afcaf21d
+Tag = 06b984d3a37cc2302e5e1dd82f2ad019
+
+AAD = cc5dee7f
+Plaintext =
+Ciphertext =
+Tag = 33864c0cdaa0013cf91a500ad6294c0b
+
+AAD = d869fa8b
+Plaintext = f11292b33354d4f575961637
+Ciphertext = 5c83059b20e1d86d62122c65
+Tag = de799d27c3240edba3ad5530dc252704
+
+AAD = ea7b0c9d
+Plaintext = 5576f61797b83859d9fa7a9b1b3cbcdd5d7efe1f9fc04061e10282a32344
+Ciphertext = 9a7872e3d3db91620d5deacb5db24b4a98d3680452cbdb4aa2ec303147a2
+Tag = c27a786f2198758277f58a5414857b0d
+
+AAD = b243d465f68718
+Plaintext =
+Ciphertext =
+Tag = 28bfeb47833b3b1ebe724d5bfdd73531
+
+AAD = c152e374059627
+Plaintext = dafb7b9c1c3dbdde5e7fff20a0c141
+Ciphertext = 6870ef5b42ef63af6fad4e5b79b148
+Tag = 706ce1f7091d6ec34553dbda6b265e77
+
+AAD = d768f98a1bac3d
+Plaintext = c6e767880829a9ca4a6beb0c8cad2d4eceef6f901031b1d25273f31494b53556d6f7779818
+Ciphertext = 98f080bf19191ffe48dd16b8b6c514f7bab29a51276d5afa7841fb1f3e6b301d32651e02bf
+Tag = bf0b25f733c1eab28429fa4b96cf3486
+
+AAD = 3acb5ced7e0fa031c253e4
+Plaintext =
+Ciphertext =
+Tag = 2175745303c30376e20879aca0d4887e
+
+AAD = 4dde6f009122b344d566f7
+Plaintext = 66870728a8c9496aea0b8bac2c4dcdee6e8f0f
+Ciphertext = fc113a66083e4072eef2b6349cd116d486d9c5
+Tag = 3deb041a4af19896b905574f7f9e84f5
+
+AAD = 69fa8b1cad3ecf60f18213
+Plaintext = 1e3fbfe060810122a2c34364e40585a62647c7e86889092aaacb4b6cec0d8dae2e4fcff070911132b2d35374f41595
+Ciphertext = b9bc2debb6d02e683d9a997e972c70b278c221fed191590d975ce9275c3b3f4ea2eabb32013df11e41282ab6f12d16
+Tag = c7fa6c120f712b85358f9e95d4b897e3
+
+AAD = 64f58617a839ca5bec7d0e9f30c152e3
+Plaintext =
+Ciphertext =
+Tag = 92c3b43a013ca0bbf979f7a7ef939c7a
+
+AAD = 7c0d9e2fc051e273049526b748d96afb
+Plaintext = 95b63657d7f87899193abadb5b7cfc1d9dbe3e5fdf0080a1
+Ciphertext = 6c6be1166a56c94eb99b1e2c660702149489e9243939ab41
+Tag = 961f9968e7859df1a46b18d423b20c9b
+
+AAD = d263f48516a738c95aeb7c0d9e2fc05141d263f48516a7
+Plaintext =
+Ciphertext =
+Tag = d7b4bb14705b8f1b4bcfcdf06b4a8b52
+
+AAD = f18213a435c657e8790a9b2cbd4edf7060f18213a435c6
+Plaintext = 0a2babcc4c6ded0e8eaf2f50d0f171921233b3d45475f51696b73758d8f979
+Ciphertext = 956f5a48d298d7f6e598e49d67f6ddfa3863d488a7d8410848c6bebd107878
+Tag = c843567e1851f94ead0336f6307ae180
+
+AAD = 8415a637c859ea7b0c9d2ebf50e17203f38415a637c859ea7b0c9d2ebf50e172
+Plaintext =
+Ciphertext =
+Tag = 9faeebd9470d48f1cafba243e56cde4c
+
+AAD = ac3dce5ff08112a334c556e778099a2b1bac3dce5ff08112a334c556e778099a
+Plaintext = c5e666870728a8c9496aea0b8bac2c4dcdee6e8f0f30b0d15172f21393b43455d5f676971738b8d9
+Ciphertext = a57a8bf6926b1a76b24c8a3e6c73b2305c7fe827d861c79cf583055e2de5eedfca8c855f7094c3f8
+Tag = 8f5f265baa8287ea6f8d52fd606cf773
+
+AAD = 1cad3ecf60f18213a435c657e8790a9b8b1cad3ecf60f18213a435c657e8790afa8b1cad3ecf60f18213a435
+Plaintext =
+Ciphertext =
+Tag = feb36c89b371c4ee1ada852848fd5167

--- a/tests/unit_tests/keccakf_lane_tests.adb
+++ b/tests/unit_tests/keccakf_lane_tests.adb
@@ -1,0 +1,71 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2019, Daniel King
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--     * Redistributions of source code must retain the above copyright
+--       notice, this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * The name of the copyright holder may not be used to endorse or promote
+--       Products derived from this software without specific prior written
+--       permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+-- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+-- THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+with AUnit.Assertions; use AUnit.Assertions;
+with Keccak.Types;     use Keccak.Types;
+
+package body KeccakF_Lane_Tests is
+
+   --  Test that XORing bytes into a (zeroed) state, then extracting them
+   --  yields the original data.
+   --
+   --  This ensures that XOR_Bits_Into_State and Extract_Bits both use the
+   --  same mapping to the internal state.
+   procedure Test_XOR_Extract(T : in out Test) is
+      State_Size_Bytes : constant Positive := State_Size_Bits / 8;
+
+      S : State;
+
+      Data_In  : Byte_Array (1 .. State_Size_Bytes);
+      Data_Out : Byte_Array (1 .. State_Size_Bytes);
+
+   begin
+      for I in Data_In'Range loop
+         Data_In (I) := Keccak.Types.Byte (I mod 256);
+      end loop;
+
+      for N in 1 .. State_Size_Bytes loop
+
+         Init_State (S);
+
+         XOR_Bits_Into_State (A       => S,
+                              Data    => Data_In,
+                              Bit_Len => N * 8);
+
+         Data_Out := (others => 16#AA#);
+
+         Extract_Bits (A       => S,
+                       Data    => Data_Out (1 .. N),
+                       Bit_Len => N * 8);
+
+         Assert (Data_In (1 .. N) = Data_Out (1 .. N),
+                 "Failed for N = " & Integer'Image (N));
+
+      end loop;
+   end Test_XOR_Extract;
+
+end KeccakF_Lane_Tests;

--- a/tests/unit_tests/keccakf_lane_tests.ads
+++ b/tests/unit_tests/keccakf_lane_tests.ads
@@ -1,0 +1,51 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2019, Daniel King
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--     * Redistributions of source code must retain the above copyright
+--       notice, this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * The name of the copyright holder may not be used to endorse or promote
+--       Products derived from this software without specific prior written
+--       permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+-- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+-- THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+with AUnit.Test_Fixtures;
+with Keccak.Generic_KeccakF.Byte_Lanes;
+with Keccak.Types;
+
+generic
+   State_Size_Bits : Positive;
+   type State is private;
+
+   with procedure Init_State (A : out State);
+
+   with procedure XOR_Bits_Into_State(A       : in out State;
+                                      Data    : in     Keccak.Types.Byte_Array;
+                                      Bit_Len : in     Natural);
+   with procedure Extract_Bits(A       : in     State;
+                               Data    :    out Keccak.Types.Byte_Array;
+                               Bit_Len : in     Natural);
+package KeccakF_Lane_Tests
+is
+
+   type Test is new AUnit.Test_Fixtures.Test_Fixture with null record;
+
+   procedure Test_XOR_Extract(T : in out Test);
+
+end KeccakF_Lane_Tests;

--- a/tests/unit_tests/keccakf_suite.adb
+++ b/tests/unit_tests/keccakf_suite.adb
@@ -26,6 +26,7 @@
 -------------------------------------------------------------------------------
 
 with KeccakF_Tests;
+with KeccakF_Lane_Tests;
 with Keccak.Keccak_1600;
 with Keccak.Keccak_800;
 with Keccak.Keccak_400;
@@ -33,6 +34,7 @@ with Keccak.Keccak_200;
 with Keccak.Keccak_100;
 with Keccak.Keccak_50;
 with Keccak.Keccak_25;
+with Keccak.Generic_KeccakF.Byte_Lanes.Twisted;
 with AUnit.Test_Caller;
 
 package body KeccakF_Suite
@@ -42,43 +44,43 @@ is
        Keccak.Keccak_1600.KeccakF_1600_Lanes.XOR_Bits_Into_State,
        Keccak.Keccak_1600.KeccakF_1600_Lanes.Extract_Bytes,
        Keccak.Keccak_1600.KeccakF_1600_Lanes.Extract_Bits);
-       
+
    package KeccakF_800_Tests is new KeccakF_Tests
       (Keccak.Keccak_800.KeccakF_800,
        Keccak.Keccak_800.KeccakF_800_Lanes.XOR_Bits_Into_State,
        Keccak.Keccak_800.KeccakF_800_Lanes.Extract_Bytes,
        Keccak.Keccak_800.KeccakF_800_Lanes.Extract_Bits);
-       
+
    package KeccakF_400_Tests is new KeccakF_Tests
       (Keccak.Keccak_400.KeccakF_400,
        Keccak.Keccak_400.KeccakF_400_Lanes.XOR_Bits_Into_State,
        Keccak.Keccak_400.KeccakF_400_Lanes.Extract_Bytes,
        Keccak.Keccak_400.KeccakF_400_Lanes.Extract_Bits);
-       
+
    package KeccakF_200_Tests is new KeccakF_Tests
       (Keccak.Keccak_200.KeccakF_200,
        Keccak.Keccak_200.KeccakF_200_Lanes.XOR_Bits_Into_State,
        Keccak.Keccak_200.KeccakF_200_Lanes.Extract_Bytes,
        Keccak.Keccak_200.KeccakF_200_Lanes.Extract_Bits);
-       
+
    package KeccakF_100_Tests is new KeccakF_Tests
       (Keccak.Keccak_100.KeccakF_100,
        Keccak.Keccak_100.KeccakF_100_Lanes.XOR_Bits_Into_State,
        Keccak.Keccak_100.KeccakF_100_Lanes.Extract_Bytes,
        Keccak.Keccak_100.KeccakF_100_Lanes.Extract_Bits);
-       
+
    package KeccakF_50_Tests is new KeccakF_Tests
       (Keccak.Keccak_50.KeccakF_50,
        Keccak.Keccak_50.KeccakF_50_Lanes.XOR_Bits_Into_State,
        Keccak.Keccak_50.KeccakF_50_Lanes.Extract_Bytes,
        Keccak.Keccak_50.KeccakF_50_Lanes.Extract_Bits);
-       
+
    package KeccakF_25_Tests is new KeccakF_Tests
       (Keccak.Keccak_25.KeccakF_25,
        Keccak.Keccak_25.KeccakF_25_Lanes.XOR_Bits_Into_State,
        Keccak.Keccak_25.KeccakF_25_Lanes.Extract_Bytes,
        Keccak.Keccak_25.KeccakF_25_Lanes.Extract_Bits);
-          
+
    package Caller_1600 is new AUnit.Test_Caller (KeccakF_1600_Tests.Test);
    package Caller_800  is new AUnit.Test_Caller (KeccakF_800_Tests.Test);
    package Caller_400  is new AUnit.Test_Caller (KeccakF_400_Tests.Test);
@@ -87,116 +89,203 @@ is
    package Caller_50   is new AUnit.Test_Caller (KeccakF_50_Tests.Test);
    package Caller_25   is new AUnit.Test_Caller (KeccakF_25_Tests.Test);
 
+   package KeccakF_1600_Lane_Tests is new KeccakF_Lane_Tests
+     (State_Size_Bits     => 1600,
+      State               => Keccak.Keccak_1600.State,
+      Init_State          => Keccak.Keccak_1600.KeccakF_1600.Init,
+      XOR_Bits_Into_State => Keccak.Keccak_1600.KeccakF_1600_Lanes.XOR_Bits_Into_State,
+      Extract_Bits        => Keccak.Keccak_1600.KeccakF_1600_Lanes.Extract_Bits);
+
+   package KeccakF_800_Lane_Tests is new KeccakF_Lane_Tests
+     (State_Size_Bits     => 1600,
+      State               => Keccak.Keccak_1600.State,
+      Init_State          => Keccak.Keccak_1600.KeccakF_1600.Init,
+      XOR_Bits_Into_State => Keccak.Keccak_1600.KeccakF_1600_Lanes.XOR_Bits_Into_State,
+      Extract_Bits        => Keccak.Keccak_1600.KeccakF_1600_Lanes.Extract_Bits);
+
+   package KeccakF_400_Lane_Tests is new KeccakF_Lane_Tests
+     (State_Size_Bits     => 1600,
+      State               => Keccak.Keccak_1600.State,
+      Init_State          => Keccak.Keccak_1600.KeccakF_1600.Init,
+      XOR_Bits_Into_State => Keccak.Keccak_1600.KeccakF_1600_Lanes.XOR_Bits_Into_State,
+      Extract_Bits        => Keccak.Keccak_1600.KeccakF_1600_Lanes.Extract_Bits);
+
+   package KeccakF_200_Lane_Tests is new KeccakF_Lane_Tests
+     (State_Size_Bits     => 1600,
+      State               => Keccak.Keccak_1600.State,
+      Init_State          => Keccak.Keccak_1600.KeccakF_1600.Init,
+      XOR_Bits_Into_State => Keccak.Keccak_1600.KeccakF_1600_Lanes.XOR_Bits_Into_State,
+      Extract_Bits        => Keccak.Keccak_1600.KeccakF_1600_Lanes.Extract_Bits);
+
+   package Caller_1600_Lanes is new AUnit.Test_Caller (KeccakF_1600_Lane_Tests.Test);
+   package Caller_800_Lanes is new AUnit.Test_Caller (KeccakF_800_Lane_Tests.Test);
+   package Caller_400_Lanes is new AUnit.Test_Caller (KeccakF_400_Lane_Tests.Test);
+   package Caller_200_Lanes is new AUnit.Test_Caller (KeccakF_200_Lane_Tests.Test);
+
+   package KeccakF_1600_Twisted_Lanes is new Keccak.Keccak_1600.KeccakF_1600_Lanes.Twisted;
+   package KeccakF_1600_Twisted_Lane_Tests is new KeccakF_Lane_Tests
+     (State_Size_Bits     => 1600,
+      State               => Keccak.Keccak_1600.State,
+      Init_State          => Keccak.Keccak_1600.KeccakF_1600.Init,
+      XOR_Bits_Into_State => KeccakF_1600_Twisted_Lanes.XOR_Bits_Into_State_Twisted,
+      Extract_Bits        => KeccakF_1600_Twisted_Lanes.Extract_Bits_Twisted);
+
+   package KeccakF_800_Twisted_Lanes is new Keccak.Keccak_800.KeccakF_800_Lanes.Twisted;
+   package KeccakF_800_Twisted_Lane_Tests is new KeccakF_Lane_Tests
+     (State_Size_Bits     => 800,
+      State               => Keccak.Keccak_800.State,
+      Init_State          => Keccak.Keccak_800.KeccakF_800.Init,
+      XOR_Bits_Into_State => KeccakF_800_Twisted_Lanes.XOR_Bits_Into_State_Twisted,
+      Extract_Bits        => KeccakF_800_Twisted_Lanes.Extract_Bits_Twisted);
+
+   package KeccakF_400_Twisted_Lanes is new Keccak.Keccak_400.KeccakF_400_Lanes.Twisted;
+   package KeccakF_400_Twisted_Lane_Tests is new KeccakF_Lane_Tests
+     (State_Size_Bits     => 400,
+      State               => Keccak.Keccak_400.State,
+      Init_State          => Keccak.Keccak_400.KeccakF_400.Init,
+      XOR_Bits_Into_State => KeccakF_400_Twisted_Lanes.XOR_Bits_Into_State_Twisted,
+      Extract_Bits        => KeccakF_400_Twisted_Lanes.Extract_Bits_Twisted);
+
+   package KeccakF_200_Twisted_Lanes is new Keccak.Keccak_200.KeccakF_200_Lanes.Twisted;
+   package KeccakF_200_Twisted_Lane_Tests is new KeccakF_Lane_Tests
+     (State_Size_Bits     => 200,
+      State               => Keccak.Keccak_200.State,
+      Init_State          => Keccak.Keccak_200.KeccakF_200.Init,
+      XOR_Bits_Into_State => KeccakF_200_Twisted_Lanes.XOR_Bits_Into_State_Twisted,
+      Extract_Bits        => KeccakF_200_Twisted_Lanes.Extract_Bits_Twisted);
+   package Caller_1600_Twisted_Lanes is new AUnit.Test_Caller (KeccakF_1600_Twisted_Lane_Tests.Test);
+   package Caller_800_Twisted_Lanes is new AUnit.Test_Caller (KeccakF_800_Twisted_Lane_Tests.Test);
+   package Caller_400_Twisted_Lanes is new AUnit.Test_Caller (KeccakF_400_Twisted_Lane_Tests.Test);
+   package Caller_200_Twisted_Lanes is new AUnit.Test_Caller (KeccakF_200_Twisted_Lane_Tests.Test);
+
    function Suite return Access_Test_Suite
    is
-   
+
       Ret : constant Access_Test_Suite := new Test_Suite;
    begin
-      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Test initial Keccak state is zero", 
+      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Test initial Keccak state is zero",
                                       KeccakF_1600_Tests.Test_Initial_State'Access));
       Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Test Extract_Bytes",
                                       KeccakF_1600_Tests.Test_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Test XOR 0 bits into the Keccak state", 
+      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Test XOR 0 bits into the Keccak state",
                                       KeccakF_1600_Tests.Test_XOR_No_Data'Access));
-      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Test XOR all bits into the Keccak state", 
+      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Test XOR all bits into the Keccak state",
                                       KeccakF_1600_Tests.Test_XOR_Entire_State'Access));
-      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Test XOR is correct all possible bit-lengths", 
+      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Test XOR is correct all possible bit-lengths",
                                       KeccakF_1600_Tests.Test_XOR_Bit_Length'Access));
-      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Test Extract_Bits and Extract_Bytes equivalence", 
+      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Test Extract_Bits and Extract_Bytes equivalence",
                                       KeccakF_1600_Tests.Test_Extract_Bits_Same_As_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Compare Optimized and Reference permutations", 
+      Ret.Add_Test(Caller_1600.Create("Keccak-f[1600]: Compare Optimized and Reference permutations",
                                       KeccakF_1600_Tests.Test_Permute_Implementations'Access));
-                                 
-      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Test initial Keccak state is zero", 
+
+      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Test initial Keccak state is zero",
                                       KeccakF_800_Tests.Test_Initial_State'Access));
       Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Test Extract_Bytes",
                                       KeccakF_800_Tests.Test_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Test XOR 0 bits into the Keccak state", 
+      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Test XOR 0 bits into the Keccak state",
                                       KeccakF_800_Tests.Test_XOR_No_Data'Access));
-      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Test XOR all bits into the Keccak state", 
+      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Test XOR all bits into the Keccak state",
                                       KeccakF_800_Tests.Test_XOR_Entire_State'Access));
-      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Test XOR is correct all possible bit-lengths", 
+      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Test XOR is correct all possible bit-lengths",
                                       KeccakF_800_Tests.Test_XOR_Bit_Length'Access));
-      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Test Extract_Bits and Extract_Bytes equivalence", 
+      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Test Extract_Bits and Extract_Bytes equivalence",
                                       KeccakF_800_Tests.Test_Extract_Bits_Same_As_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Compare Optimized and Reference permutations", 
+      Ret.Add_Test(Caller_800.Create("Keccak-f[800]: Compare Optimized and Reference permutations",
                                       KeccakF_800_Tests.Test_Permute_Implementations'Access));
-                                 
-      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Test initial Keccak state is zero", 
+
+      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Test initial Keccak state is zero",
                                       KeccakF_400_Tests.Test_Initial_State'Access));
       Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Test Extract_Bytes",
                                       KeccakF_400_Tests.Test_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Test XOR 0 bits into the Keccak state", 
+      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Test XOR 0 bits into the Keccak state",
                                       KeccakF_400_Tests.Test_XOR_No_Data'Access));
-      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Test XOR all bits into the Keccak state", 
+      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Test XOR all bits into the Keccak state",
                                       KeccakF_400_Tests.Test_XOR_Entire_State'Access));
-      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Test XOR is correct all possible bit-lengths", 
+      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Test XOR is correct all possible bit-lengths",
                                       KeccakF_400_Tests.Test_XOR_Bit_Length'Access));
-      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Test Extract_Bits and Extract_Bytes equivalence", 
+      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Test Extract_Bits and Extract_Bytes equivalence",
                                       KeccakF_400_Tests.Test_Extract_Bits_Same_As_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Compare Optimized and Reference permutations", 
+      Ret.Add_Test(Caller_400.Create("Keccak-f[400]: Compare Optimized and Reference permutations",
                                       KeccakF_400_Tests.Test_Permute_Implementations'Access));
-                                 
-      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Test initial Keccak state is zero", 
+
+      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Test initial Keccak state is zero",
                                       KeccakF_200_Tests.Test_Initial_State'Access));
       Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Test Extract_Bytes",
                                       KeccakF_200_Tests.Test_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Test XOR 0 bits into the Keccak state", 
+      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Test XOR 0 bits into the Keccak state",
                                       KeccakF_200_Tests.Test_XOR_No_Data'Access));
-      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Test XOR all bits into the Keccak state", 
+      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Test XOR all bits into the Keccak state",
                                       KeccakF_200_Tests.Test_XOR_Entire_State'Access));
-      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Test XOR is correct all possible bit-lengths", 
+      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Test XOR is correct all possible bit-lengths",
                                       KeccakF_200_Tests.Test_XOR_Bit_Length'Access));
-      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Test Extract_Bits and Extract_Bytes equivalence", 
+      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Test Extract_Bits and Extract_Bytes equivalence",
                                       KeccakF_200_Tests.Test_Extract_Bits_Same_As_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Compare Optimized and Reference permutations", 
+      Ret.Add_Test(Caller_200.Create("Keccak-f[200]: Compare Optimized and Reference permutations",
                                       KeccakF_200_Tests.Test_Permute_Implementations'Access));
-                                 
-      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Test initial Keccak state is zero", 
+
+      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Test initial Keccak state is zero",
                                       KeccakF_100_Tests.Test_Initial_State'Access));
       Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Test Extract_Bytes",
                                       KeccakF_100_Tests.Test_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Test XOR 0 bits into the Keccak state", 
+      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Test XOR 0 bits into the Keccak state",
                                       KeccakF_100_Tests.Test_XOR_No_Data'Access));
-      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Test XOR all bits into the Keccak state", 
+      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Test XOR all bits into the Keccak state",
                                       KeccakF_100_Tests.Test_XOR_Entire_State'Access));
-      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Test XOR is correct all possible bit-lengths", 
+      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Test XOR is correct all possible bit-lengths",
                                       KeccakF_100_Tests.Test_XOR_Bit_Length'Access));
-      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Test Extract_Bits and Extract_Bytes equivalence", 
+      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Test Extract_Bits and Extract_Bytes equivalence",
                                       KeccakF_100_Tests.Test_Extract_Bits_Same_As_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Compare Optimized and Reference permutations", 
+      Ret.Add_Test(Caller_100.Create("Keccak-f[100]: Compare Optimized and Reference permutations",
                                       KeccakF_100_Tests.Test_Permute_Implementations'Access));
-                                 
-      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Test initial Keccak state is zero", 
+
+      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Test initial Keccak state is zero",
                                      KeccakF_50_Tests.Test_Initial_State'Access));
       Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Test Extract_Bytes",
                                      KeccakF_50_Tests.Test_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Test XOR 0 bits into the Keccak state", 
+      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Test XOR 0 bits into the Keccak state",
                                      KeccakF_50_Tests.Test_XOR_No_Data'Access));
-      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Test XOR all bits into the Keccak state", 
+      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Test XOR all bits into the Keccak state",
                                      KeccakF_50_Tests.Test_XOR_Entire_State'Access));
-      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Test XOR is correct all possible bit-lengths", 
+      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Test XOR is correct all possible bit-lengths",
                                      KeccakF_50_Tests.Test_XOR_Bit_Length'Access));
-      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Test Extract_Bits and Extract_Bytes equivalence", 
+      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Test Extract_Bits and Extract_Bytes equivalence",
                                      KeccakF_50_Tests.Test_Extract_Bits_Same_As_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Compare Optimized and Reference permutations", 
+      Ret.Add_Test(Caller_50.Create("Keccak-f[50]: Compare Optimized and Reference permutations",
                                      KeccakF_50_Tests.Test_Permute_Implementations'Access));
-                                 
-      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Test initial Keccak state is zero", 
+
+      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Test initial Keccak state is zero",
                                      KeccakF_25_Tests.Test_Initial_State'Access));
       Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Test Extract_Bytes",
                                      KeccakF_25_Tests.Test_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Test XOR 0 bits into the Keccak state", 
+      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Test XOR 0 bits into the Keccak state",
                                      KeccakF_25_Tests.Test_XOR_No_Data'Access));
-      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Test XOR all bits into the Keccak state", 
+      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Test XOR all bits into the Keccak state",
                                      KeccakF_25_Tests.Test_XOR_Entire_State'Access));
-      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Test XOR is correct all possible bit-lengths", 
+      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Test XOR is correct all possible bit-lengths",
                                      KeccakF_25_Tests.Test_XOR_Bit_Length'Access));
-      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Test Extract_Bits and Extract_Bytes equivalence", 
+      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Test Extract_Bits and Extract_Bytes equivalence",
                                       KeccakF_25_Tests.Test_Extract_Bits_Same_As_Extract_Bytes'Access));
-      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Compare Optimized and Reference permutations", 
+      Ret.Add_Test(Caller_25.Create("Keccak-f[25]: Compare Optimized and Reference permutations",
                                      KeccakF_25_Tests.Test_Permute_Implementations'Access));
-      
+
+      Ret.Add_Test(Caller_1600_Lanes.Create("Keccak-f[1600] lanes: Test XOR_Bits_Into_State and Extract_Bits equivalence",
+                                            KeccakF_1600_Lane_Tests.Test_XOR_Extract'Access));
+      Ret.Add_Test(Caller_800_Lanes.Create("Keccak-f[800] lanes: Test XOR_Bits_Into_State and Extract_Bits equivalence",
+                                            KeccakF_800_Lane_Tests.Test_XOR_Extract'Access));
+      Ret.Add_Test(Caller_400_Lanes.Create("Keccak-f[400] lanes: Test XOR_Bits_Into_State and Extract_Bits equivalence",
+                                            KeccakF_400_Lane_Tests.Test_XOR_Extract'Access));
+      Ret.Add_Test(Caller_200_Lanes.Create("Keccak-f[200] lanes: Test XOR_Bits_Into_State and Extract_Bits equivalence",
+                                            KeccakF_200_Lane_Tests.Test_XOR_Extract'Access));
+
+      Ret.Add_Test(Caller_1600_Twisted_Lanes.Create("Keccak-f[1600] twisted lanes: Test XOR_Bits_Into_State and Extract_Bits equivalence",
+                                                    KeccakF_1600_Twisted_Lane_Tests.Test_XOR_Extract'Access));
+      Ret.Add_Test(Caller_800_Twisted_Lanes.Create("Keccak-f[800] twisted lanes: Test XOR_Bits_Into_State and Extract_Bits equivalence",
+                                                    KeccakF_800_Twisted_Lane_Tests.Test_XOR_Extract'Access));
+      Ret.Add_Test(Caller_400_Twisted_Lanes.Create("Keccak-f[400] twisted lanes: Test XOR_Bits_Into_State and Extract_Bits equivalence",
+                                                    KeccakF_400_Twisted_Lane_Tests.Test_XOR_Extract'Access));
+      Ret.Add_Test(Caller_200_Twisted_Lanes.Create("Keccak-f[200] twisted lanes: Test XOR_Bits_Into_State and Extract_Bits equivalence",
+                                                    KeccakF_200_Twisted_Lane_Tests.Test_XOR_Extract'Access));
+
       return Ret;
    end Suite;
 

--- a/tests/unit_tests/ketje_suite.adb
+++ b/tests/unit_tests/ketje_suite.adb
@@ -1,0 +1,125 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2016, Daniel King
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--     * Redistributions of source code must retain the above copyright
+--       notice, this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * The name of the copyright holder may not be used to endorse or promote
+--       Products derived from this software without specific prior written
+--       permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+-- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+-- THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+with Ketje_Tests;
+with Ketje;
+with AUnit.Test_Caller;
+
+package body Ketje_Suite
+is
+
+   package Ketje_Jr_Tests is new Ketje_Tests (Ketje.Jr);
+   package Ketje_Sr_Tests is new Ketje_Tests (Ketje.Jr);
+   package Ketje_Minor_Tests is new Ketje_Tests (Ketje.Minor);
+   package Ketje_Major_Tests is new Ketje_Tests (Ketje.Major);
+
+   package Caller_Jr is new AUnit.Test_Caller (Ketje_Jr_Tests.Test);
+   package Caller_Sr is new AUnit.Test_Caller (Ketje_Sr_Tests.Test);
+   package Caller_Minor is new AUnit.Test_Caller (Ketje_Minor_Tests.Test);
+   package Caller_Major is new AUnit.Test_Caller (Ketje_Major_Tests.Test);
+
+   function Suite return Access_Test_Suite
+   is
+
+      Ret : constant Access_Test_Suite := new Test_Suite;
+   begin
+      --  KetjeJr
+      Ret.Add_Test
+         (Caller_Jr.Create
+            ("KetjeJr: Test encrypt -> decrypt loopback",
+             Ketje_Jr_Tests.Test_Encrypt_Decrypt'Access));
+      Ret.Add_Test
+         (Caller_Jr.Create
+            ("KetjeJr: Test streaming AAD",
+             Ketje_Jr_Tests.Test_Streaming_AAD'Access));
+      Ret.Add_Test
+         (Caller_Jr.Create
+            ("KetjeJr: Test streaming ciphertext",
+             Ketje_Jr_Tests.Test_Streaming_Ciphertext'Access));
+      Ret.Add_Test
+         (Caller_Jr.Create
+            ("KetjeJr: Test streaming tag",
+             Ketje_Jr_Tests.Test_Streaming_Tag'Access));
+
+      --  KetjeSr
+      Ret.Add_Test
+         (Caller_Sr.Create
+            ("KetjeSr: Test encrypt -> decrypt loopback",
+             Ketje_Sr_Tests.Test_Encrypt_Decrypt'Access));
+      Ret.Add_Test
+         (Caller_Sr.Create
+            ("KetjeSr: Test streaming AAD",
+             Ketje_Sr_Tests.Test_Streaming_AAD'Access));
+      Ret.Add_Test
+         (Caller_Sr.Create
+            ("KetjeSr: Test streaming ciphertext",
+             Ketje_Sr_Tests.Test_Streaming_Ciphertext'Access));
+      Ret.Add_Test
+         (Caller_Sr.Create
+            ("KetjeSr: Test streaming tag",
+             Ketje_Sr_Tests.Test_Streaming_Tag'Access));
+
+      --  KetjeMinor
+      Ret.Add_Test
+         (Caller_Minor.Create
+            ("KetjeMinor: Test encrypt -> decrypt loopback",
+             Ketje_Minor_Tests.Test_Encrypt_Decrypt'Access));
+      Ret.Add_Test
+         (Caller_Minor.Create
+            ("KetjeMinor: Test streaming AAD",
+             Ketje_Minor_Tests.Test_Streaming_AAD'Access));
+      Ret.Add_Test
+         (Caller_Minor.Create
+            ("KetjeMinor: Test streaming ciphertext",
+             Ketje_Minor_Tests.Test_Streaming_Ciphertext'Access));
+      Ret.Add_Test
+         (Caller_Minor.Create
+            ("KetjeMinor: Test streaming tag",
+             Ketje_Minor_Tests.Test_Streaming_Tag'Access));
+
+      --  KetjeMajor
+      Ret.Add_Test
+         (Caller_Major.Create
+            ("KetjeMajor: Test encrypt -> decrypt loopback",
+             Ketje_Major_Tests.Test_Encrypt_Decrypt'Access));
+      Ret.Add_Test
+         (Caller_Major.Create
+            ("KetjeMajor: Test streaming AAD",
+             Ketje_Major_Tests.Test_Streaming_AAD'Access));
+      Ret.Add_Test
+         (Caller_Major.Create
+            ("KetjeMajor: Test streaming ciphertext",
+             Ketje_Major_Tests.Test_Streaming_Ciphertext'Access));
+      Ret.Add_Test
+         (Caller_Major.Create
+            ("KetjeMajor: Test streaming tag",
+             Ketje_Major_Tests.Test_Streaming_Tag'Access));
+
+      return Ret;
+   end Suite;
+
+end Ketje_Suite;

--- a/tests/unit_tests/ketje_suite.adb
+++ b/tests/unit_tests/ketje_suite.adb
@@ -68,6 +68,14 @@ is
          (Caller_Jr.Create
             ("KetjeJr: Test streaming tag",
              Ketje_Jr_Tests.Test_Streaming_Tag'Access));
+      Ret.Add_Test
+         (Caller_Jr.Create
+            ("KetjeJr: Test Verify_Tag",
+             Ketje_Jr_Tests.Test_Verify_Tag'Access));
+      Ret.Add_Test
+         (Caller_Jr.Create
+            ("KetjeJr: Test streaming Verify_Tag",
+             Ketje_Jr_Tests.Test_Streaming_Verify_Tag'Access));
 
       --  KetjeSr
       Ret.Add_Test
@@ -90,6 +98,14 @@ is
          (Caller_Sr.Create
             ("KetjeSr: Test streaming tag",
              Ketje_Sr_Tests.Test_Streaming_Tag'Access));
+      Ret.Add_Test
+         (Caller_Sr.Create
+            ("KetjeSr: Test Verify_Tag",
+             Ketje_Sr_Tests.Test_Verify_Tag'Access));
+      Ret.Add_Test
+         (Caller_Sr.Create
+            ("KetjeSr: Test streaming Verify_Tag",
+             Ketje_Sr_Tests.Test_Streaming_Verify_Tag'Access));
 
       --  KetjeMinor
       Ret.Add_Test
@@ -112,6 +128,14 @@ is
          (Caller_Minor.Create
             ("KetjeMinor: Test streaming tag",
              Ketje_Minor_Tests.Test_Streaming_Tag'Access));
+      Ret.Add_Test
+         (Caller_Minor.Create
+            ("KetjeMinor: Test Verify_Tag",
+             Ketje_Minor_Tests.Test_Verify_Tag'Access));
+      Ret.Add_Test
+         (Caller_Minor.Create
+            ("KetjeMinor: Test streaming Verify_Tag",
+             Ketje_Minor_Tests.Test_Streaming_Verify_Tag'Access));
 
       --  KetjeMajor
       Ret.Add_Test
@@ -134,6 +158,14 @@ is
          (Caller_Major.Create
             ("KetjeMajor: Test streaming tag",
              Ketje_Major_Tests.Test_Streaming_Tag'Access));
+      Ret.Add_Test
+         (Caller_Major.Create
+            ("KetjeMajor: Test Verify_Tag",
+             Ketje_Major_Tests.Test_Verify_Tag'Access));
+      Ret.Add_Test
+         (Caller_Major.Create
+            ("KetjeMajor: Test streaming Verify_Tag",
+             Ketje_Major_Tests.Test_Streaming_Verify_Tag'Access));
 
       return Ret;
    end Suite;

--- a/tests/unit_tests/ketje_suite.adb
+++ b/tests/unit_tests/ketje_suite.adb
@@ -58,8 +58,12 @@ is
              Ketje_Jr_Tests.Test_Streaming_AAD'Access));
       Ret.Add_Test
          (Caller_Jr.Create
-            ("KetjeJr: Test streaming ciphertext",
-             Ketje_Jr_Tests.Test_Streaming_Ciphertext'Access));
+            ("KetjeJr: Test streaming encryption",
+             Ketje_Jr_Tests.Test_Streaming_Encryption'Access));
+      Ret.Add_Test
+         (Caller_Jr.Create
+            ("KetjeJr: Test streaming decryption",
+             Ketje_Jr_Tests.Test_Streaming_Decryption'Access));
       Ret.Add_Test
          (Caller_Jr.Create
             ("KetjeJr: Test streaming tag",
@@ -76,8 +80,12 @@ is
              Ketje_Sr_Tests.Test_Streaming_AAD'Access));
       Ret.Add_Test
          (Caller_Sr.Create
-            ("KetjeSr: Test streaming ciphertext",
-             Ketje_Sr_Tests.Test_Streaming_Ciphertext'Access));
+            ("KetjeSr: Test streaming encryption",
+             Ketje_Sr_Tests.Test_Streaming_Encryption'Access));
+      Ret.Add_Test
+         (Caller_Sr.Create
+            ("KetjeSr: Test streaming decryption",
+             Ketje_Sr_Tests.Test_Streaming_Decryption'Access));
       Ret.Add_Test
          (Caller_Sr.Create
             ("KetjeSr: Test streaming tag",
@@ -94,8 +102,12 @@ is
              Ketje_Minor_Tests.Test_Streaming_AAD'Access));
       Ret.Add_Test
          (Caller_Minor.Create
-            ("KetjeMinor: Test streaming ciphertext",
-             Ketje_Minor_Tests.Test_Streaming_Ciphertext'Access));
+            ("KetjeMinor: Test streaming encryption",
+             Ketje_Minor_Tests.Test_Streaming_Encryption'Access));
+      Ret.Add_Test
+         (Caller_Minor.Create
+            ("KetjeMinor: Test streaming decryption",
+             Ketje_Minor_Tests.Test_Streaming_Decryption'Access));
       Ret.Add_Test
          (Caller_Minor.Create
             ("KetjeMinor: Test streaming tag",
@@ -112,8 +124,12 @@ is
              Ketje_Major_Tests.Test_Streaming_AAD'Access));
       Ret.Add_Test
          (Caller_Major.Create
-            ("KetjeMajor: Test streaming ciphertext",
-             Ketje_Major_Tests.Test_Streaming_Ciphertext'Access));
+            ("KetjeMajor: Test streaming encryption",
+             Ketje_Major_Tests.Test_Streaming_Encryption'Access));
+      Ret.Add_Test
+         (Caller_Major.Create
+            ("KetjeMajor: Test streaming decryption",
+             Ketje_Major_Tests.Test_Streaming_Decryption'Access));
       Ret.Add_Test
          (Caller_Major.Create
             ("KetjeMajor: Test streaming tag",

--- a/tests/unit_tests/ketje_suite.ads
+++ b/tests/unit_tests/ketje_suite.ads
@@ -25,27 +25,10 @@
 -- THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------------------------------------------------------------------------
 
-with KeccakF_Suite;
-with Sponge_Suite;
-with Parallel_Sponge_Suite;
-with Util_Suite;
-with Ketje_Suite;
-with AUnit.Test_Caller;
+with AUnit.Test_Suites; use AUnit.Test_Suites;
 
-package body Keccak_Suites
-is
-   function Suite return Access_Test_Suite
-   is
+package Ketje_Suite is
 
-      Ret : constant Access_Test_Suite := new Test_Suite;
-   begin
-      Ret.Add_Test(KeccakF_Suite.Suite);
-      Ret.Add_Test(Sponge_Suite.Suite);
-      Ret.Add_Test(Parallel_Sponge_Suite.Suite);
-      Ret.Add_Test(Util_Suite.Suite);
-      Ret.Add_Test(Ketje_Suite.Suite);
+   function Suite return Access_Test_Suite;
 
-      return Ret;
-   end Suite;
-
-end Keccak_Suites;
+end Ketje_Suite;

--- a/tests/unit_tests/ketje_tests.adb
+++ b/tests/unit_tests/ketje_tests.adb
@@ -1,0 +1,95 @@
+-------------------------------------------------------------------------------
+-- Copyright (c) 2019, Daniel King
+-- All rights reserved.
+--
+-- Redistribution and use in source and binary forms, with or without
+-- modification, are permitted provided that the following conditions are met:
+--     * Redistributions of source code must retain the above copyright
+--       notice, this list of conditions and the following disclaimer.
+--     * Redistributions in binary form must reproduce the above copyright
+--       notice, this list of conditions and the following disclaimer in the
+--       documentation and/or other materials provided with the distribution.
+--     * The name of the copyright holder may not be used to endorse or promote
+--       Products derived from this software without specific prior written
+--       permission.
+--
+-- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+-- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+-- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+-- ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+-- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+-- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+-- THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-------------------------------------------------------------------------------
+
+with AUnit.Assertions; use AUnit.Assertions;
+
+package body Ketje_Tests
+is
+
+   --  Test that performing an encrypt then a decrypt yields the original plaintext.
+   --
+   --  The test is repeated for varying lengths of AAD preceding the encryption/decryption.
+   procedure Test_Encrypt_Decrypt (T : in out Test) is
+      Ctx : MonkeyWrap.Context;
+
+      Key   : constant Byte_Array (1 .. 8) := (others => 16#AA#);
+      Nonce : constant Byte_Array (1 .. 8) := (others => 16#55#);
+
+      AAD : constant Byte_Array (1 .. 50) := (others => 16#FF#);
+      PT1 : Byte_Array (1 .. 1024);
+      CT1 : Byte_Array (1 .. 1024) := (others => 0);
+      PT2 : Byte_Array (1 .. 1024) := (others => 0);
+
+   begin
+      for I in 0 .. PT1'Length - 1 loop
+         PT1 (PT1'First + I) := Byte (I mod 256);
+      end loop;
+
+      for N in 0 .. AAD'Length loop
+         MonkeyWrap.Init (Ctx   => Ctx,
+                        Key   => Key,
+                        Nonce => Nonce);
+
+         MonkeyWrap.Update_Auth_Data (Ctx  => Ctx,
+                                      Data => AAD (1 .. N));
+
+         MonkeyWrap.Update_Encrypt (Ctx        => Ctx,
+                                    Plaintext  => PT1,
+                                    Ciphertext => CT1);
+
+         MonkeyWrap.Init (Ctx   => Ctx,
+                        Key   => Key,
+                        Nonce => Nonce);
+
+         MonkeyWrap.Update_Auth_Data (Ctx  => Ctx,
+                                      Data => AAD (1 .. N));
+
+         MonkeyWrap.Update_Decrypt (Ctx        => Ctx,
+                                    Ciphertext => CT1,
+                                    Plaintext  => PT2);
+
+         Assert (PT1 = PT2, "Decryption resulted in different plaintext with AAD'Length=" & Integer'Image (N));
+      end loop;
+
+   end Test_Encrypt_Decrypt;
+
+   procedure Test_Streaming_AAD (T : in out Test) is
+   begin
+      null;
+   end Test_Streaming_AAD;
+
+   procedure Test_Streaming_Ciphertext (T : in out Test) is
+   begin
+      null;
+   end Test_Streaming_Ciphertext;
+
+   procedure Test_Streaming_Tag (T : in out Test) is
+   begin
+      null;
+   end Test_Streaming_Tag;
+
+end Ketje_Tests;

--- a/tests/unit_tests/ketje_tests.ads
+++ b/tests/unit_tests/ketje_tests.ads
@@ -41,6 +41,9 @@ is
    procedure Test_Streaming_Encryption (T : in out Test);
    procedure Test_Streaming_Decryption (T : in out Test);
    procedure Test_Streaming_Tag (T : in out Test);
+   procedure Test_Verify_Tag (T : in out Test);
+   procedure Test_Streaming_Verify_Tag (T : in out Test);
+
 
 end Ketje_Tests;
 

--- a/tests/unit_tests/ketje_tests.ads
+++ b/tests/unit_tests/ketje_tests.ads
@@ -38,7 +38,8 @@ is
 
    procedure Test_Encrypt_Decrypt (T : in out Test);
    procedure Test_Streaming_AAD (T : in out Test);
-   procedure Test_Streaming_Ciphertext (T : in out Test);
+   procedure Test_Streaming_Encryption (T : in out Test);
+   procedure Test_Streaming_Decryption (T : in out Test);
    procedure Test_Streaming_Tag (T : in out Test);
 
 end Ketje_Tests;

--- a/tests/unit_tests/ketje_tests.ads
+++ b/tests/unit_tests/ketje_tests.ads
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------------------
--- Copyright (c) 2016, Daniel King
+-- Copyright (c) 2019, Daniel King
 -- All rights reserved.
 --
 -- Redistribution and use in source and binary forms, with or without
@@ -25,27 +25,21 @@
 -- THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------------------------------------------------------------------------
 
-with KeccakF_Suite;
-with Sponge_Suite;
-with Parallel_Sponge_Suite;
-with Util_Suite;
-with Ketje_Suite;
-with AUnit.Test_Caller;
+with AUnit.Test_Fixtures;
+with Keccak.Generic_MonkeyWrap;
+with Keccak.Types;              use Keccak.Types;
 
-package body Keccak_Suites
+generic
+   with package MonkeyWrap is new Keccak.Generic_MonkeyWrap (<>);
+package Ketje_Tests
 is
-   function Suite return Access_Test_Suite
-   is
 
-      Ret : constant Access_Test_Suite := new Test_Suite;
-   begin
-      Ret.Add_Test(KeccakF_Suite.Suite);
-      Ret.Add_Test(Sponge_Suite.Suite);
-      Ret.Add_Test(Parallel_Sponge_Suite.Suite);
-      Ret.Add_Test(Util_Suite.Suite);
-      Ret.Add_Test(Ketje_Suite.Suite);
+   type Test is new AUnit.Test_Fixtures.Test_Fixture with null record;
 
-      return Ret;
-   end Suite;
+   procedure Test_Encrypt_Decrypt (T : in out Test);
+   procedure Test_Streaming_AAD (T : in out Test);
+   procedure Test_Streaming_Ciphertext (T : in out Test);
+   procedure Test_Streaming_Tag (T : in out Test);
 
-end Keccak_Suites;
+end Ketje_Tests;
+


### PR DESCRIPTION
This implements the Ketje v2 authenticated encryption scheme based on Keccak-p as described by the Keccak authors in [1]. Ketje was a third-round candidate for the CAESAR competition.

The API is a streaming API, so an arbitrary number of calls can be made during each phase to process a large amounts of data.

Tasks:
- [x] Implement generic MonkeyDuplex
- [x] Implement generic MonkeyWrap
- [x] Instantiate MonkeyWrap for Ketje Jr, Sr, Minor, and Major
- [x] Add to benchmark
- [x] Add test vectors
- [x] Add unit tests
- [x] Check proof

[1] https://keccak.team/ketje.html