### PR TITLE
Move gnatprove dependency from the top-level alire.toml to a nested crate

### DIFF
--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -31,4 +31,8 @@ jobs:
       # Generate the proofs
       # Note that this is likely to take a fairly long time on a dual-core CI runner.
       - name: Prove
-        run: alr gnatprove -Plibkeccak
+        run: |
+          cd proof
+          alr exec -- gnatprove -P../libkeccak \
+            -XLIBKECCAK_ARCH=${{ matrix.arch }} \
+            -XLIBKECCAK_SIMD=${{ matrix.simd }}

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -32,7 +32,7 @@ jobs:
       # Note that this is likely to take a fairly long time on a dual-core CI runner.
       - name: Prove
         run: |
-          cd proof
+          cd prove
           alr exec -- gnatprove -P../libkeccak \
             -XLIBKECCAK_ARCH=${{ matrix.arch }} \
             -XLIBKECCAK_SIMD=${{ matrix.simd }}

--- a/README.md
+++ b/README.md
@@ -241,13 +241,14 @@ Assuming you have Alire >= 1.2.0 installed, then:
 ### Proofs
 
 ```sh
-alr gnatprove -Plibkeccak -XLIBKECCAK_ARCH=generic -XLIBKECCAK_SIMD=none
+cd prove
+alr exec -- gnatprove -P../libkeccak -XLIBKECCAK_ARCH=generic -XLIBKECCAK_SIMD=none
 ```
 
 >:bulb: Change `-XLIBKECCAK_ARCH` and `-XLIBKECCAK_SIMD` to run the proofs using
 different SIMD instruction sets.
 
-A summary of the proof results is stored in `obj/generic_none/gnatprove.out`.
+A summary of the proof results is stored in `obj/<arch>_<simd>/gnatprove.out`.
 
 The project file configures the prover limits so that they should give the same
 results on all machines.

--- a/alire.toml
+++ b/alire.toml
@@ -15,7 +15,6 @@ maintainers-logins = ["damaki"]
 
 [[depends-on]]
 gnat = ">=11.0.0"
-gnatprove = "^11.2.3"
 
 [gpr-externals]
 LIBKECCAK_LIBRARY_TYPE = ["relocatable", "static", "static-pic"]

--- a/prove/.gitignore
+++ b/prove/.gitignore
@@ -1,0 +1,4 @@
+/obj/
+/lib/
+/alire/
+/config/

--- a/prove/README.md
+++ b/prove/README.md
@@ -1,0 +1,9 @@
+This directory contains a nested Alire crate configured for running GNATprove.
+The purpose of this nested project is to avoid a dependency on `gnatprove` in the
+top-level `alire.toml`.
+
+The recommended workflow is to have a nested crate (this crate) that depends on
+libkeccak and on gnatprove, that is used for the verification. This nested crate
+needs not to be explicitly published, but can be distributed normally with the
+main library sources.
+See here: https://github.com/alire-project/alire/blob/master/doc/catalog-format-spec.md#using-pins-for-crate-testing

--- a/prove/alire.toml
+++ b/prove/alire.toml
@@ -1,0 +1,14 @@
+name = "prove"
+description = "Project to prove libkeccak"
+version = "0.1.0-dev"
+
+authors = ["Daniel King"]
+maintainers = ["Daniel King <damaki.gh@gmail.com>"]
+maintainers-logins = ["damaki"]
+
+[[depends-on]]
+libkeccak = "*"
+gnatprove = "^11.2.3"
+
+[[pins]]
+libkeccak = { path = ".." }


### PR DESCRIPTION
This prevents users of this crate from needing to pull in gnatprove
(which is quite large) when they "with" this crate. gnatprove is
used only for verifying the library and is not needed to use it.

The recommended workflow is to have a nested crate which depends
on the library and GNATprove, and that is used for verification.
Having an actual project file does not seem to be needed, since
`alr exec` can be used to run `gnatprove` on `libkeccak.gpr` within
in the nested crate's environment.

Fixes #22 