### PR TITLE
Fix SSE2 and AVX2 vector type definitions.

### DIFF
--- a/src/common/gimli-sponge.ads
+++ b/src/common/gimli-sponge.ads
@@ -26,7 +26,6 @@
 -------------------------------------------------------------------------------
 pragma SPARK_Mode (On);
 
-with Gimli;
 with Keccak.Generic_Sponge;
 with Keccak.Padding;
 

--- a/src/x86_64/AVX2_defs/keccak-arch-avx2.ads
+++ b/src/x86_64/AVX2_defs/keccak-arch-avx2.ads
@@ -45,7 +45,7 @@ is
 
       type V4DI_Index is range 0 .. 3;
 
-      type V4DI is array (V4DI_Index) of Unsigned_64
+      type V4DI is array (V4DI_Index) of Integer_64
         with Alignment => 32,
         Size => 256,
         Object_Size => 256;

--- a/src/x86_64/SSE2_defs/keccak-arch-sse2.ads
+++ b/src/x86_64/SSE2_defs/keccak-arch-sse2.ads
@@ -45,7 +45,7 @@ is
 
       type V2DI_Index is range 0 .. 1;
 
-      type V2DI is array (V2DI_Index) of Unsigned_64
+      type V2DI is array (V2DI_Index) of Integer_64
         with Alignment => 16,
         Size => 128,
         Object_Size => 128;
@@ -105,7 +105,7 @@ is
 
       type V4SI_Index is range 0 .. 3;
 
-      type V4SI is array (V4SI_Index) of Unsigned_32
+      type V4SI is array (V4SI_Index) of Integer_32
         with Alignment => 16,
         Size => 128,
         Object_Size => 128;

--- a/tests/benchmark/benchmark.gpr
+++ b/tests/benchmark/benchmark.gpr
@@ -50,7 +50,6 @@ project Benchmark is
             "-gnatyi",    -- Check if-then layout
             "-gnatyk",    -- Check keyword casing
             "-gnatyl",    -- Check layout
-            "-gnatyL6",   -- Set maximum nesting level
             "-gnatyM100", -- Set maximum line length
             "-gnatyn",    -- Check casing of entities in Standard
             "-gnatyO",    -- Overriding subprogrms explicitly marked as such


### PR DESCRIPTION
New checks in GCC 12 found require specific integer types for the array elements in SSE2/AVX2 vector types. This commit changes these vector type to the correct types.

Closes #27 