### PR TITLE
Add compiler flags to support GNATStack analysis.

### DIFF
--- a/libkeccak.gpr
+++ b/libkeccak.gpr
@@ -129,6 +129,8 @@ project Libkeccak is
         Style_Checks_Switches &
         Contracts_Switches &
         ("-gnatw.X", -- Disable warnings for No_Exception_Propagation
+         "-fcallgraph-info=su,da", -- Generate data for GNATStack
+         "-fstack-usage",
          "-gnatQ");  -- Don't quit. Generate ALI and tree files even if illegalities
    end Compiler;
 


### PR DESCRIPTION
Adds -fcallgraph-info=su,da -fstack-usage to standard compiler options to enable GNATStack analysis of these packages. Please review.
